### PR TITLE
Skill checkpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This is the documentation map for Agent Memory Orchestrator.
 | Develop locally | [Local development](./setup/local-development.md) |
 | Configure local models | [Local models](./setup/local-models.md) |
 | Test retrieval quality | [Retrieval pipeline](./operations/retrieval.md) |
+| Build reusable skills from checkpoints | [Skill checkpoint pipeline](./skill_checkpoint/README.md) |
 | Connect Slack | [Slack connector](./integrations/slack.md) |
 | Understand repo layout | [Repository layout](./development/REPO_LAYOUT.md) |
 
@@ -27,6 +28,7 @@ V2 source of truth:
 - [Local development](./setup/local-development.md)
 - [Local models](./setup/local-models.md)
 - [Retrieval pipeline](./operations/retrieval.md)
+- [Skill checkpoint pipeline](./skill_checkpoint/README.md)
 - [Slack connector](./integrations/slack.md)
 
 ## Development and Release

--- a/docs/reasoning_graph/modules/qwen-contracts.md
+++ b/docs/reasoning_graph/modules/qwen-contracts.md
@@ -179,6 +179,43 @@ Output schema:
 
 Threshold: `>= 0.60`. Low confidence uses deterministic top-term label.
 
+## Call: Skill Checkpoint Distillation
+
+Owner: skill checkpoint module.
+
+This call turns one compact checkpoint packet into structured skill sections. It does not install a skill and does not mutate graph state.
+
+Production runtime is local Ollama, normally `qwen3.5:9b`. Colab/GPU notebooks are development harnesses only.
+
+Input:
+
+```json
+{
+  "checkpoint": {"checkpoint_id": "string"},
+  "events": [{"ref": "E0001", "type": "user_prompt|git_commit|commit_expansion|validation|stop_summary", "content": "bounded text"}]
+}
+```
+
+Output schema:
+
+```json
+{
+  "checkpoint_id": "string",
+  "evidence_cards": [{"ref": "E0001", "summary": "string", "semantic_role": "string", "importance": "high|medium|low", "confidence": 0.0}],
+  "work_chains": [{"chain_type": "implementation_workflow", "problem_or_goal": "string", "problem_source": "user_stated|inferred_from_events|not_clear", "symptom_refs": ["E0001"], "diagnosis_refs": ["E0002"], "action_refs": ["E0003"], "validation_refs": ["E0004"], "reusable_pattern": "string", "confidence": 0.0}],
+  "skill_name": "lowercase-hyphen-name",
+  "description": "specific what-and-when description",
+  "skill_sections": {"title": "string", "overview": "string", "when_to_use": ["string"], "workflow": ["string"], "validation": ["string"], "safety": ["string"]},
+  "diagnostics": []
+}
+```
+
+AMO renders `SKILL.md` from `skill_sections`. Qwen must not return raw `skill_md` or `skill_md_lines`.
+
+May create: no graph nodes directly. The module may write a rendered `SKILL.md`, `skill_provenance.json`, corrected Qwen result, and validation report.
+
+Hard gate: rendered `SKILL.md` must not contain evidence refs, raw transcript ids, tool-call ids, or private absolute paths. `validation_refs` must point to validation/test events; safe automatic repair may replace invalid validation refs with actual validation refs from the same packet.
+
 May update: `Community.label` only.
 
 Must never change membership or decision status.

