### PR TITLE
fix(installer): simplify first-run output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Prerequisites:
 
 ```bash
 ollama pull qwen3.5:9b
-npx agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
+npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
 amo-cli doctor --target codex
 amo-daemon
 ```
@@ -124,7 +124,7 @@ amo-cli graph-retrieve --query "why did this code change?" --require-vector
 Install the optional Slack Socket Mode runtime:
 
 ```bash
-npx agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b --with-slack
+npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b --with-slack
 ```
 
 Create or configure the Slack app locally:

--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -21,7 +21,7 @@ AMO can run a local Slack Socket Mode connector. It captures selected sent Slack
 Install optional Slack runtime:
 
 ```bash
-npx agent-memory-orchestrator-cli -- install --with-slack --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
+npx -y agent-memory-orchestrator-cli -- install --with-slack --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
 ```
 
 Print a one-click Slack app setup URL:

--- a/npm/agent-memory-orchestrator-cli/README.md
+++ b/npm/agent-memory-orchestrator-cli/README.md
@@ -7,7 +7,7 @@ It installs the Python AMO runtime with `pipx`, writes local config, configures 
 ## Install
 
 ```bash
-npx agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
+npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
 ```
 
 The `--` after the package name is intentional. It prevents npm/npx from consuming AMO flags such as `--target`.
@@ -15,10 +15,10 @@ The `--` after the package name is intentional. It prevents npm/npx from consumi
 Install for Claude and Codex:
 
 ```bash
-npx agent-memory-orchestrator-cli -- install --target all --preset cpu-balanced --qwen-model qwen3.5:9b
+npx -y agent-memory-orchestrator-cli -- install --target all --preset cpu-balanced --qwen-model qwen3.5:9b
 ```
 
-If `npx` resolves `agent-memory-orchestrator-cli@0.1.1`, that registry package is too old for this command shape. Publish/use `0.1.2` or newer.
+If `npx` resolves `agent-memory-orchestrator-cli@0.1.1`, that registry package is too old for this command shape. Publish/use `0.1.3` or newer.
 
 ## Common Options
 
@@ -37,7 +37,7 @@ If `npx` resolves `agent-memory-orchestrator-cli@0.1.1`, that registry package i
 ## Diagnostics
 
 ```bash
-npx agent-memory-orchestrator-cli -- doctor --target codex
+npx -y agent-memory-orchestrator-cli -- doctor --target codex
 amo-cli doctor --target codex
 ```
 
@@ -50,7 +50,7 @@ amo-cli uninstall --target all
 ## Optional Slack Runtime
 
 ```bash
-npx agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b --with-slack
+npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b --with-slack
 amo-cli slack setup-wizard
 amo-cli slack run --reply-mode answer
 ```

