### PR TITLE
Skill checkpoint

### DIFF
--- a/docs/skill_checkpoint/README.md
+++ b/docs/skill_checkpoint/README.md
@@ -20,7 +20,14 @@ Production now supports the validated Stage 8 core:
 6. Repair safe provenance-only mistakes, such as non-validation refs in `validation_refs`.
 7. Write the skill, provenance, corrected result, and validation report.
 
-Checkpoint selection and slash-command UX are intentionally not finalized yet. Those will decide how users mark a checkpoint during a live Codex/Claude session. The production core here starts after a compact packet already exists.
+Live checkpoint marking is now configured by the installer:
+
+- Claude Code gets a `/skill-checkpoint` command file at `.claude/commands/skill-checkpoint.md`.
+- Codex gets a discoverable `amo-skill-checkpoint` skill because this environment exposes skills but not the same command-file surface.
+
+Both surfaces tell the agent to run one local `amo-cli skill-checkpoint mark` command. The command records a lightweight checkpoint marker in AMO evidence and writes a pending marker file. It does not summarize the session inside the agent.
+
+The compact packet builder from a pending marker is still the next phase. The production core here starts once a compact packet exists.
 
 ## Why This Shape Exists
 
@@ -112,6 +119,20 @@ Qwen must not return `skill_md` or `skill_md_lines`. AMO renders the final Markd
 
 ## Commands
 