--- a/docs/skill_checkpoint/README.md
+++ b/docs/skill_checkpoint/README.md
@@ -1,0 +1,165 @@
+# Skill Checkpoint Pipeline
+
+## Purpose
+
+Skill checkpoints turn a bounded agent/user work slice into one reusable agent skill.
+
+The goal is not to summarize a chat. The goal is to preserve a repeated workflow so a future agent can reuse it without rediscovering the same process or making the same mistake.
+
+Final user-facing output is a clean `SKILL.md`. Provenance, evidence refs, checkpoint ids, and validation details stay in AMO metadata files.
+
+## Current Production Scope
+
+Production now supports the validated Stage 8 core:
+
+1. Read one compact checkpoint packet.
+2. Send the packet to local Ollama/Qwen, normally `qwen3.5:9b`.
+3. Require Qwen to return structured `skill_sections`, not raw Markdown.
+4. Render `SKILL.md` deterministically inside AMO.
+5. Validate evidence refs and rendered skill safety.
+6. Repair safe provenance-only mistakes, such as non-validation refs in `validation_refs`.
+7. Write the skill, provenance, corrected result, and validation report.
+
+Checkpoint selection and slash-command UX are intentionally not finalized yet. Those will decide how users mark a checkpoint during a live Codex/Claude session. The production core here starts after a compact packet already exists.
+
+## Why This Shape Exists
+
+Stage 8 reached this shape after several failures:
+
+| Attempt | Result | Decision |
+| --- | --- | --- |
+| Full raw JSONL-style checkpoint packet | Too large and noisy | Do not send full raw session dumps to Qwen. |
+| Colab Qwen with large context/output budget | GPU memory pressure | Keep packets compact and mechanically bounded. |
+| Ask Qwen for raw `skill_md` string | JSON escaped multiline output was fragile | AMO should render Markdown, not Qwen. |
+| Ask Qwen for `skill_md_lines` | Model inserted invalid newlines inside list items | Still too formatting-sensitive. |
+| Ask Qwen for `skill_sections` | Parsed cleanly and rendered reliably | Keep this as the production contract. |
+| Let Qwen choose all refs freely | It used commit-expansion refs as validation refs | Add AMO post-validation and safe provenance repair. |
+
+The important boundary is:
+
+- Qwen infers semantic meaning and writes compact section content.
+- AMO owns packet selection, clipping, validation, rendering, provenance, and installation.
+
+## Why Evidence Refs Exist
+
+Refs like `E0001` are not meant for the final skill reader. They are internal handles back to the compact packet event cards.
+
+AMO needs them for:
+
+- grounding Qwen claims in the actual checkpoint packet,
+- debugging why Qwen inferred a workflow,
+- validating that `validation_refs` point to test/validation evidence,
+- storing provenance separately from clean skill content,
+- rebuilding or comparing the skill later with a different model/prompt.
+
+The rendered `SKILL.md` must not contain refs, raw transcript ids, tool-call ids, or private absolute paths.
+
+## Input Packet
+
+The current accepted input is a compact JSON packet with event cards:
+
+```json
+{
+  "task": "one_pass_skill_distillation_from_agent_checkpoint",
+  "checkpoint": {"checkpoint_id": "skillcp_example"},
+  "events": [
+    {"ref": "E0001", "type": "user_prompt", "content": "..."},
+    {"ref": "E0002", "type": "git_commit", "cmd": "..."},
+    {"ref": "E0003", "type": "commit_expansion", "patch": "..."},
+    {"ref": "E0004", "type": "validation", "cmd": "python -m pytest ..."}
+  ]
+}
+```
+
+Current event types used by the validator:
+
+- `user_prompt`
+- `git_commit`
+- `commit_expansion`
+- `deterministic_commit_expansion`
+- `tool_call`
+- `tool_result`
+- `command_result`
+- `validation`
+- `test_run`
+- `test_result`
+- `stop_summary`
+
+## Qwen Output Contract
+
+Qwen must return JSON with:
+
+```json
+{
+  "checkpoint_id": "skillcp_example",
+  "evidence_cards": [],
+  "work_chains": [],
+  "skill_name": "lowercase-hyphen-name",
+  "description": "specific what-and-when description",
+  "skill_sections": {
+    "title": "Skill Title",
+    "overview": "One short paragraph.",
+    "when_to_use": ["short bullet"],
+    "workflow": ["short step"],
+    "validation": ["short bullet"],
+    "safety": ["short bullet"]
+  },
+  "diagnostics": []
+}
+```
+
+Qwen must not return `skill_md` or `skill_md_lines`. AMO renders the final Markdown.
+
+## Commands
+
+Run local Qwen extraction:
+
+```powershell
+amo-cli skill-checkpoint extract `
+  --packet .tmp/reasoning-graph-v2-reset-2026-05-14/08_skill_checkpoint_simulation/skill_checkpoint_qwen_packet_workflow.compact.json `
+  --out-dir .tmp/skill-checkpoint-run `
+  --num-ctx 8192 `
+  --num-predict 1300
+```
+
+Finalize a returned Qwen result without calling Qwen:
+
+```powershell
+amo-cli skill-checkpoint finalize `
+  --result C:\Users\sumit\Downloads\stage8_skill_checkpoint_qwen35_9b_4bit_result.json `
+  --packet .tmp/reasoning-graph-v2-reset-2026-05-14/08_skill_checkpoint_simulation/skill_checkpoint_qwen_packet_workflow.compact.json `
+  --out-dir .tmp/skill-checkpoint-run
+```
+
+Outputs:
+
+- `SKILL.md`
+- `skill_provenance.json`
+- `stage8_qwen_result_corrected.json`
+- `stage8_post_validation_report.json`
+
+## Validation Rules
+
+Hard failures:
+
+- missing parsed output,
+- bad `skill_name`,
+- missing or invalid `skill_sections`,
+- evidence refs not present in the packet,
+- `validation_refs` pointing to non-validation events,
+- raw transcript/tool ids or private absolute paths in rendered `SKILL.md`.
+
+Safe automatic repair:
+
+- If Qwen places commit refs in `validation_refs`, AMO can replace them with actual validation refs from the same packet.
+- This repair changes provenance only. It does not rewrite the skill prose.
+
+## Still To Build
+
+These are intentionally left for the next phase:
+
+- live checkpoint marking UX, such as a slash command or explicit AMO checkpoint command,
+- checkpoint-window selection from hook evidence,
+- installing the rendered skill into Codex/Claude discovery paths,
+- skill quality scoring across multiple checkpoints,
+- graph links from generated skills back to checkpoint/session/version nodes.

--- a/src/agent_memory_orchestrator/app/cli.py
+++ b/src/agent_memory_orchestrator/app/cli.py
@@ -33,6 +33,10 @@ from ..reasoning_graph.session_runtime import build_and_query_session_graph
 from ..reasoning_graph.session_runtime import build_session_graph
 from ..reasoning_graph.session_runtime import default_session_graph_path
 from ..reasoning_graph.session_runtime import query_session_graph
+from ..skill_checkpoint import DEFAULT_LOCAL_NUM_CTX
+from ..skill_checkpoint import DEFAULT_NUM_PREDICT
+from ..skill_checkpoint import run_local_skill_checkpoint_extraction
+from ..skill_checkpoint import write_skill_checkpoint_outputs
 from .client import DaemonClient, DaemonUnavailable
 
 
@@ -280,6 +284,31 @@ def _build_parser() -> argparse.ArgumentParser:
     debug_retrieval = debug_sub.add_parser("retrieval", help="Show retrieval output through daemon")
     debug_retrieval.add_argument("--query", required=True)
     debug_retrieval.add_argument("--limit", type=int, default=8)
+
+    skill_checkpoint = sub.add_parser(
+        "skill-checkpoint",
+        help="Build or finalize a reusable skill from a compact checkpoint packet",
+    )
+    skill_checkpoint_sub = skill_checkpoint.add_subparsers(dest="skill_checkpoint_command", required=True)
+    skill_checkpoint_extract = skill_checkpoint_sub.add_parser(
+        "extract",
+        help="Run local Ollama/Qwen over a compact checkpoint packet and write validated skill outputs",
+    )
+    skill_checkpoint_extract.add_argument("--packet", required=True, type=Path)
+    skill_checkpoint_extract.add_argument("--out-dir", required=True, type=Path)
+    skill_checkpoint_extract.add_argument("--num-ctx", type=int, default=DEFAULT_LOCAL_NUM_CTX)
+    skill_checkpoint_extract.add_argument("--num-predict", type=int, default=DEFAULT_NUM_PREDICT)
+    skill_checkpoint_extract.add_argument("--timeout-seconds", type=float)
+    skill_checkpoint_extract.add_argument("--no-auto-repair-validation-refs", action="store_true")
+
+    skill_checkpoint_finalize = skill_checkpoint_sub.add_parser(
+        "finalize",
+        help="Post-validate a Qwen skill-checkpoint result and render SKILL.md/provenance",
+    )
+    skill_checkpoint_finalize.add_argument("--result", required=True, type=Path)
+    skill_checkpoint_finalize.add_argument("--packet", required=True, type=Path)
+    skill_checkpoint_finalize.add_argument("--out-dir", required=True, type=Path)
+    skill_checkpoint_finalize.add_argument("--no-auto-repair-validation-refs", action="store_true")
 
     timeline = sub.add_parser("timeline", help="View session timeline")
     timeline.add_argument("--session-id", required=True)
@@ -901,6 +930,34 @@ def main(argv: list[str] | None = None) -> int:
                     _print({"ok": False, "requires_daemon": True, "error": str(exc)})
                     return 1
                 return 0
+
+        if args.command == "skill-checkpoint":
+            if args.skill_checkpoint_command == "extract":
+                settings = Settings.load()
+                packet = json.loads(args.packet.read_text(encoding="utf-8"))
+                report = run_local_skill_checkpoint_extraction(
+                    packet=packet,
+                    settings=settings,
+                    out_dir=args.out_dir,
+                    num_ctx=args.num_ctx,
+                    num_predict=args.num_predict,
+                    timeout_seconds=args.timeout_seconds,
+                    auto_repair_validation_refs=not args.no_auto_repair_validation_refs,
+                )
+            elif args.skill_checkpoint_command == "finalize":
+                packet = json.loads(args.packet.read_text(encoding="utf-8"))
+                result = json.loads(args.result.read_text(encoding="utf-8"))
+                report = write_skill_checkpoint_outputs(
+                    result=result,
+                    packet=packet,
+                    out_dir=args.out_dir,
+                    auto_repair_validation_refs=not args.no_auto_repair_validation_refs,
+                )
+            else:
+                parser.error(f"unknown skill-checkpoint command: {args.skill_checkpoint_command}")
+                return 2
+            _print({"ok": report.get("status") == "accepted", "result": report})
+            return 0 if report.get("status") == "accepted" else 1
 
         settings = Settings.load()
         orch = OrchestratorService(settings)

--- a/src/agent_memory_orchestrator/llm/qwen.py
+++ b/src/agent_memory_orchestrator/llm/qwen.py
@@ -138,6 +138,23 @@ class OllamaQwenClient:
             raise QwenUnavailable("ollama returned no context text")
         return text
 
+    def generate_json(
+        self,
+        prompt: str,
+        *,
+        num_predict: int,
+        timeout_seconds: float | None = None,
+        schema: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Run a local Ollama JSON call for bounded production extraction tasks."""
+
+        return self._generate_json(
+            prompt,
+            num_predict=num_predict,
+            timeout_seconds=timeout_seconds,
+            schema=schema,
+        )
+
     def _generate_json(
         self,
         prompt: str,

--- a/src/agent_memory_orchestrator/skill_checkpoint/__init__.py
+++ b/src/agent_memory_orchestrator/skill_checkpoint/__init__.py
@@ -1,0 +1,21 @@
+from .pipeline import DEFAULT_NUM_PREDICT
+from .pipeline import DEFAULT_LOCAL_NUM_CTX
+from .pipeline import DEFAULT_PROMPT_PROFILE
+from .pipeline import SKILL_CHECKPOINT_SCHEMA_VERSION
+from .pipeline import build_skill_checkpoint_prompt
+from .pipeline import finalize_skill_checkpoint_result
+from .pipeline import render_skill_md
+from .pipeline import run_local_skill_checkpoint_extraction
+from .pipeline import write_skill_checkpoint_outputs
+
+__all__ = [
+    "DEFAULT_NUM_PREDICT",
+    "DEFAULT_LOCAL_NUM_CTX",
+    "DEFAULT_PROMPT_PROFILE",
+    "SKILL_CHECKPOINT_SCHEMA_VERSION",
+    "build_skill_checkpoint_prompt",
+    "finalize_skill_checkpoint_result",
+    "render_skill_md",
+    "run_local_skill_checkpoint_extraction",
+    "write_skill_checkpoint_outputs",
+]

--- a/src/agent_memory_orchestrator/skill_checkpoint/pipeline.py
+++ b/src/agent_memory_orchestrator/skill_checkpoint/pipeline.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..core.config import Settings
+from ..llm.qwen import OllamaQwenClient
+
+SKILL_CHECKPOINT_SCHEMA_VERSION = "skill-checkpoint-v1"
+DEFAULT_NUM_PREDICT = 1300
+DEFAULT_LOCAL_NUM_CTX = 8192
+DEFAULT_PROMPT_PROFILE: dict[str, int] = {
+    "authoring_guide_chars": 3600,
+    "commit_stat_chars": 900,
+    "commit_patch_chars": 1800,
+    "stop_summary_chars": 2200,
+    "user_prompt_chars": 1800,
+    "command_chars": 800,
+    "result_chars": 900,
+    "generic_chars": 1200,
+}
+
+VALIDATION_EVENT_TYPES = {"validation", "test_run", "test_result"}
+VALIDATION_RESULT_TYPES = {"tool_result", "command_result"}
+ACTION_EVENT_TYPES = {
+    "git_commit",
+    "commit_expansion",
+    "deterministic_commit_expansion",
+    "tool_call",
+    "tool_result",
+    "command_result",
+    "code_change",
+}
+RAW_LEAK_PATTERNS = (
+    "tool_use:call_",
+    "tool_result:call_",
+    "transcript:",
+    "\\\\?\\C:",
+    "C:\\Users\\",
+)
+
+AUTHORING_GUIDE = """Skill authoring rules for Qwen:
+- Return one focused reusable capability, not a project summary.
+- Write for a future coding agent that must repeat the workflow safely.
+- Preserve concrete commands, validation checks, failure modes, and boundaries.
+- Do not include evidence refs, raw event ids, transcript ids, or private absolute paths in rendered skill content.
+- Generalize private paths as <workspace>, <repo>, <user_home>, <codex_home>, or relative paths.
+- Use only these final sections: title, overview, when_to_use, workflow, validation, safety.
+- Keep section items compact and practical.
+"""
+
+
+class JsonGenerator(Protocol):
+    def generate_json(
+        self,
+        prompt: str,
+        *,
+        num_predict: int,
+        timeout_seconds: float | None = None,
+        schema: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        ...
+
+
+def build_skill_checkpoint_prompt(
+    packet: dict[str, Any],
+    *,
+    prompt_profile: dict[str, int] | None = None,
+) -> tuple[str, dict[str, Any], str]:
+    """Build the local-Qwen prompt for one compact skill-checkpoint packet."""
+
+    profile = {**DEFAULT_PROMPT_PROFILE, **(prompt_profile or {})}
+    prompt_packet = build_prompt_packet(packet, prompt_profile=profile)
+    response_shape = {
+        "checkpoint_id": "string",
+        "evidence_cards": [
+            {
+                "ref": "E0001",
+                "summary": "short grounded summary",
+                "semantic_role": "user_goal|symptom|constraint|diagnosis|workflow_step|fix|validation|context|noise",
+                "importance": "high|medium|low",
+                "confidence": 0.0,
+            }
+        ],
+        "work_chains": [
+            {
+                "chain_type": "problem_fix|implementation_workflow|debugging_workflow|validation_workflow",
+                "problem_or_goal": "single factual claim",
+                "problem_source": "user_stated|inferred_from_events|not_clear",
+                "symptom_refs": ["E0001"],
+                "diagnosis_refs": ["E0002"],
+                "action_refs": ["E0003"],
+                "validation_refs": ["E0004"],
+                "reusable_pattern": "what future agents should reuse",
+                "confidence": 0.0,
+            }
+        ],
+        "skill_name": "lowercase-hyphen-name",
+        "description": "specific what-and-when discovery description under 1024 characters",
+        "skill_sections": {
+            "title": "Skill Title",
+            "overview": "One short paragraph.",
+            "when_to_use": ["short bullet"],
+            "workflow": ["short numbered step"],
+            "validation": ["short bullet"],
+            "safety": ["short bullet"],
+        },
+        "diagnostics": [],
+    }
+    prompt = "\n".join(
+        [
+            "/no_think",
+            "You are Qwen running inside Agent Memory Orchestrator's local skill checkpoint pipeline.",
+            "",
+            "Goal: build one reusable agent skill from the checkpoint packet.",
+            "",
+            "Rules:",
+            "- This is one pass only.",
+            "- AMO selected and mechanically cleaned the checkpoint events.",
+            "- Infer meaning from event card content; refs like E0001 are citation handles only.",
+            "- Return JSON only. Do not include markdown fences.",
+            "- Return skill_sections only; AMO renders final SKILL.md.",
+            "- Do not return skill_md or skill_md_lines.",
+            "- Every evidence card and work chain ref must cite packet.events[].ref.",
+            "- Renderable skill content must not include evidence refs, raw event ids, tool call ids, transcript ids, or private absolute paths.",
+            "- Generalize private paths as <workspace>, <repo>, <user_home>, <codex_home>, or relative paths.",
+            "- Keep output concise: at most 7 evidence_cards and exactly 1 work_chain.",
+            "- skill_sections must include only title, overview, when_to_use, workflow, validation, safety.",
+            "",
+            "Authoring guide:",
+            AUTHORING_GUIDE.strip(),
+            "",
+            "Required JSON shape:",
+            json.dumps(response_shape, ensure_ascii=False, indent=2),
+            "",
+            "Checkpoint packet:",
+            json.dumps(prompt_packet, ensure_ascii=False, separators=(",", ":")),
+        ]
+    )
+    prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    return prompt, prompt_packet, prompt_hash
+
+
+def build_prompt_packet(packet: dict[str, Any], *, prompt_profile: dict[str, int]) -> dict[str, Any]:
+    """Mechanically bound packet text while preserving the selected event cards."""
+
+    slim = copy.deepcopy(packet)
+    guide = slim.get("authoring_guide")
+    if isinstance(guide, dict) and "content" in guide:
+        guide["content"] = _clip_text(str(guide.get("content") or ""), prompt_profile["authoring_guide_chars"])
+
+    events: list[dict[str, Any]] = []
+    for event in slim.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        bounded = copy.deepcopy(event)
+        event_type = bounded.get("type")
+        if event_type in {"deterministic_commit_expansion", "commit_expansion"}:
+            bounded["stat"] = _clip_text_container(bounded.get("stat"), prompt_profile["commit_stat_chars"])
+            bounded["patch"] = _clip_text_container(bounded.get("patch"), prompt_profile["commit_patch_chars"])
+            bounded["patch_excerpt"] = _clip_text_container(
+                bounded.get("patch_excerpt"), prompt_profile["commit_patch_chars"]
+            )
+        elif event_type == "stop_summary":
+            bounded["content"] = _clip_text_container(bounded.get("content"), prompt_profile["stop_summary_chars"])
+        elif event_type == "user_prompt":
+            bounded["content"] = _clip_text_container(bounded.get("content"), prompt_profile["user_prompt_chars"])
+        elif event_type in {"git_commit", "validation", "git_status", "git_history"}:
+            bounded["cmd"] = _clip_text_container(bounded.get("cmd"), prompt_profile["command_chars"])
+            bounded["result"] = _clip_text_container(bounded.get("result"), prompt_profile["result_chars"])
+        else:
+            bounded["cmd"] = _clip_text_container(bounded.get("cmd"), prompt_profile["generic_chars"])
+            bounded["result"] = _clip_text_container(bounded.get("result"), prompt_profile["generic_chars"])
+            bounded["content"] = _clip_text_container(bounded.get("content"), prompt_profile["generic_chars"])
+        events.append(bounded)
+
+    slim["events"] = events
+    slim["prompt_profile"] = {
+        "schema_version": SKILL_CHECKPOINT_SCHEMA_VERSION,
+        "purpose": "local_qwen_skill_checkpoint",
+        "text_limits": prompt_profile,
+    }
+    return slim
+
+
+def run_local_skill_checkpoint_extraction(
+    *,
+    packet: dict[str, Any],
+    settings: Settings,
+    out_dir: Path,
+    num_ctx: int | None = None,
+    num_predict: int = DEFAULT_NUM_PREDICT,
+    timeout_seconds: float | None = None,
+    auto_repair_validation_refs: bool = True,
+) -> dict[str, Any]:
+    """Run local Ollama/Qwen and write validated skill-checkpoint outputs."""
+
+    prompt, prompt_packet, prompt_hash = build_skill_checkpoint_prompt(packet)
+    client = OllamaQwenClient(
+        endpoint=settings.qwen_endpoint,
+        model=settings.qwen_model,
+        timeout_seconds=timeout_seconds or settings.qwen_extract_timeout_seconds,
+        num_ctx=max(DEFAULT_LOCAL_NUM_CTX, int(num_ctx or settings.qwen_num_ctx)),
+    )
+    parsed_output = client.generate_json(
+        prompt,
+        num_predict=num_predict,
+        timeout_seconds=timeout_seconds or settings.qwen_extract_timeout_seconds,
+    )
+    qwen_result = {
+        "schema_version": SKILL_CHECKPOINT_SCHEMA_VERSION,
+        "runtime": settings.qwen_runtime,
+        "model": settings.qwen_model,
+        "call": "skill_checkpoint_one_pass",
+        "prompt_hash": prompt_hash,
+        "prompt_packet": prompt_packet,
+        "parsed_output": parsed_output,
+    }
+    return write_skill_checkpoint_outputs(
+        result=qwen_result,
+        packet=packet,
+        out_dir=out_dir,
+        auto_repair_validation_refs=auto_repair_validation_refs,
+    )
+
+
+def write_skill_checkpoint_outputs(
+    *,
+    result: dict[str, Any],
+    packet: dict[str, Any],
+    out_dir: Path,
+    auto_repair_validation_refs: bool = True,
+) -> dict[str, Any]:
+    finalized = finalize_skill_checkpoint_result(
+        result=result,
+        packet=packet,
+        auto_repair_validation_refs=auto_repair_validation_refs,
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    skill_path = out_dir / "SKILL.md"
+    provenance_path = out_dir / "skill_provenance.json"
+    corrected_result_path = out_dir / "stage8_qwen_result_corrected.json"
+    report_path = out_dir / "stage8_post_validation_report.json"
+
+    skill_path.write_text(finalized["skill_md"], encoding="utf-8")
+    provenance_path.write_text(json.dumps(finalized["provenance"], indent=2), encoding="utf-8")
+    corrected_result_path.write_text(json.dumps(finalized["corrected_result"], indent=2), encoding="utf-8")
+
+    report = {
+        "stage": "08_skill_checkpoint_post_validation",
+        "schema_version": SKILL_CHECKPOINT_SCHEMA_VERSION,
+        "status": finalized["status"],
+        "summary": {
+            "skill_name": finalized["skill_name"],
+            "error_count": finalized["error_count"],
+            "warning_count": finalized["warning_count"],
+            "skill_path": str(skill_path),
+            "provenance_path": str(provenance_path),
+            "corrected_result_path": str(corrected_result_path),
+        },
+        "repair_actions": finalized["repair_actions"],
+        "diagnostics": finalized["diagnostics"],
+    }
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return report
+
+
+def finalize_skill_checkpoint_result(
+    *,
+    result: dict[str, Any],
+    packet: dict[str, Any],
+    auto_repair_validation_refs: bool = True,
+) -> dict[str, Any]:
+    parsed = result.get("parsed_output")
+    diagnostics: list[dict[str, Any]] = []
+    if not isinstance(parsed, dict):
+        parsed = {}
+        diagnostics.append({"level": "error", "kind": "parsed_output_missing"})
+    else:
+        parsed = copy.deepcopy(parsed)
+
+    events_by_ref = _events_by_ref(packet)
+    repair_actions: list[dict[str, Any]] = []
+    if auto_repair_validation_refs:
+        parsed, repair_actions = repair_validation_refs(parsed, events_by_ref)
+
+    ref_diagnostics, provenance = validate_refs(parsed, events_by_ref)
+    diagnostics.extend(ref_diagnostics)
+
+    skill_md = render_skill_md(parsed)
+    diagnostics.extend(validate_skill_text(skill_md, parsed))
+
+    error_count = sum(1 for item in diagnostics if item.get("level") == "error")
+    warning_count = sum(1 for item in diagnostics if item.get("level") == "warning")
+
+    corrected_result = copy.deepcopy(result)
+    corrected_result["parsed_output"] = parsed
+    corrected_result["post_validation_repair_actions"] = repair_actions
+
+    return {
+        "status": "accepted" if error_count == 0 else "needs_review",
+        "skill_name": parsed.get("skill_name"),
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "diagnostics": diagnostics,
+        "repair_actions": repair_actions,
+        "skill_md": skill_md,
+        "provenance": provenance,
+        "corrected_result": corrected_result,
+    }
+
+
+def repair_validation_refs(
+    parsed: dict[str, Any],
+    events_by_ref: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    repaired = copy.deepcopy(parsed)
+    repair_actions: list[dict[str, Any]] = []
+    available = sorted(ref for ref, event in events_by_ref.items() if is_validation_event(event))
+    if not available:
+        return repaired, repair_actions
+
+    for chain_index, chain in enumerate(repaired.get("work_chains") or []):
+        if not isinstance(chain, dict):
+            continue
+        refs = chain.get("validation_refs", [])
+        if not isinstance(refs, list) or not refs:
+            continue
+        valid = [ref for ref in refs if is_validation_event(events_by_ref.get(ref, {}))]
+        invalid = [ref for ref in refs if ref not in valid]
+        if invalid:
+            replacement = sorted(set(valid + available))
+            chain["validation_refs"] = replacement
+            repair_actions.append(
+                {
+                    "kind": "validation_refs_repaired",
+                    "chain_index": chain_index,
+                    "before": refs,
+                    "after": replacement,
+                    "reason": "validation_refs must point to validation/test events, not commit or expansion events",
+                }
+            )
+    return repaired, repair_actions
+
+
+def validate_refs(
+    parsed: dict[str, Any],
+    events_by_ref: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    used_refs: set[str] = set()
+    validation_refs_available = sorted(ref for ref, event in events_by_ref.items() if is_validation_event(event))
+
+    for index, card in enumerate(parsed.get("evidence_cards") or []):
+        ref = card.get("ref") if isinstance(card, dict) else None
+        used_refs.add(str(ref))
+        if ref not in events_by_ref:
+            diagnostics.append({"level": "error", "kind": "evidence_card_ref_not_in_packet", "index": index, "ref": ref})
+
+    for chain_index, chain in enumerate(parsed.get("work_chains") or []):
+        if not isinstance(chain, dict):
+            diagnostics.append({"level": "error", "kind": "work_chain_not_object", "chain_index": chain_index})
+            continue
+        for field in ("symptom_refs", "diagnosis_refs", "action_refs", "validation_refs"):
+            refs = chain.get(field, [])
+            if not isinstance(refs, list):
+                diagnostics.append(
+                    {"level": "error", "kind": "chain_ref_field_not_list", "chain_index": chain_index, "field": field}
+                )
+                continue
+            for ref in refs:
+                used_refs.add(str(ref))
+                event = events_by_ref.get(ref)
+                if event is None:
+                    diagnostics.append(
+                        {
+                            "level": "error",
+                            "kind": "chain_ref_not_in_packet",
+                            "chain_index": chain_index,
+                            "field": field,
+                            "ref": ref,
+                        }
+                    )
+                    continue
+                event_type = event.get("type")
+                if field == "validation_refs" and not is_validation_event(event):
+                    diagnostics.append(
+                        {
+                            "level": "error",
+                            "kind": "validation_ref_not_validation_event",
+                            "chain_index": chain_index,
+                            "ref": ref,
+                            "event_type": event_type,
+                            "suggested_validation_refs": validation_refs_available,
+                        }
+                    )
+                elif field == "action_refs" and event_type not in ACTION_EVENT_TYPES:
+                    diagnostics.append(
+                        {
+                            "level": "warning",
+                            "kind": "action_ref_unusual_event_type",
+                            "chain_index": chain_index,
+                            "ref": ref,
+                            "event_type": event_type,
+                        }
+                    )
+
+    provenance = {
+        "schema_version": SKILL_CHECKPOINT_SCHEMA_VERSION,
+        "checkpoint_id": (parsed.get("checkpoint_id") or ""),
+        "used_refs": sorted(used_refs),
+        "validation_refs_available": validation_refs_available,
+        "events": [
+            {
+                "ref": ref,
+                "type": event.get("type"),
+                "is_validation": is_validation_event(event),
+                "preview": re.sub(r"\s+", " ", event_text(event)).strip()[:280],
+            }
+            for ref, event in sorted(events_by_ref.items())
+            if ref in used_refs
+        ],
+    }
+    return diagnostics, provenance
+
+
+def render_skill_md(parsed: dict[str, Any]) -> str:
+    sections = parsed.get("skill_sections")
+    if not isinstance(sections, dict):
+        return ""
+
+    skill_name = str(parsed.get("skill_name") or "generated-skill")
+    description = str(parsed.get("description") or "Generated skill from AMO checkpoint.").replace("\n", " ").strip()
+    title = str(sections.get("title") or skill_name).replace("\n", " ").strip()
+    overview = str(sections.get("overview") or "").replace("\n", " ").strip()
+
+    lines = [
+        "---",
+        f"name: {skill_name}",
+        f"description: {description}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+    ]
+    if overview:
+        lines.extend([overview, ""])
+
+    section_map = [
+        ("When To Use", "when_to_use", "- {item}"),
+        ("Workflow", "workflow", "{idx}. {item}"),
+        ("Validation", "validation", "- {item}"),
+        ("Safety", "safety", "- {item}"),
+    ]
+    for heading, key, template in section_map:
+        lines.extend([f"## {heading}", ""])
+        for idx, item in enumerate(_section_items(sections.get(key)), 1):
+            lines.append(template.format(idx=idx, item=item.replace("\n", " ").strip()))
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def validate_skill_text(skill_md: str, parsed: dict[str, Any]) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+    if not skill_md.startswith("---"):
+        diagnostics.append({"level": "error", "kind": "skill_md_missing_frontmatter"})
+
+    skill_name = parsed.get("skill_name")
+    if not isinstance(skill_name, str) or not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,63}", skill_name or ""):
+        diagnostics.append({"level": "error", "kind": "invalid_skill_name", "skill_name": skill_name})
+
+    description = parsed.get("description")
+    if not isinstance(description, str) or len(description) > 1024 or len(description.strip()) < 20:
+        diagnostics.append({"level": "error", "kind": "invalid_description"})
+
+    sections = parsed.get("skill_sections")
+    if not isinstance(sections, dict):
+        diagnostics.append({"level": "error", "kind": "invalid_skill_sections"})
+    else:
+        expected = {"title", "overview", "when_to_use", "workflow", "validation", "safety"}
+        missing = sorted(expected - set(sections))
+        extra = sorted(set(sections) - expected)
+        if missing:
+            diagnostics.append({"level": "error", "kind": "missing_skill_sections", "sections": missing})
+        if extra:
+            diagnostics.append({"level": "warning", "kind": "unexpected_skill_sections", "sections": extra})
+
+    leaked = [pattern for pattern in RAW_LEAK_PATTERNS if pattern in skill_md]
+    if leaked:
+        diagnostics.append({"level": "error", "kind": "raw_or_private_id_leak", "patterns": leaked})
+
+    evidence_refs = sorted(set(re.findall(r"\bE\d{4}\b", skill_md)))
+    if evidence_refs:
+        diagnostics.append({"level": "warning", "kind": "evidence_refs_in_rendered_skill", "refs": evidence_refs})
+
+    return diagnostics
+
+
+def is_validation_event(event: dict[str, Any]) -> bool:
+    event_type = event.get("type")
+    if event_type in VALIDATION_EVENT_TYPES:
+        return True
+    if event_type not in VALIDATION_RESULT_TYPES:
+        return False
+    text = event_text(event).lower()
+    return any(marker in text for marker in ("pytest", "ruff check", "tests passed", "test passed", "passed in"))
+
+
+def event_text(event: dict[str, Any]) -> str:
+    chunks: list[str] = []
+    for key in ("summary", "content", "cmd", "result", "patch", "patch_excerpt", "stat"):
+        value = event.get(key)
+        if isinstance(value, str):
+            chunks.append(value)
+        elif isinstance(value, dict) and isinstance(value.get("text"), str):
+            chunks.append(value["text"])
+    return "\n".join(chunks)
+
+
+def _events_by_ref(packet: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        event["ref"]: event
+        for event in packet.get("events") or []
+        if isinstance(event, dict) and isinstance(event.get("ref"), str)
+    }
+
+
+def _section_items(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _clip_text(value: str, limit: int) -> str:
+    text = "" if value is None else str(value)
+    if len(text) <= limit:
+        return text
+    head = limit // 2
+    tail = limit - head
+    return f"{text[:head]}\n...[TRUNCATED_FOR_QWEN_CONTEXT]...\n{text[-tail:]}"
+
+
+def _clip_text_container(value: Any, limit: int) -> Any:
+    if isinstance(value, dict) and "text" in value:
+        out = dict(value)
+        original = str(out.get("text") or "")
+        out["text"] = _clip_text(original, limit)
+        out["trimmed_for_qwen"] = len(original) > limit
+        return out
+    if isinstance(value, str):
+        return _clip_text(value, limit)
+    return value

--- a/tests/test_skill_checkpoint.py
+++ b/tests/test_skill_checkpoint.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_memory_orchestrator.skill_checkpoint import build_skill_checkpoint_prompt
+from agent_memory_orchestrator.skill_checkpoint import finalize_skill_checkpoint_result
+from agent_memory_orchestrator.skill_checkpoint import write_skill_checkpoint_outputs
+
+
+def _packet() -> dict:
+    return {
+        "task": "one_pass_skill_distillation_from_agent_checkpoint",
+        "checkpoint": {"checkpoint_id": "skillcp_test"},
+        "events": [
+            {"ref": "E0001", "type": "user_prompt", "content": "User asked to build a reusable checkpoint skill."},
+            {"ref": "E0002", "type": "git_commit", "cmd": "git commit -m feat(skill): add checkpoint flow"},
+            {"ref": "E0003", "type": "commit_expansion", "patch": "diff --git a/src/skill.py b/src/skill.py"},
+            {"ref": "E0004", "type": "validation", "cmd": "python -m pytest tests/test_skill_checkpoint.py -q"},
+        ],
+    }
+
+
+def _qwen_result() -> dict:
+    return {
+        "parsed_output": {
+            "checkpoint_id": "skillcp_test",
+            "evidence_cards": [
+                {
+                    "ref": "E0001",
+                    "summary": "User wanted a reusable checkpoint skill.",
+                    "semantic_role": "user_goal",
+                    "importance": "high",
+                    "confidence": 0.9,
+                }
+            ],
+            "work_chains": [
+                {
+                    "chain_type": "implementation_workflow",
+                    "problem_or_goal": "Build a reusable checkpoint skill from a session slice.",
+                    "problem_source": "user_stated",
+                    "symptom_refs": ["E0001"],
+                    "diagnosis_refs": ["E0002"],
+                    "action_refs": ["E0002", "E0003"],
+                    "validation_refs": ["E0003"],
+                    "reusable_pattern": "Select evidence, ask Qwen for sections, validate provenance, render SKILL.md.",
+                    "confidence": 0.88,
+                }
+            ],
+            "skill_name": "checkpoint-skill-authoring",
+            "description": "Build a reusable skill from a compact checkpoint packet and validated provenance.",
+            "skill_sections": {
+                "title": "Checkpoint Skill Authoring",
+                "overview": "Use a compact checkpoint packet to create a focused reusable agent skill.",
+                "when_to_use": ["When a session workflow should become reusable agent behavior."],
+                "workflow": [
+                    "Select the checkpoint packet with user goal, actions, and validation.",
+                    "Use local Qwen to infer the reusable workflow.",
+                    "Render SKILL.md only after deterministic validation.",
+                ],
+                "validation": ["Confirm validation_refs point to validation events."],
+                "safety": ["Keep refs and private paths out of rendered SKILL.md."],
+            },
+            "diagnostics": [],
+        }
+    }
+
+
+def test_skill_checkpoint_prompt_uses_sections_not_raw_markdown_output() -> None:
+    prompt, prompt_packet, prompt_hash = build_skill_checkpoint_prompt(_packet())
+
+    assert prompt_hash
+    assert prompt_packet["prompt_profile"]["schema_version"] == "skill-checkpoint-v1"
+    assert "skill_sections" in prompt
+    assert "Do not return skill_md or skill_md_lines" in prompt
+
+
+def test_finalize_repairs_validation_refs_to_actual_validation_events() -> None:
+    finalized = finalize_skill_checkpoint_result(result=_qwen_result(), packet=_packet())
+
+    assert finalized["status"] == "accepted"
+    assert finalized["error_count"] == 0
+    assert finalized["repair_actions"] == [
+        {
+            "kind": "validation_refs_repaired",
+            "chain_index": 0,
+            "before": ["E0003"],
+            "after": ["E0004"],
+            "reason": "validation_refs must point to validation/test events, not commit or expansion events",
+        }
+    ]
+    assert "E0003" not in finalized["skill_md"]
+    assert "C:\\Users\\" not in finalized["skill_md"]
+    assert finalized["corrected_result"]["parsed_output"]["work_chains"][0]["validation_refs"] == ["E0004"]
+
+
+def test_finalize_without_repair_rejects_commit_expansion_validation_ref() -> None:
+    finalized = finalize_skill_checkpoint_result(
+        result=_qwen_result(),
+        packet=_packet(),
+        auto_repair_validation_refs=False,
+    )
+
+    assert finalized["status"] == "needs_review"
+    assert finalized["error_count"] == 1
+    assert finalized["diagnostics"][0]["kind"] == "validation_ref_not_validation_event"
+    assert finalized["diagnostics"][0]["suggested_validation_refs"] == ["E0004"]
+
+
+def test_write_skill_checkpoint_outputs_writes_rendered_skill_and_provenance(tmp_path: Path) -> None:
+    report = write_skill_checkpoint_outputs(result=_qwen_result(), packet=_packet(), out_dir=tmp_path)
+
+    assert report["status"] == "accepted"
+    assert (tmp_path / "SKILL.md").read_text(encoding="utf-8").startswith("---\nname: checkpoint-skill-authoring")
+    assert (tmp_path / "skill_provenance.json").exists()
+    assert (tmp_path / "stage8_qwen_result_corrected.json").exists()
+    assert (tmp_path / "stage8_post_validation_report.json").exists()


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.