--- a/npm/agent-memory-orchestrator-cli/bin/cli.js
+++ b/npm/agent-memory-orchestrator-cli/bin/cli.js
@@ -27,8 +27,8 @@ function printUsage() {
 Agent Memory Orchestrator installer
 
 Usage:
-  npx agent-memory-orchestrator-cli -- install [--from <pip_spec>] [wrapper flags] [amo install flags]
-  npx agent-memory-orchestrator-cli -- doctor [--target codex|claude|all]
+  npx -y agent-memory-orchestrator-cli -- install [--from <pip_spec>] [wrapper flags] [amo install flags]
+  npx -y agent-memory-orchestrator-cli -- doctor [--target codex|claude|all]
   npx agent-memory-orchestrator-cli --help
 
 Wrapper flags:
@@ -38,10 +38,10 @@ Wrapper flags:
   --with-all-extras     Enable all optional runtime extras.
 
 Examples:
-  npx agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
-  npx agent-memory-orchestrator-cli -- install --with-models --download-models --target all
-  npx agent-memory-orchestrator-cli -- install --with-slack --target claude
-  npx agent-memory-orchestrator-cli -- doctor --target codex
+  npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b
+  npx -y agent-memory-orchestrator-cli -- install --with-models --download-models --target all
+  npx -y agent-memory-orchestrator-cli -- install --with-slack --target claude
+  npx -y agent-memory-orchestrator-cli -- doctor --target codex
   `);
 }
 
@@ -50,12 +50,30 @@ function run(cmd, args, options = {}) {
     stdio: options.silent ? "pipe" : "inherit",
     encoding: "utf-8",
     shell: false,
+    env: { ...process.env, ...(options.env || {}) },
   });
 
   if (result.error) {
     return { ok: false, error: result.error.message, status: result.status ?? 1 };
   }
   return { ok: result.status === 0, status: result.status ?? 0, stdout: result.stdout, stderr: result.stderr };
+}
+
+function outputTail(text, maxChars = 4000) {
+  const value = String(text || "").trim();
+  if (!value) {
+    return "";
+  }
+  return value.length > maxChars ? value.slice(value.length - maxChars) : value;
+}
+
+function runQuietOrThrow(cmd, args, message, options = {}) {
+  const result = run(cmd, args, { ...options, silent: true });
+  if (result.ok) {
+    return result;
+  }
+  const detail = outputTail(`${result.stdout || ""}\n${result.stderr || ""}`);
+  throw new Error(detail ? `${message}\n${detail}` : message);
 }
 
 function commandExists(cmd) {
@@ -148,13 +166,15 @@ function parseInstallArgs(argv) {
 
 function bootstrapPipx(pyCmd) {
   console.log("[1/5] Installing pipx...");
-  const installPipx = run(pyCmd, ["-m", "pip", "install", "--user", "pipx"]);
-  if (!installPipx.ok) {
-    throw new Error("Failed to install pipx with python -m pip install --user pipx");
-  }
+  runQuietOrThrow(
+    pyCmd,
+    ["-m", "pip", "install", "--disable-pip-version-check", "--user", "pipx"],
+    "Failed to install pipx with python -m pip install --user pipx.",
+    { env: { PIP_DISABLE_PIP_VERSION_CHECK: "1" } }
+  );
 
   console.log("[2/5] Ensuring pipx app path...");
-  run(pyCmd, ["-m", "pipx", "ensurepath"]);
+  runQuietOrThrow(pyCmd, ["-m", "pipx", "ensurepath"], "Failed to update the pipx app path.");
 }
 
 function injectOptionalPackages(runner, extras) {
@@ -170,10 +190,11 @@ function injectOptionalPackages(runner, extras) {
   }
 
   console.log(`[4/5] Installing optional runtime packages: ${packages.join(", ")}...`);
-  const result = run(runner.cmd, pipxArgs(runner, ["inject", PIPX_PACKAGE, ...packages]));
-  if (!result.ok) {
-    throw new Error("pipx inject failed for optional AMO runtime packages.");
-  }
+  runQuietOrThrow(
+    runner.cmd,
+    pipxArgs(runner, ["inject", PIPX_PACKAGE, ...packages]),
+    "pipx inject failed for optional AMO runtime packages."
+  );
 }
 
 function pipxBinDirs(runner) {
@@ -225,10 +246,7 @@ function runInstall(argv) {
   }
 
   console.log("[3/5] Installing Agent Memory Orchestrator with pipx...");
-  const install = run(runner.cmd, pipxArgs(runner, ["install", "--force", spec]));
-  if (!install.ok) {
-    throw new Error("pipx install failed.");
-  }
+  runQuietOrThrow(runner.cmd, pipxArgs(runner, ["install", "--force", spec]), "pipx install failed.");
 
   injectOptionalPackages(runner, extras);
 
@@ -247,11 +265,7 @@ function runInstall(argv) {
     process.exit(installConfig.status || 1);
   }
 
-  console.log("Install complete.");
-  console.log("Next:");
-  console.log("  1) Restart Claude/Codex so they reload hooks and MCP config.");
-  console.log(`  2) Run: ${amoCli} doctor --target codex`);
-  console.log("  3) Run: amo-daemon");
+  console.log("Installer finished.");
 }
 
 function runDoctor(args) {
@@ -268,7 +282,7 @@ function runDoctor(args) {
         python: py || null,
         pipx_available: Boolean(runner),
         amo_cli_available: false,
-        hint: "Run `npx agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b`.",
+        hint: "Run `npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b`.",
       },
       null,
       2

--- a/npm/agent-memory-orchestrator-cli/package.json
+++ b/npm/agent-memory-orchestrator-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-memory-orchestrator-cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "npx installer wrapper for Agent Memory Orchestrator",
   "license": "MIT",
   "type": "commonjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-memory-orchestrator"
-version = "0.1.2"
+version = "0.1.3"
 description = "Shared persistent memory and multi-agent orchestration over local MCP."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agent_memory_orchestrator/app/cli.py
+++ b/src/agent_memory_orchestrator/app/cli.py
@@ -66,6 +66,7 @@ def _build_parser() -> argparse.ArgumentParser:
     install.add_argument("--skip-init-db", action="store_true", help="Do not initialize the AMO SQLite database.")
     install.add_argument("--dry-run", action="store_true", help="Show planned changes without writing files.")
     install.add_argument("--yes", action="store_true", help="Apply without interactive confirmation.")
+    install.add_argument("--json", action="store_true", help="Print machine-readable install details.")
     install.add_argument("--force", action="store_true", help="Overwrite existing AMO target entries when safe.")
 
     doctor_cmd = sub.add_parser("doctor", help="Check AMO install/config status")
@@ -355,12 +356,21 @@ def main(argv: list[str] | None = None) -> int:
             plan = build_install_plan(options)
             summary = _summarize_install_plan(plan)
             if args.dry_run:
-                _print({"ok": True, "dry_run": True, "plan": summary})
+                if args.json:
+                    _print({"ok": True, "dry_run": True, "plan": summary})
+                else:
+                    print(_format_install_plan(summary, dry_run=True))
                 return 0
             if not args.yes:
-                _print({"ok": True, "pending_plan": summary})
+                if args.json:
+                    _print({"ok": True, "pending_plan": summary})
+                else:
+                    print(_format_install_plan(summary))
                 if not _confirm("Apply AMO install changes?"):
-                    _print({"ok": False, "cancelled": True, "plan": summary})
+                    if args.json:
+                        _print({"ok": False, "cancelled": True, "plan": summary})
+                    else:
+                        print("Install cancelled. No files changed.")
                     return 1
             result = apply_install_plan(plan)
             model_result = None
@@ -388,16 +398,18 @@ def main(argv: list[str] | None = None) -> int:
                     init_graph = {"ok": True, "graph_path": str(init_settings.graph_path)}
                 except GraphBackendUnavailable as exc:
                     init_graph = {"ok": False, "error": str(exc)}
-            _print(
-                {
-                    "ok": True,
-                    "plan": summary,
-                    "apply": result,
-                    "models": model_result,
-                    "init_db": init_result,
-                    "init_graph": init_graph,
-                }
-            )
+            payload = {
+                "ok": True,
+                "plan": summary,
+                "apply": result,
+                "models": model_result,
+                "init_db": init_result,
+                "init_graph": init_graph,
+            }
+            if args.json:
+                _print(payload)
+            else:
+                print(_format_install_result(payload))
             return 0
 
         if args.command == "doctor":
@@ -1046,6 +1058,105 @@ def _summarize_install_plan(plan: dict) -> dict:
         "operations": operations,
         "notes": plan["notes"],
     }
+
+
+def _format_install_plan(summary: dict, *, dry_run: bool = False) -> str:
+    models = summary.get("models", {})
+    operations = summary.get("operations", [])
+    changed = [op for op in operations if op.get("changed")]
+    unchanged = [op for op in operations if not op.get("changed")]
+
+    lines = ["AMO install plan"]
+    if dry_run:
+        lines[0] = "AMO install dry run"
+    lines.extend(
+        [
+            f"- Target: {', '.join(summary.get('targets', [])) or summary.get('target', 'all')}",
+            f"- AMO home: {summary.get('amo_home', '')}",
+            f"- Preset: {models.get('preset', '')}",
+            f"- Qwen model: {models.get('qwen_model', '')}",
+            f"- Embeddings: {models.get('embedding_model', '')}",
+            f"- Reranker: {models.get('reranker_model', '')}",
+            "",
+            "Changes to apply:",
+        ]
+    )
+    if changed:
+        lines.extend(f"- {_operation_label(op)}" for op in changed)
+    else:
+        lines.append("- No file changes needed.")
+    if unchanged:
+        lines.append(f"- {len(unchanged)} item(s) already up to date.")
+    lines.extend(
+        [
+            "",
+            "Existing files are backed up before they are changed.",
+            "Use --json to inspect exact paths and generated config.",
+        ]
+    )
+    if dry_run:
+        lines.append("No files changed.")
+    return "\n".join(lines)
+
+
+def _format_install_result(payload: dict) -> str:
+    plan = payload.get("plan", {})
+    results = payload.get("apply", {}).get("results", [])
+    changed = [item for item in results if item.get("changed")]
+    unchanged = [item for item in results if not item.get("changed")]
+    targets = ", ".join(plan.get("targets", [])) or plan.get("target", "all")
+
+    lines = [
+        "AMO install complete.",
+        f"- Target: {targets}",
+        f"- AMO home: {plan.get('amo_home', '')}",
+    ]
+    if changed:
+        lines.append("")
+        lines.append("Updated:")
+        lines.extend(f"- {_operation_label(item)}" for item in changed)
+    if unchanged:
+        lines.append(f"- {len(unchanged)} item(s) already up to date.")
+
+    init_db = payload.get("init_db")
+    init_graph = payload.get("init_graph")
+    if init_db or init_graph:
+        lines.append("")
+        lines.append("Initialized:")
+        if init_db:
+            lines.append(f"- SQLite memory DB: {init_db.get('db_path', '')}")
+        if init_graph:
+            status = "ready" if init_graph.get("ok") else f"skipped: {init_graph.get('error', '')}"
+            lines.append(f"- Kuzu graph: {status}")
+
+    model_result = payload.get("models")
+    if model_result:
+        lines.append("")
+        lines.append(f"Model cache: {'ready' if model_result.get('ok') else 'check required'}")
+
+    lines.extend(
+        [
+            "",
+            "Next:",
+            "1. Restart Codex or Claude so hooks and MCP config reload.",
+            "2. Run: amo-cli doctor --target codex",
+            "3. Run: amo-daemon",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _operation_label(operation: dict) -> str:
+    labels = {
+        "amo": "AMO runtime config",
+        "amo-hook-launcher": "hook launcher",
+        "codex": "Codex MCP config",
+        "codex-hooks": "Codex command hooks",
+        "codex-skill-checkpoint": "Codex skill-checkpoint helper",
+        "claude": "Claude MCP and hook config",
+        "claude-skill-checkpoint": "Claude skill-checkpoint command",
+    }
+    return labels.get(str(operation.get("target", "")), str(operation.get("target", "config")))
 
 
 def _rebuild_clean_db(settings: Settings, out_path: Path, codex_root: Path, limit: int, force: bool) -> dict:

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -171,6 +171,7 @@ def test_cli_install_dry_run_does_not_write(tmp_path: Path, capsys) -> None:
             "--amo-home",
             str(amo_home),
             "--dry-run",
+            "--json",
         ]
     )
 
@@ -178,4 +179,30 @@ def test_cli_install_dry_run_does_not_write(tmp_path: Path, capsys) -> None:
     output = json.loads(capsys.readouterr().out)
     assert output["ok"] is True
     assert output["dry_run"] is True
+    assert not (user_home / ".codex" / "config.toml").exists()
+
+
+def test_cli_install_dry_run_is_human_readable_by_default(tmp_path: Path, capsys) -> None:
+    user_home = tmp_path / "home"
+    amo_home = tmp_path / "amo"
+
+    exit_code = main(
+        [
+            "install",
+            "--target",
+            "codex",
+            "--user-home",
+            str(user_home),
+            "--amo-home",
+            str(amo_home),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "AMO install dry run" in output
+    assert "Codex MCP config" in output
+    assert "after_preview" not in output
+    assert "amo_hook_launcher.py" not in output
     assert not (user_home / ".codex" / "config.toml").exists()


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--json` flag to the install command for structured JSON output

* **Documentation**
  * Updated installation guides to include non-interactive execution options with the `-y` flag

* **Improvements**
  * Enhanced CLI output formatting and streamlined post-installation messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spurbey/agent-memory-orchestrator/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->