+Mark the current session as a pending checkpoint:
+
+```powershell
+amo-cli skill-checkpoint mark `
+  --agent codex `
+  --note "turn this workflow into a reusable skill"
+```
+
+List pending checkpoints:
+
+```powershell
+amo-cli skill-checkpoint status
+```
+
 Run local Qwen extraction:
 
 ```powershell
@@ -158,8 +179,7 @@ Safe automatic repair:
 
 These are intentionally left for the next phase:
 
-- live checkpoint marking UX, such as a slash command or explicit AMO checkpoint command,
-- checkpoint-window selection from hook evidence,
+- compact packet building from a pending checkpoint marker,
 - installing the rendered skill into Codex/Claude discovery paths,
 - skill quality scoring across multiple checkpoints,
 - graph links from generated skills back to checkpoint/session/version nodes.

--- a/src/agent_memory_orchestrator/app/cli.py
+++ b/src/agent_memory_orchestrator/app/cli.py
@@ -35,6 +35,8 @@ from ..reasoning_graph.session_runtime import default_session_graph_path
 from ..reasoning_graph.session_runtime import query_session_graph
 from ..skill_checkpoint import DEFAULT_LOCAL_NUM_CTX
 from ..skill_checkpoint import DEFAULT_NUM_PREDICT
+from ..skill_checkpoint import list_skill_checkpoints
+from ..skill_checkpoint import mark_skill_checkpoint
 from ..skill_checkpoint import run_local_skill_checkpoint_extraction
 from ..skill_checkpoint import write_skill_checkpoint_outputs
 from .client import DaemonClient, DaemonUnavailable
@@ -296,10 +298,29 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     skill_checkpoint_extract.add_argument("--packet", required=True, type=Path)
     skill_checkpoint_extract.add_argument("--out-dir", required=True, type=Path)
+    skill_checkpoint_extract.add_argument("--amo-home", type=Path)
     skill_checkpoint_extract.add_argument("--num-ctx", type=int, default=DEFAULT_LOCAL_NUM_CTX)
     skill_checkpoint_extract.add_argument("--num-predict", type=int, default=DEFAULT_NUM_PREDICT)
     skill_checkpoint_extract.add_argument("--timeout-seconds", type=float)
     skill_checkpoint_extract.add_argument("--no-auto-repair-validation-refs", action="store_true")
+
+    skill_checkpoint_mark = skill_checkpoint_sub.add_parser(
+        "mark",
+        help="Mark the current agent session as a pending skill checkpoint",
+    )
+    skill_checkpoint_mark.add_argument("--agent", choices=["codex", "claude"], default="codex")
+    skill_checkpoint_mark.add_argument("--session-id", default="", help="Optional explicit session id. Defaults to latest captured session for the agent.")
+    skill_checkpoint_mark.add_argument("--note", default="", help="Optional user intent or checkpoint note.")
+    skill_checkpoint_mark.add_argument("--mode", choices=["workflow", "single_commit"], default="workflow")
+    skill_checkpoint_mark.add_argument("--cwd", type=Path, default=Path.cwd())
+    skill_checkpoint_mark.add_argument("--amo-home", type=Path)
+
+    skill_checkpoint_status = skill_checkpoint_sub.add_parser(
+        "status",
+        help="List pending skill checkpoints",
+    )
+    skill_checkpoint_status.add_argument("--limit", type=int, default=20)
+    skill_checkpoint_status.add_argument("--amo-home", type=Path)
 
     skill_checkpoint_finalize = skill_checkpoint_sub.add_parser(
         "finalize",
@@ -308,6 +329,7 @@ def _build_parser() -> argparse.ArgumentParser:
     skill_checkpoint_finalize.add_argument("--result", required=True, type=Path)
     skill_checkpoint_finalize.add_argument("--packet", required=True, type=Path)
     skill_checkpoint_finalize.add_argument("--out-dir", required=True, type=Path)
+    skill_checkpoint_finalize.add_argument("--amo-home", type=Path)
     skill_checkpoint_finalize.add_argument("--no-auto-repair-validation-refs", action="store_true")
 
     timeline = sub.add_parser("timeline", help="View session timeline")
@@ -932,6 +954,8 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
 
         if args.command == "skill-checkpoint":
+            if getattr(args, "amo_home", None):
+                os.environ["AMO_HOME"] = str(args.amo_home.expanduser().resolve())
             if args.skill_checkpoint_command == "extract":
                 settings = Settings.load()
                 packet = json.loads(args.packet.read_text(encoding="utf-8"))
@@ -944,6 +968,19 @@ def main(argv: list[str] | None = None) -> int:
                     timeout_seconds=args.timeout_seconds,
                     auto_repair_validation_refs=not args.no_auto_repair_validation_refs,
                 )
+            elif args.skill_checkpoint_command == "mark":
+                settings = Settings.load()
+                report = mark_skill_checkpoint(
+                    settings=settings,
+                    agent=args.agent,
+                    session_id=args.session_id,
+                    note=args.note,
+                    mode=args.mode,
+                    cwd=args.cwd,
+                )
+            elif args.skill_checkpoint_command == "status":
+                settings = Settings.load()
+                report = list_skill_checkpoints(settings, limit=args.limit)
             elif args.skill_checkpoint_command == "finalize":
                 packet = json.loads(args.packet.read_text(encoding="utf-8"))
                 result = json.loads(args.result.read_text(encoding="utf-8"))
@@ -956,8 +993,9 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 parser.error(f"unknown skill-checkpoint command: {args.skill_checkpoint_command}")
                 return 2
-            _print({"ok": report.get("status") == "accepted", "result": report})
-            return 0 if report.get("status") == "accepted" else 1
+            ok = bool(report.get("ok", report.get("status") == "accepted"))
+            _print({"ok": ok, "result": report})
+            return 0 if ok else 1
 
         settings = Settings.load()
         orch = OrchestratorService(settings)

--- a/src/agent_memory_orchestrator/install/service.py
+++ b/src/agent_memory_orchestrator/install/service.py
@@ -14,6 +14,7 @@ from ..llm.models import resolve_models
 
 MANAGED_BEGIN = "# BEGIN AMO MANAGED BLOCK"
 MANAGED_END = "# END AMO MANAGED BLOCK"
+SKILL_CHECKPOINT_MARKER = "AMO_SKILL_CHECKPOINT_MANAGED"
 CLAUDE_MCP_NAME = "agent-memory-orchestrator"
 CODEX_MCP_NAME = "agent_memory_orchestrator"
 SUPPORTED_TARGETS = {"codex", "claude", "all"}
@@ -66,10 +67,24 @@ def build_install_plan(options: InstallOptions) -> dict[str, Any]:
                 python_command=options.python_command,
             )
         )
+        operations.append(
+            _codex_skill_checkpoint_operation(
+                skill_path=user_home / ".codex" / "skills" / "amo-skill-checkpoint" / "SKILL.md",
+                amo_home=amo_home,
+                python_command=options.python_command,
+            )
+        )
     if "claude" in targets:
         operations.append(
             _claude_operation(
                 settings_path=user_home / ".claude" / "settings.json",
+                amo_home=amo_home,
+                python_command=options.python_command,
+            )
+        )
+        operations.append(
+            _claude_skill_checkpoint_command_operation(
+                command_path=user_home / ".claude" / "commands" / "skill-checkpoint.md",
                 amo_home=amo_home,
                 python_command=options.python_command,
             )
@@ -123,9 +138,11 @@ def uninstall(target: str = "all", user_home: Path | None = None) -> dict[str, A
     if "codex" in selected:
         results.append(_uninstall_codex(home / ".codex" / "config.toml"))
         results.append(_uninstall_codex_hooks(home / ".codex" / "hooks.json"))
+        results.append(_uninstall_managed_file(home / ".codex" / "skills" / "amo-skill-checkpoint" / "SKILL.md", "codex-skill-checkpoint"))
     if "claude" in selected:
         path = home / ".claude" / "settings.json"
         results.append(_uninstall_claude(path))
+        results.append(_uninstall_managed_file(home / ".claude" / "commands" / "skill-checkpoint.md", "claude-skill-checkpoint"))
     return {"ok": True, "results": results}
 
 
@@ -156,6 +173,7 @@ def doctor(target: str = "all", user_home: Path | None = None, amo_home: Path | 
             "mcp_configured": CODEX_MCP_NAME in text,
             "hooks_configured": "agent_memory_orchestrator.hook" in text or _codex_has_amo_hooks(hooks_payload),
             "codex_hooks_enabled": bool(re.search(r"(?m)^\s*codex_hooks\s*=\s*true\s*$", text)),
+            "skill_checkpoint_configured": (home / ".codex" / "skills" / "amo-skill-checkpoint" / "SKILL.md").exists(),
         }
     if "claude" in selected:
         path = home / ".claude" / "settings.json"
@@ -165,6 +183,7 @@ def doctor(target: str = "all", user_home: Path | None = None, amo_home: Path | 
             "settings_exists": path.exists(),
             "mcp_configured": CLAUDE_MCP_NAME in payload.get("mcpServers", {}),
             "hooks_configured": _claude_has_amo_hooks(payload),
+            "skill_checkpoint_configured": (home / ".claude" / "commands" / "skill-checkpoint.md").exists(),
         }
     ok = checks["amo_home"]["config_exists"] and all(
         not isinstance(item, dict)
@@ -326,6 +345,26 @@ def _codex_hooks_operation(
     }
 
 
+def _codex_skill_checkpoint_operation(*, skill_path: Path, amo_home: Path, python_command: str) -> dict[str, Any]:
+    return {
+        "target": "codex-skill-checkpoint",
+        "path": str(skill_path),
+        "exists": skill_path.exists(),
+        "after": _codex_skill_checkpoint_skill(amo_home=amo_home, python_command=python_command),
+        "description": "Install the AMO skill-checkpoint trigger skill for Codex.",
+    }
+
+
+def _claude_skill_checkpoint_command_operation(*, command_path: Path, amo_home: Path, python_command: str) -> dict[str, Any]:
+    return {
+        "target": "claude-skill-checkpoint",
+        "path": str(command_path),
+        "exists": command_path.exists(),
+        "after": _claude_skill_checkpoint_command(amo_home=amo_home, python_command=python_command),
+        "description": "Install the /skill-checkpoint command for Claude Code.",
+    }
+
+
 def _codex_hooks_cleanup_operation(*, hooks_path: Path) -> dict[str, Any]:
     exists = hooks_path.exists()
     payload = _read_json(hooks_path)
@@ -347,6 +386,55 @@ def _codex_hooks_cleanup_operation(*, hooks_path: Path) -> dict[str, Any]:
         "after": json.dumps(payload, indent=2, sort_keys=True) + "\n" if payload or exists else "",
         "description": "Remove stale AMO hooks.json entries before writing the current hook set.",
     }
+
+
+def _codex_skill_checkpoint_skill(*, amo_home: Path, python_command: str) -> str:
+    command = _skill_checkpoint_mark_command(python_command, "codex", amo_home, note_placeholder="<user note>")
+    return (
+        "---\n"
+        "name: amo-skill-checkpoint\n"
+        "description: Use when the user types /skill-checkpoint or asks to turn the current workflow into a reusable AMO skill checkpoint.\n"
+        "---\n\n"
+        f"<!-- {SKILL_CHECKPOINT_MARKER}: codex -->\n\n"
+        "# AMO Skill Checkpoint\n\n"
+        "When the user asks for `/skill-checkpoint`, do not summarize the session manually and do not call sub-agents.\n\n"
+        "Run one local AMO marker command from the current workspace:\n\n"
+        "```powershell\n"
+        f"{command}\n"
+        "```\n\n"
+        "Replace `<user note>` with the user's checkpoint note if provided. If no note is provided, omit `--note` or pass an empty note.\n\n"
+        "After the command returns, report only the `checkpoint_id` and marker path. AMO hooks already captured the surrounding prompts, tool calls, tool results, code reads, patches, commits, and validation evidence.\n"
+    )
+
+
+def _claude_skill_checkpoint_command(*, amo_home: Path, python_command: str) -> str:
+    command = _skill_checkpoint_mark_command(python_command, "claude", amo_home, note_placeholder="$ARGUMENTS")
+    return (
+        "---\n"
+        "description: Mark the current AMO session as a reusable skill checkpoint\n"
+        "---\n\n"
+        f"<!-- {SKILL_CHECKPOINT_MARKER}: claude -->\n\n"
+        "Mark the current AMO session as a pending skill checkpoint. Do not summarize the session manually.\n\n"
+        "Run this command from the current workspace:\n\n"
+        "```bash\n"
+        f"{command}\n"
+        "```\n\n"
+        "Then reply with the `checkpoint_id`, marker path, and that AMO will build the compact packet later from captured hook evidence.\n"
+    )
+
+
+def _skill_checkpoint_mark_command(
+    python_command: str,
+    agent: str,
+    amo_home: Path,
+    *,
+    note_placeholder: str,
+) -> str:
+    note = note_placeholder.replace('"', '\\"')
+    return (
+        f'{_shell_command_atom(python_command)} -m agent_memory_orchestrator.app.cli '
+        f'skill-checkpoint mark --agent {agent} --amo-home "{amo_home}" --note "{note}"'
+    )
 
 
 def _claude_operation(*, settings_path: Path, amo_home: Path, python_command: str) -> dict[str, Any]:
@@ -499,6 +587,20 @@ def _uninstall_codex_hooks(path: Path) -> dict[str, Any]:
             backup_path = str(backup)
         path.write_text(after, encoding="utf-8")
     return {"target": "codex-hooks", "path": str(path), "changed": changed, "backup_path": backup_path}
+
+
+def _uninstall_managed_file(path: Path, target: str) -> dict[str, Any]:
+    changed = False
+    backup_path = ""
+    if path.exists():
+        text = path.read_text(encoding="utf-8")
+        if SKILL_CHECKPOINT_MARKER in text:
+            backup = _backup_path(path)
+            shutil.copy2(path, backup)
+            backup_path = str(backup)
+            path.unlink()
+            changed = True
+    return {"target": target, "path": str(path), "changed": changed, "backup_path": backup_path}
 
 
 def _uninstall_claude(path: Path) -> dict[str, Any]:

--- a/src/agent_memory_orchestrator/skill_checkpoint/__init__.py
+++ b/src/agent_memory_orchestrator/skill_checkpoint/__init__.py
@@ -4,6 +4,9 @@ from .pipeline import DEFAULT_PROMPT_PROFILE
 from .pipeline import SKILL_CHECKPOINT_SCHEMA_VERSION
 from .pipeline import build_skill_checkpoint_prompt
 from .pipeline import finalize_skill_checkpoint_result
+from .pipeline import infer_latest_session_id
+from .pipeline import list_skill_checkpoints
+from .pipeline import mark_skill_checkpoint
 from .pipeline import render_skill_md
 from .pipeline import run_local_skill_checkpoint_extraction
 from .pipeline import write_skill_checkpoint_outputs
@@ -15,6 +18,9 @@ __all__ = [
     "SKILL_CHECKPOINT_SCHEMA_VERSION",
     "build_skill_checkpoint_prompt",
     "finalize_skill_checkpoint_result",
+    "infer_latest_session_id",
+    "list_skill_checkpoints",
+    "mark_skill_checkpoint",
     "render_skill_md",
     "run_local_skill_checkpoint_extraction",
     "write_skill_checkpoint_outputs",

--- a/src/agent_memory_orchestrator/skill_checkpoint/pipeline.py
+++ b/src/agent_memory_orchestrator/skill_checkpoint/pipeline.py
@@ -4,10 +4,13 @@ import copy
 import hashlib
 import json
 import re
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
 
 from ..core.config import Settings
+from ..evidence.raw_store import RawEvidenceStore
 from ..llm.qwen import OllamaQwenClient
 
 SKILL_CHECKPOINT_SCHEMA_VERSION = "skill-checkpoint-v1"
@@ -23,6 +26,7 @@ DEFAULT_PROMPT_PROFILE: dict[str, int] = {
     "result_chars": 900,
     "generic_chars": 1200,
 }
+CHECKPOINT_MODES = {"workflow", "single_commit"}
 
 VALIDATION_EVENT_TYPES = {"validation", "test_run", "test_result"}
 VALIDATION_RESULT_TYPES = {"tool_result", "command_result"}
@@ -228,6 +232,119 @@ def run_local_skill_checkpoint_extraction(
     )
 
 
+def mark_skill_checkpoint(
+    *,
+    settings: Settings,
+    agent: str,
+    note: str = "",
+    mode: str = "workflow",
+    session_id: str = "",
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    """Record a lightweight checkpoint marker without interrupting the agent."""
+
+    if mode not in CHECKPOINT_MODES:
+        raise ValueError(f"mode must be one of: {', '.join(sorted(CHECKPOINT_MODES))}")
+    if agent not in {"codex", "claude"}:
+        raise ValueError("agent must be codex or claude")
+
+    resolved_cwd = (cwd or Path.cwd()).expanduser().resolve()
+    inferred_session = session_id.strip() or infer_latest_session_id(settings.evidence_dir, source_app=agent)
+    if not inferred_session:
+        inferred_session = f"manual-{agent}-{_timestamp_compact()}"
+    checkpoint_id = f"skillcp_{_timestamp_compact()}_{uuid.uuid4().hex[:8]}"
+    created_at = datetime.now(timezone.utc).isoformat()
+    payload = {
+        "hook_event_name": "SkillCheckpoint",
+        "event_type": "skill_checkpoint",
+        "session_id": inferred_session,
+        "source_app": agent,
+        "created_at": created_at,
+        "cwd": str(resolved_cwd),
+        "checkpoint": {
+            "checkpoint_id": checkpoint_id,
+            "mode": mode,
+            "note": note.strip(),
+            "selection_policy": "previous_stop_or_nearest_prior_commit_to_checkpoint",
+        },
+    }
+    evidence = RawEvidenceStore(settings.evidence_dir).append(
+        payload,
+        session_id=inferred_session,
+        source_app=agent,
+        event_name="skill_checkpoint",
+    )
+    marker = {
+        "schema_version": SKILL_CHECKPOINT_SCHEMA_VERSION,
+        "checkpoint_id": checkpoint_id,
+        "status": "pending_packet",
+        "agent": agent,
+        "session_id": inferred_session,
+        "mode": mode,
+        "note": note.strip(),
+        "cwd": str(resolved_cwd),
+        "created_at": created_at,
+        "evidence": evidence.as_dict(),
+        "next_steps": [
+            "Build a compact checkpoint packet from captured evidence.",
+            "Run amo-cli skill-checkpoint extract once packet selection is available.",
+        ],
+    }
+    marker_path = _checkpoint_marker_path(settings, checkpoint_id)
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text(json.dumps(marker, indent=2), encoding="utf-8")
+    return {"ok": True, "checkpoint": marker, "marker_path": str(marker_path)}
+
+
+def list_skill_checkpoints(settings: Settings, *, limit: int = 20) -> dict[str, Any]:
+    root = settings.home / "skill-checkpoints" / "pending"
+    rows: list[dict[str, Any]] = []
+    if root.exists():
+        for path in sorted(root.glob("*.json"), key=lambda item: item.stat().st_mtime, reverse=True)[:limit]:
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            rows.append(
+                {
+                    "checkpoint_id": payload.get("checkpoint_id"),
+                    "status": payload.get("status"),
+                    "agent": payload.get("agent"),
+                    "session_id": payload.get("session_id"),
+                    "mode": payload.get("mode"),
+                    "note": payload.get("note"),
+                    "created_at": payload.get("created_at"),
+                    "path": str(path),
+                }
+            )
+    return {"ok": True, "count": len(rows), "checkpoints": rows}
+
+
+def infer_latest_session_id(evidence_dir: Path, *, source_app: str) -> str:
+    """Best-effort inference for slash-command ergonomics."""
+
+    try:
+        files = sorted(evidence_dir.glob("*.jsonl"), key=lambda item: item.stat().st_mtime, reverse=True)
+    except OSError:
+        return ""
+    for path in files[:7]:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in reversed(lines):
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if str(record.get("source_app") or "") != source_app:
+                continue
+            session_id = str(record.get("session_id") or "").strip()
+            if session_id:
+                return session_id
+    return ""
+
+
 def write_skill_checkpoint_outputs(
     *,
     result: dict[str, Any],
@@ -268,6 +385,14 @@ def write_skill_checkpoint_outputs(
     }
     report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
     return report
+
+
+def _checkpoint_marker_path(settings: Settings, checkpoint_id: str) -> Path:
+    return settings.home / "skill-checkpoints" / "pending" / f"{checkpoint_id}.json"
+
+
+def _timestamp_compact() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 def finalize_skill_checkpoint_result(

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -49,6 +49,9 @@ def test_codex_install_applies_managed_hooks_and_mcp(tmp_path: Path) -> None:
     assert "amo_hook_launcher.py" in hook_command
     assert "--agent codex" in hook_command
     assert str(amo_home.resolve()) in hook_command
+    codex_skill = user_home / ".codex" / "skills" / "amo-skill-checkpoint" / "SKILL.md"
+    assert codex_skill.exists()
+    assert "skill-checkpoint mark --agent codex" in codex_skill.read_text(encoding="utf-8")
     launcher_text = (amo_home / "bin" / "amo_hook_launcher.py").read_text(encoding="utf-8")
     assert "IMPORT_ROOT" in launcher_text
     assert "runpy.run_module('agent_memory_orchestrator.hook'" in launcher_text
@@ -57,6 +60,7 @@ def test_codex_install_applies_managed_hooks_and_mcp(tmp_path: Path) -> None:
     assert status["ok"] is True
     assert status["checks"]["codex"]["hooks_configured"] is True
     assert status["checks"]["codex"]["hooks_file_exists"] is True
+    assert status["checks"]["codex"]["skill_checkpoint_configured"] is True
 
 
 def test_claude_install_merges_json_settings(tmp_path: Path) -> None:
@@ -77,10 +81,14 @@ def test_claude_install_merges_json_settings(tmp_path: Path) -> None:
     assert payload["mcpServers"]["agent-memory-orchestrator"]["args"][-1] == str(amo_home.resolve())
     assert "UserPromptSubmit" in payload["hooks"]
     assert any("agent_memory_orchestrator.hook --agent claude" in hook["command"] for hook in payload["hooks"]["Stop"][0]["hooks"])
+    command = user_home / ".claude" / "commands" / "skill-checkpoint.md"
+    assert command.exists()
+    assert "skill-checkpoint mark --agent claude" in command.read_text(encoding="utf-8")
 
     status = doctor(target="claude", user_home=user_home, amo_home=amo_home)
     assert status["checks"]["claude"]["mcp_configured"] is True
     assert status["checks"]["claude"]["hooks_configured"] is True
+    assert status["checks"]["claude"]["skill_checkpoint_configured"] is True
 
 
 def test_uninstall_removes_managed_entries(tmp_path: Path) -> None:
@@ -100,6 +108,8 @@ def test_uninstall_removes_managed_entries(tmp_path: Path) -> None:
     assert "amo_hook_launcher.py" not in codex_hooks
     assert "agent-memory-orchestrator" not in claude_payload.get("mcpServers", {})
     assert not any(claude_payload.get("hooks", {}).values())
+    assert not (user_home / ".codex" / "skills" / "amo-skill-checkpoint" / "SKILL.md").exists()
+    assert not (user_home / ".claude" / "commands" / "skill-checkpoint.md").exists()
 
 
 def test_settings_loads_installer_runtime_config(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_skill_checkpoint.py
+++ b/tests/test_skill_checkpoint.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from agent_memory_orchestrator.core.config import Settings
+from agent_memory_orchestrator.evidence.raw_store import RawEvidenceStore
 from agent_memory_orchestrator.skill_checkpoint import build_skill_checkpoint_prompt
 from agent_memory_orchestrator.skill_checkpoint import finalize_skill_checkpoint_result
+from agent_memory_orchestrator.skill_checkpoint import infer_latest_session_id
+from agent_memory_orchestrator.skill_checkpoint import list_skill_checkpoints
+from agent_memory_orchestrator.skill_checkpoint import mark_skill_checkpoint
 from agent_memory_orchestrator.skill_checkpoint import write_skill_checkpoint_outputs
 
 
@@ -114,3 +119,36 @@ def test_write_skill_checkpoint_outputs_writes_rendered_skill_and_provenance(tmp
     assert (tmp_path / "skill_provenance.json").exists()
     assert (tmp_path / "stage8_qwen_result_corrected.json").exists()
     assert (tmp_path / "stage8_post_validation_report.json").exists()
+
+
+def test_mark_skill_checkpoint_infers_latest_session_and_writes_marker(tmp_path: Path, monkeypatch) -> None:
+    amo_home = tmp_path / "amo"
+    monkeypatch.setenv("AMO_HOME", str(amo_home))
+    settings = Settings.load()
+    RawEvidenceStore(settings.evidence_dir).append(
+        {"hook_event_name": "UserPromptSubmit", "session_id": "codex-session-1"},
+        session_id="codex-session-1",
+        source_app="codex",
+        event_name="user_prompt_submit",
+    )
+
+    assert infer_latest_session_id(settings.evidence_dir, source_app="codex") == "codex-session-1"
+
+    result = mark_skill_checkpoint(
+        settings=settings,
+        agent="codex",
+        note="turn this workflow into a skill",
+        mode="workflow",
+        cwd=tmp_path,
+    )
+
+    marker_path = Path(result["marker_path"])
+    marker = marker_path.read_text(encoding="utf-8")
+    assert result["checkpoint"]["session_id"] == "codex-session-1"
+    assert result["checkpoint"]["status"] == "pending_packet"
+    assert "turn this workflow into a skill" in marker
+    assert result["checkpoint"]["evidence"]["event_name"] == "skill_checkpoint"
+
+    listed = list_skill_checkpoints(settings)
+    assert listed["count"] == 1
+    assert listed["checkpoints"][0]["checkpoint_id"] == result["checkpoint"]["checkpoint_id"]


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill checkpoint marking and discovery to record lightweight progress indicators
  * Integrated checkpoint commands into Claude and Codex with automatic installer configuration
  * Added CLI support for marking checkpoints, viewing status, and managing pending markers

* **Documentation**
  * Updated installation guide with usage examples and configuration details for checkpoint commands

* **Tests**
  * Added test coverage for checkpoint marking and status functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spurbey/agent-memory-orchestrator/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->