### PR TITLE
Peer rooms tailscale

### DIFF
--- a/docs/operations/peer-network-libp2p.md
+++ b/docs/operations/peer-network-libp2p.md
@@ -134,12 +134,17 @@ python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> import-card
 For lower-friction onboarding, use an invite code/bundle:
 
 ```powershell
-python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> create-invite --out node-a.invite.json
-python -m agent_memory_orchestrator.app.cli peer --amo-home <home_b> accept-invite --file node-a.invite.json --response-out node-b.card.json
-python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> import-card --file node-b.card.json
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> create-invite --auto-approve --out node-a.invite.json
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_b> accept-invite --file node-a.invite.json
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> poll-netd
 ```
 
-The invite wraps the inviter's public peer card, recommended trust level, and a card hash. It never contains a shared-secret value. If `accept-invite` runs while the peer sidecar is active, it can emit the accepting node's response card so the inviter can trust it.
+The invite wraps the inviter's public peer card, recommended trust level, one-time invite token, and a card hash. It never contains a shared-secret value. If both sidecars are running, `accept-invite` sends a `peer_join_request` back to the inviter. With `--auto-approve`, the inviter imports the accepting peer after token validation. Without `--auto-approve`, review the request explicitly:
+
+```powershell
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> join-requests --status pending
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> approve-join --request-id <request_id>
+```
 
 Manual config still exists for smoke tests and advanced use:
 

--- a/peer-netd/README.md
+++ b/peer-netd/README.md
@@ -100,12 +100,12 @@ The sidecar persists delivered envelopes when `--store-path` is set. AMO's manag
 Use invite bundles/codes to avoid hand-editing peer-card JSON:
 
 ```powershell
-python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> create-invite --out node-a.invite.json
-python -m agent_memory_orchestrator.app.cli peer --amo-home <home_b> accept-invite --file node-a.invite.json --response-out node-b.card.json
-python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> import-card --file node-b.card.json
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> create-invite --auto-approve --out node-a.invite.json
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_b> accept-invite --file node-a.invite.json
+python -m agent_memory_orchestrator.app.cli peer --amo-home <home_a> poll-netd
 ```
 
-The invite contains public reachability details and a card hash, not private memory or secret values. `accept-invite` imports the inviter under the recommended trust policy and writes a response card when this node has a usable sidecar address.
+The invite contains public reachability details, a one-time invite token, and a card hash, not private memory or secret values. `accept-invite` imports the inviter under the recommended trust policy and sends a `peer_join_request` back through netd when both sidecars are reachable. If the invite was not created with `--auto-approve`, use `peer join-requests` and `peer approve-join` on the inviter.
 
 ## Current Scope
 
@@ -123,6 +123,7 @@ Implemented:
 - AMO-managed build/start/stop/status runtime
 - AMO startup-service planning through CLI
 - AMO watcher startup-service planning through CLI
+- tokenized peer invite and join-request handshake
 - unit tests for envelope verification
 - integration test for node-to-node delivery
 - integration test for rendezvous discovery plus message delivery

--- a/src/agent_memory_orchestrator/app/cli.py
+++ b/src/agent_memory_orchestrator/app/cli.py
@@ -332,6 +332,9 @@ def _build_parser() -> argparse.ArgumentParser:
     peer_invite.add_argument("--base-url", default="", help="Optional legacy direct HTTP URL to include.")
     peer_invite.add_argument("--rendezvous-addr", default="", help="Optional rendezvous node multiaddr to include.")
     peer_invite.add_argument("--rendezvous-namespace", default="", help="Optional rendezvous namespace to include.")
+    peer_invite.add_argument("--auto-approve", action="store_true", help="Auto-import the accepting peer after token proof.")
+    peer_invite.add_argument("--expires-minutes", type=int, default=1440, help="Invite validity window.")
+    peer_invite.add_argument("--max-uses", type=int, default=1, help="Maximum accepted join requests.")
     peer_accept = peer_sub.add_parser("accept-invite", help="Import an invite and optionally write this node's response card")
     peer_accept_source = peer_accept.add_mutually_exclusive_group(required=True)
     peer_accept_source.add_argument("--file", type=Path, help="Invite JSON file to accept.")
@@ -339,6 +342,14 @@ def _build_parser() -> argparse.ArgumentParser:
     peer_accept.add_argument("--trust", choices=["trusted", "limited", "blocked"], default="")
     peer_accept.add_argument("--shared-secret-env", default="")
     peer_accept.add_argument("--response-out", type=Path, help="Optional response peer-card JSON path to send back.")
+    peer_accept.add_argument("--no-send-join-request", action="store_true", help="Do not send the automatic return join request.")
+    peer_join_requests = peer_sub.add_parser("join-requests", help="List pending peer join requests")
+    peer_join_requests.add_argument("--status", default="", choices=["", "pending", "approved", "rejected"])
+    peer_approve_join = peer_sub.add_parser("approve-join", help="Approve a pending peer join request")
+    peer_approve_join.add_argument("--request-id", required=True)
+    peer_reject_join = peer_sub.add_parser("reject-join", help="Reject a pending peer join request")
+    peer_reject_join.add_argument("--request-id", required=True)
+    peer_reject_join.add_argument("--reason", default="")
     peer_sub.add_parser("rooms", help="List local peer investigation rooms")
     peer_context = peer_sub.add_parser("context", help="Build the three-layer context pack for a room")
     peer_context.add_argument("--room-id", required=True)
@@ -832,6 +843,9 @@ def main(argv: list[str] | None = None) -> int:
                     base_url=args.base_url,
                     rendezvous_addr=args.rendezvous_addr,
                     rendezvous_namespace=args.rendezvous_namespace,
+                    auto_approve=args.auto_approve,
+                    expires_minutes=args.expires_minutes,
+                    max_uses=args.max_uses,
                 )
                 if result.get("ok") and args.out:
                     args.out.write_text(json.dumps(result["invite"], indent=2), encoding="utf-8")
@@ -846,10 +860,22 @@ def main(argv: list[str] | None = None) -> int:
                     invite,
                     trust=args.trust,
                     shared_secret_env=args.shared_secret_env,
+                    send_join_request=not args.no_send_join_request,
                 )
                 if result.get("ok") and args.response_out and result.get("response_card"):
                     args.response_out.write_text(json.dumps(result["response_card"], indent=2), encoding="utf-8")
                     result["response_out"] = str(args.response_out)
+                _print(result)
+                return 0 if result.get("ok") else 1
+            if args.peer_command == "join-requests":
+                _print(svc.list_join_requests(status=args.status))
+                return 0
+            if args.peer_command == "approve-join":
+                result = svc.approve_join_request(args.request_id)
+                _print(result)
+                return 0 if result.get("ok") else 1
+            if args.peer_command == "reject-join":
+                result = svc.reject_join_request(args.request_id, reason=args.reason)
                 _print(result)
                 return 0 if result.get("ok") else 1
             if args.peer_command == "rooms":

--- a/src/agent_memory_orchestrator/peer/invites.py
+++ b/src/agent_memory_orchestrator/peer/invites.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import base64
+import hmac
 import hashlib
 import json
+import secrets
 import zlib
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -21,6 +23,10 @@ def build_peer_invite(
     trust: str = "trusted",
     shared_secret_env: str = "",
     label: str = "",
+    auto_approve: bool = False,
+    expires_minutes: int = 1440,
+    max_uses: int = 1,
+    token: str = "",
 ) -> dict[str, Any]:
     """Build a portable invite bundle around a peer card.
 
@@ -33,14 +39,22 @@ def build_peer_invite(
         raise ValueError("invite card node_id is required")
     # Reuse card validation so unusable transport addresses fail before sharing.
     peer_from_card(card, trust=trust, shared_secret_env=shared_secret_env)
+    token = token.strip() or generate_invite_token()
+    expires_minutes = max(1, int(expires_minutes or 1))
+    max_uses = max(1, int(max_uses or 1))
+    now = datetime.now(timezone.utc)
     return {
         "amo_peer_invite_version": PEER_INVITE_VERSION,
-        "invite_id": f"invite_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}_{uuid4().hex[:8]}",
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "invite_id": f"invite_{now.strftime('%Y%m%d_%H%M%S')}_{uuid4().hex[:8]}",
+        "created_at": now.isoformat(),
+        "expires_at": (now + timedelta(minutes=expires_minutes)).isoformat(),
         "created_by_node_id": node_id,
         "label": label.strip(),
         "recommended_trust": trust,
         "shared_secret_env": shared_secret_env.strip(),
+        "auto_approve": bool(auto_approve),
+        "max_uses": max_uses,
+        "invite_token": token,
         "card_sha256": peer_card_sha256(card),
         "card": card,
     }
@@ -60,7 +74,18 @@ def parse_peer_invite(invite: dict[str, Any]) -> dict[str, Any]:
     _validate_trust(trust)
     shared_secret_env = str(invite.get("shared_secret_env") or "").strip()
     peer_from_card(card, trust=trust, shared_secret_env=shared_secret_env)
-    return {"card": card, "trust": trust, "shared_secret_env": shared_secret_env, "card_sha256": actual_hash}
+    return {
+        "invite_id": str(invite.get("invite_id") or "").strip(),
+        "card": card,
+        "trust": trust,
+        "shared_secret_env": shared_secret_env,
+        "card_sha256": actual_hash,
+        "invite_token": str(invite.get("invite_token") or "").strip(),
+        "token_proof": invite_token_proof(str(invite.get("invite_token") or "").strip()),
+        "auto_approve": bool(invite.get("auto_approve", False)),
+        "expires_at": str(invite.get("expires_at") or "").strip(),
+        "max_uses": max(1, int(invite.get("max_uses") or 1)),
+    }
 
 
 def encode_invite_code(invite: dict[str, Any]) -> str:
@@ -87,6 +112,26 @@ def decode_invite_code(code: str) -> dict[str, Any]:
 
 def peer_card_sha256(card: dict[str, Any]) -> str:
     return hashlib.sha256(_canonical_json(card).encode("utf-8")).hexdigest()
+
+
+def generate_invite_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def invite_token_hash(token: str) -> str:
+    if not token:
+        raise ValueError("invite token is required")
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def invite_token_proof(token: str) -> str:
+    return invite_token_hash(token) if token else ""
+
+
+def verify_invite_token_proof(*, token_hash: str, token_proof: str) -> bool:
+    if not token_hash or not token_proof:
+        return False
+    return hmac.compare_digest(token_hash, token_proof)
 
 
 def _canonical_json(payload: dict[str, Any]) -> str:

--- a/src/agent_memory_orchestrator/peer/netd_client.py
+++ b/src/agent_memory_orchestrator/peer/netd_client.py
@@ -130,7 +130,11 @@ class PeerNetdClient:
 
 def _strip_empty(value: Any) -> Any:
     if isinstance(value, dict):
-        return {key: _strip_empty(item) for key, item in value.items() if item not in ("", None, [], {})}
+        return {
+            key: item if key == "peer_card" else _strip_empty(item)
+            for key, item in value.items()
+            if key == "peer_card" or item not in ("", None, [], {})
+        }
     if isinstance(value, list):
         return [_strip_empty(item) for item in value]
     return value

--- a/src/agent_memory_orchestrator/peer/service.py
+++ b/src/agent_memory_orchestrator/peer/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from datetime import datetime, timezone
 from typing import Any
 from urllib import request
 from urllib.error import HTTPError, URLError
@@ -10,7 +11,12 @@ from urllib.error import HTTPError, URLError
 from ..core.config import Settings
 from .auth import PeerAuthError, secret_for_peer, unwrap_payload, wrap_payload
 from .cards import build_peer_card, peer_from_card
-from .invites import build_peer_invite, encode_invite_code, parse_peer_invite
+from .invites import build_peer_invite
+from .invites import encode_invite_code
+from .invites import invite_token_hash
+from .invites import parse_peer_invite
+from .invites import peer_card_sha256
+from .invites import verify_invite_token_proof
 from .models import PeerNode
 from .netd_client import PeerNetdClient, PeerNetdError
 from .netd_runtime import PeerNetdRuntime
@@ -99,9 +105,12 @@ class PeerService:
         config = self.store.load_config()
         netd_health = None
         try:
-            runtime_status = PeerNetdRuntime(self.settings).status()
-            if runtime_status.get("api_ok"):
-                netd_health = runtime_status.get("health")
+            if self.netd_client is not None:
+                netd_health = self.netd_client.health()
+            else:
+                runtime_status = PeerNetdRuntime(self.settings).status()
+                if runtime_status.get("api_ok"):
+                    netd_health = runtime_status.get("health")
         except Exception:
             netd_health = None
         card = build_peer_card(
@@ -130,6 +139,9 @@ class PeerService:
         base_url: str = "",
         rendezvous_addr: str = "",
         rendezvous_namespace: str = "",
+        auto_approve: bool = False,
+        expires_minutes: int = 1440,
+        max_uses: int = 1,
     ) -> dict[str, Any]:
         card_result = self.share_card(
             base_url=base_url,
@@ -143,6 +155,26 @@ class PeerService:
             trust=trust,
             shared_secret_env=shared_secret_env,
             label=label,
+            auto_approve=auto_approve,
+            expires_minutes=expires_minutes,
+            max_uses=max_uses,
+        )
+        self.store.save_peer_invite_record(
+            {
+                "invite_id": invite["invite_id"],
+                "created_at": invite["created_at"],
+                "expires_at": invite["expires_at"],
+                "created_by_node_id": invite["created_by_node_id"],
+                "label": invite["label"],
+                "recommended_trust": invite["recommended_trust"],
+                "shared_secret_env": invite["shared_secret_env"],
+                "auto_approve": invite["auto_approve"],
+                "max_uses": invite["max_uses"],
+                "used_count": 0,
+                "status": "pending",
+                "token_hash": invite_token_hash(str(invite["invite_token"])),
+                "card_sha256": invite["card_sha256"],
+            }
         )
         return {
             "ok": True,
@@ -157,6 +189,7 @@ class PeerService:
         *,
         trust: str = "",
         shared_secret_env: str = "",
+        send_join_request: bool = True,
     ) -> dict[str, Any]:
         parsed = parse_peer_invite(invite)
         effective_trust = trust.strip() or str(parsed["trust"])
@@ -172,14 +205,146 @@ class PeerService:
                 response_error = str(response.get("error") or "could not create response card")
         except Exception as exc:
             response_error = str(exc)
+        join_request_delivery = None
+        if send_join_request and response_card and parsed.get("invite_token"):
+            peer = self.store.load_config().peer_by_id(str(imported.get("peer", {}).get("node_id") or ""))
+            if peer is not None and peer.peer_id:
+                join_request_delivery = self._send_payload_via_netd(
+                    peer,
+                    {
+                        "type": "peer_join_request",
+                        "invite_id": parsed["invite_id"],
+                        "token_proof": parsed["token_proof"],
+                        "peer_card": response_card,
+                        "peer_card_sha256": peer_card_sha256(response_card),
+                        "requested_trust": effective_trust,
+                    },
+                    message_type="peer_join_request",
+                    room_id="",
+                )
         return {
             "ok": True,
             "imported_peer": imported.get("peer"),
             "card_sha256": parsed["card_sha256"],
             "response_card": response_card,
             "response_card_error": response_error,
-            "next_step": "Return response_card to the inviter so they can import this node.",
+            "join_request_delivery": join_request_delivery,
+            "next_step": (
+                "Join request sent to inviter."
+                if join_request_delivery and join_request_delivery.get("ok")
+                else "Return response_card to the inviter or ensure both sidecars are running for auto-handshake."
+            ),
         }
+
+    def receive_join_request(
+        self,
+        payload: dict[str, Any],
+        *,
+        transport_auth: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        try:
+            invite_id = str(payload.get("invite_id") or "").strip()
+            token_proof = str(payload.get("token_proof") or "").strip()
+            peer_card = payload.get("peer_card")
+            if not invite_id:
+                return {"ok": False, "accepted": False, "error": "invite_id is required", "auth": transport_auth or {}}
+            if not isinstance(peer_card, dict):
+                return {"ok": False, "accepted": False, "error": "peer_card is required", "auth": transport_auth or {}}
+            provided_card_hash = str(payload.get("peer_card_sha256") or "").strip()
+            actual_card_hash = peer_card_sha256(peer_card)
+            if provided_card_hash and provided_card_hash != actual_card_hash:
+                return {
+                    "ok": False,
+                    "accepted": False,
+                    "error": "peer_card hash mismatch",
+                    "auth": transport_auth or {},
+                }
+            record = self.store.get_peer_invite_record(invite_id)
+            validation = self._validate_join_request(record=record, token_proof=token_proof, peer_card=peer_card)
+            if not validation.get("ok"):
+                return validation | {"auth": transport_auth or {}}
+            requested_trust = str(payload.get("requested_trust") or record.get("recommended_trust") or "trusted")
+            if record.get("auto_approve"):
+                imported = self.import_card(
+                    peer_card,
+                    trust=requested_trust,
+                    shared_secret_env=str(record.get("shared_secret_env") or ""),
+                )
+                updated_invite = self._mark_invite_used(record)
+                delivery = self._send_join_accepted(imported.get("peer"), invite_id)
+                return {
+                    "ok": True,
+                    "accepted": True,
+                    "mode": "auto_approved",
+                    "peer": imported.get("peer"),
+                    "invite": updated_invite,
+                    "join_accepted_delivery": delivery,
+                    "auth": transport_auth or {},
+                }
+            request_record = self.store.save_join_request(
+                {
+                    "invite_id": invite_id,
+                    "peer_card": peer_card,
+                    "peer_card_sha256": actual_card_hash,
+                    "token_proof": token_proof,
+                    "requested_trust": requested_trust,
+                    "status": "pending",
+                    "auth": transport_auth or {},
+                }
+            )
+            return {
+                "ok": True,
+                "accepted": False,
+                "mode": "pending_approval",
+                "request": request_record,
+                "auth": transport_auth or {},
+            }
+        except (FileNotFoundError, ValueError, PermissionError) as exc:
+            return {"ok": False, "accepted": False, "error": str(exc), "auth": transport_auth or {}}
+
+    def list_join_requests(self, *, status: str = "") -> dict[str, Any]:
+        return {"ok": True, "requests": self.store.list_join_requests(status=status)}
+
+    def approve_join_request(self, request_id: str) -> dict[str, Any]:
+        request_record = self.store.get_join_request(request_id)
+        if request_record.get("status") != "pending":
+            return {"ok": False, "error": f"join request is not pending: {request_record.get('status')}"}
+        invite = self.store.get_peer_invite_record(str(request_record.get("invite_id") or ""))
+        validation = self._validate_join_request(
+            record=invite,
+            token_proof=str(request_record.get("token_proof") or invite.get("token_hash") or ""),
+            peer_card=request_record.get("peer_card"),
+            allow_stored_token_hash=True,
+        )
+        if not validation.get("ok"):
+            return validation
+        expected_card_hash = str(request_record.get("peer_card_sha256") or "")
+        actual_card_hash = peer_card_sha256(request_record["peer_card"])
+        if expected_card_hash and expected_card_hash != actual_card_hash:
+            return {"ok": False, "error": "peer_card hash mismatch"}
+        imported = self.import_card(
+            request_record["peer_card"],
+            trust=str(request_record.get("requested_trust") or invite.get("recommended_trust") or "trusted"),
+            shared_secret_env=str(invite.get("shared_secret_env") or ""),
+        )
+        updated_invite = self._mark_invite_used(invite)
+        updated_request = self.store.update_join_request(request_id, {"status": "approved", "approved_at": _utc_now()})
+        delivery = self._send_join_accepted(imported.get("peer"), str(invite.get("invite_id") or ""))
+        return {
+            "ok": True,
+            "request": updated_request,
+            "peer": imported.get("peer"),
+            "invite": updated_invite,
+            "join_accepted_delivery": delivery,
+        }
+
+    def reject_join_request(self, request_id: str, *, reason: str = "") -> dict[str, Any]:
+        request_record = self.store.get_join_request(request_id)
+        updated = self.store.update_join_request(
+            request_id,
+            {"status": "rejected", "rejected_at": _utc_now(), "reject_reason": reason.strip()},
+        )
+        return {"ok": True, "request": updated, "previous_status": request_record.get("status")}
 
     def capabilities(self) -> dict[str, Any]:
         config = self.store.load_config()
@@ -354,6 +519,10 @@ class PeerService:
         }
         if message_type == "room_invite":
             return self.receive_invite(payload, transport_auth=auth)
+        if message_type == "peer_join_request":
+            return self.receive_join_request(payload, transport_auth=auth)
+        if message_type == "peer_join_accepted":
+            return {"ok": True, "accepted": True, "type": "peer_join_accepted", "payload": payload, "auth": auth}
         payload.setdefault("type", message_type)
         payload.setdefault("room_id", message.get("room_id"))
         payload.setdefault("from_node_id", message.get("from_node_id"))
@@ -361,6 +530,64 @@ class PeerService:
         payload.setdefault("citations", message.get("citations") or [])
         payload.setdefault("created_at", message.get("created_at") or "")
         return self.receive_message(payload, transport_auth=auth)
+
+    def _validate_join_request(
+        self,
+        *,
+        record: dict[str, Any],
+        token_proof: str,
+        peer_card: Any,
+        allow_stored_token_hash: bool = False,
+    ) -> dict[str, Any]:
+        if not isinstance(peer_card, dict):
+            return {"ok": False, "accepted": False, "error": "peer_card is required"}
+        status = str(record.get("status") or "pending")
+        if status in {"revoked", "expired", "accepted"}:
+            return {"ok": False, "accepted": False, "error": f"invite is {status}"}
+        expires_at = _parse_datetime(str(record.get("expires_at") or ""))
+        if expires_at and expires_at < datetime.now(timezone.utc):
+            self.store.update_peer_invite_record(str(record.get("invite_id") or ""), {"status": "expired"})
+            return {"ok": False, "accepted": False, "error": "invite is expired"}
+        used_count = int(record.get("used_count") or 0)
+        max_uses = max(1, int(record.get("max_uses") or 1))
+        if used_count >= max_uses:
+            return {"ok": False, "accepted": False, "error": "invite use limit reached"}
+        token_hash = str(record.get("token_hash") or "")
+        token_ok = verify_invite_token_proof(token_hash=token_hash, token_proof=token_proof)
+        if allow_stored_token_hash and token_proof == token_hash:
+            token_ok = True
+        if not token_ok:
+            return {"ok": False, "accepted": False, "error": "invite token proof mismatch"}
+        existing = self.store.load_config().peer_by_id(str(peer_card.get("node_id") or ""))
+        if existing is not None and existing.trust == "blocked":
+            return {"ok": False, "accepted": False, "error": f"peer is blocked: {existing.node_id}"}
+        return {"ok": True}
+
+    def _mark_invite_used(self, record: dict[str, Any]) -> dict[str, Any]:
+        used_count = int(record.get("used_count") or 0) + 1
+        max_uses = max(1, int(record.get("max_uses") or 1))
+        status = "accepted" if used_count >= max_uses else "pending"
+        return self.store.update_peer_invite_record(
+            str(record.get("invite_id") or ""),
+            {"used_count": used_count, "status": status},
+        )
+
+    def _send_join_accepted(self, peer_payload: Any, invite_id: str) -> dict[str, Any] | None:
+        if not isinstance(peer_payload, dict):
+            return None
+        peer = self.store.load_config().peer_by_id(str(peer_payload.get("node_id") or ""))
+        if peer is None or not peer.peer_id:
+            return None
+        return self._send_payload_via_netd(
+            peer,
+            {
+                "type": "peer_join_accepted",
+                "invite_id": invite_id,
+                "trusted_as": peer.trust,
+            },
+            message_type="peer_join_accepted",
+            room_id="",
+        )
 
     def list_rooms(self) -> dict[str, Any]:
         return {"ok": True, "rooms": self.store.list_rooms()}
@@ -490,3 +717,19 @@ def _netd_envelope_id(envelope: dict[str, Any]) -> str:
         return signature
     canonical = json.dumps(envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/src/agent_memory_orchestrator/peer/store.py
+++ b/src/agent_memory_orchestrator/peer/store.py
@@ -28,6 +28,13 @@ def _safe_room_id(room_id: str) -> str:
     return clean
 
 
+def _safe_peer_record_id(value: str) -> str:
+    clean = "".join(ch for ch in value.strip() if ch.isalnum() or ch in {"-", "_"})
+    if not clean:
+        raise ValueError("record id is required")
+    return clean
+
+
 class PeerStore:
     """Filesystem-backed peer room state.
 
@@ -40,9 +47,13 @@ class PeerStore:
         self.root = settings.home / ".peer"
         self.config_path = self.root / "peers.json"
         self.rooms_dir = self.root / "rooms"
+        self.invites_dir = self.root / "invites"
+        self.join_requests_dir = self.root / "join_requests"
         self.netd_processed_path = self.root / "netd_processed.json"
         self.root.mkdir(parents=True, exist_ok=True)
         self.rooms_dir.mkdir(parents=True, exist_ok=True)
+        self.invites_dir.mkdir(parents=True, exist_ok=True)
+        self.join_requests_dir.mkdir(parents=True, exist_ok=True)
 
     def load_config(self) -> PeerConfig:
         if not self.config_path.exists():
@@ -82,6 +93,77 @@ class PeerStore:
             raise ValueError("peer requires base_url, peer_id, multiaddrs, relay_addrs, or rendezvous_addr")
         config = self.load_config()
         return self.save_config(config.with_peer(peer))
+
+    def save_peer_invite_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        invite_id = _safe_peer_record_id(str(record.get("invite_id") or ""))
+        payload = dict(record)
+        payload["invite_id"] = invite_id
+        payload.setdefault("created_at", _utc_now())
+        payload.setdefault("updated_at", _utc_now())
+        payload.setdefault("status", "pending")
+        payload.setdefault("used_count", 0)
+        self._write_json(self.invites_dir / f"{invite_id}.json", payload)
+        return payload
+
+    def get_peer_invite_record(self, invite_id: str) -> dict[str, Any]:
+        path = self.invites_dir / f"{_safe_peer_record_id(invite_id)}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"peer invite not found: {invite_id}")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"peer invite must be an object: {path}")
+        return payload
+
+    def update_peer_invite_record(self, invite_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        record = self.get_peer_invite_record(invite_id)
+        record.update(updates)
+        record["updated_at"] = _utc_now()
+        return self.save_peer_invite_record(record)
+
+    def save_join_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        request_id = str(request.get("request_id") or "").strip()
+        if not request_id:
+            invite_id = str(request.get("invite_id") or "invite").strip() or "invite"
+            node_id = str((request.get("peer_card") or {}).get("node_id") or "peer").strip() or "peer"
+            request_id = f"join_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}_{_sha256(invite_id + ':' + node_id)[:8]}"
+        request_id = _safe_peer_record_id(request_id)
+        payload = dict(request)
+        payload["request_id"] = request_id
+        payload.setdefault("created_at", _utc_now())
+        payload.setdefault("updated_at", _utc_now())
+        payload.setdefault("status", "pending")
+        self._write_json(self.join_requests_dir / f"{request_id}.json", payload)
+        return payload
+
+    def get_join_request(self, request_id: str) -> dict[str, Any]:
+        path = self.join_requests_dir / f"{_safe_peer_record_id(request_id)}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"peer join request not found: {request_id}")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"peer join request must be an object: {path}")
+        return payload
+
+    def update_join_request(self, request_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        request = self.get_join_request(request_id)
+        request.update(updates)
+        request["updated_at"] = _utc_now()
+        return self.save_join_request(request)
+
+    def list_join_requests(self, status: str = "") -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for path in sorted(self.join_requests_dir.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            if status and payload.get("status") != status:
+                continue
+            rows.append(payload)
+        rows.sort(key=lambda item: str(item.get("updated_at") or item.get("created_at") or ""), reverse=True)
+        return rows
 
     def list_rooms(self) -> list[dict[str, Any]]:
         rooms: list[dict[str, Any]] = []
@@ -309,6 +391,10 @@ class PeerStore:
         processed = self.load_processed_netd_ids()
         processed.add(envelope_id)
         self.netd_processed_path.write_text(json.dumps(sorted(processed), indent=2), encoding="utf-8")
+
+    def _write_json(self, path: Any, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
     def render_room_md(
         self,

--- a/tests/test_peer_cards.py
+++ b/tests/test_peer_cards.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 
 from agent_memory_orchestrator.peer.cards import build_peer_card, peer_from_card
-from agent_memory_orchestrator.peer.invites import build_peer_invite, decode_invite_code, encode_invite_code, parse_peer_invite
+from agent_memory_orchestrator.peer.invites import build_peer_invite
+from agent_memory_orchestrator.peer.invites import decode_invite_code
+from agent_memory_orchestrator.peer.invites import encode_invite_code
+from agent_memory_orchestrator.peer.invites import invite_token_hash
+from agent_memory_orchestrator.peer.invites import parse_peer_invite
 from agent_memory_orchestrator.peer.models import PeerConfig
 
 
@@ -51,6 +55,8 @@ def test_peer_invite_code_round_trip() -> None:
     assert decoded["invite_id"] == invite["invite_id"]
     assert parsed["card"]["node_id"] == "node-a"
     assert parsed["trust"] == "trusted"
+    assert parsed["invite_token"]
+    assert invite_token_hash(parsed["invite_token"]) == parsed["token_proof"]
 
 
 def test_peer_invite_rejects_card_hash_mismatch() -> None:

--- a/tests/test_peer_netd_cli.py
+++ b/tests/test_peer_netd_cli.py
@@ -147,6 +147,9 @@ def test_peer_create_and_accept_invite_code(tmp_path: Path, capsys) -> None:
             "http://127.0.0.1:8787",
             "--label",
             "Node A invite",
+            "--auto-approve",
+            "--expires-minutes",
+            "60",
             "--out",
             str(invite_path),
         ]
@@ -155,6 +158,8 @@ def test_peer_create_and_accept_invite_code(tmp_path: Path, capsys) -> None:
     assert create_code == 0
     assert invite_path.exists()
     assert create_payload["invite"]["card"]["node_id"] == "node-a"
+    assert create_payload["invite"]["auto_approve"] is True
+    assert create_payload["invite"]["invite_token"]
     assert create_payload["invite_code"].startswith("amo-peer-invite:")
 
     assert main(["peer", "--amo-home", str(home_b), "init", "--node-id", "node-b"]) == 0

--- a/tests/test_peer_netd_client.py
+++ b/tests/test_peer_netd_client.py
@@ -62,6 +62,39 @@ def test_peer_netd_client_raises_on_sidecar_error() -> None:
         server.server_close()
 
 
+def test_peer_netd_client_preserves_peer_card_payloads() -> None:
+    server, state = start_fake_netd()
+    try:
+        client = PeerNetdClient(base_url=f"http://127.0.0.1:{server.server_port}", timeout_seconds=2)
+        client.send_raw(
+            "peer-a",
+            {
+                "type": "peer_join_request",
+                "payload": {
+                    "peer_card": {
+                        "node_id": "node-b",
+                        "base_url": "",
+                        "relay_addrs": [],
+                        "rendezvous_addr": "",
+                    },
+                    "empty_field": "",
+                },
+            },
+        )
+
+        payload = state["send"][0]["message"]["payload"]
+        assert "empty_field" not in payload
+        assert payload["peer_card"] == {
+            "node_id": "node-b",
+            "base_url": "",
+            "relay_addrs": [],
+            "rendezvous_addr": "",
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
 def start_fake_netd(send_status: int = 200) -> tuple[ThreadingHTTPServer, dict[str, list[dict]]]:
     state: dict[str, list[dict]] = {
         "bootstrap": [],

--- a/tests/test_peer_rooms.py
+++ b/tests/test_peer_rooms.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 from agent_memory_orchestrator.core.config import Settings
 from agent_memory_orchestrator.peer.auth import wrap_payload
-from agent_memory_orchestrator.peer.models import PeerNode
+from agent_memory_orchestrator.peer.cards import build_peer_card
+from agent_memory_orchestrator.peer.invites import build_peer_invite, invite_token_hash, invite_token_proof, peer_card_sha256
+from agent_memory_orchestrator.peer.models import PeerConfig, PeerNode
 from agent_memory_orchestrator.peer.service import PeerService
 from agent_memory_orchestrator.peer.store import PeerStore
 
@@ -55,6 +57,61 @@ def test_peer_config_accepts_libp2p_peer_identity_without_legacy_base_url(tmp_pa
     assert peer.peer_id == "12D3KooWPeer"
     assert peer.multiaddrs == ("/ip4/127.0.0.1/tcp/9001/p2p/12D3KooWPeer",)
     assert peer.rendezvous_namespace == "amo-team"
+
+
+def test_peer_join_request_auto_approves_with_valid_invite_token(tmp_path: Path) -> None:
+    store = PeerStore(make_settings(tmp_path / "initiator"))
+    store.init_config(node_id="zenbook-amo")
+    invite = _save_test_invite(store, auto_approve=True, token="join-secret")
+    peer_card = _peer_card("mac-amo", "12D3KooWMac")
+    netd = FakeNetdClient()
+
+    result = PeerService(store.settings, store=store, netd_client=netd).receive_netd_envelope(
+        _join_request_envelope(invite=invite, peer_card=peer_card, token="join-secret")
+    )
+
+    assert result["ok"] is True
+    assert result["accepted"] is True
+    assert result["mode"] == "auto_approved"
+    peer = store.load_config().peer_by_id("mac-amo")
+    assert peer is not None
+    assert peer.peer_id == "12D3KooWMac"
+    assert store.get_peer_invite_record(invite["invite_id"])["status"] == "accepted"
+    assert netd.sent[-1]["message"]["type"] == "peer_join_accepted"
+
+
+def test_peer_join_request_can_wait_for_manual_approval(tmp_path: Path) -> None:
+    store = PeerStore(make_settings(tmp_path / "initiator"))
+    store.init_config(node_id="zenbook-amo")
+    invite = _save_test_invite(store, auto_approve=False, token="join-secret")
+    peer_card = _peer_card("mac-amo", "12D3KooWMac")
+
+    result = PeerService(store.settings, store=store).receive_netd_envelope(
+        _join_request_envelope(invite=invite, peer_card=peer_card, token="join-secret")
+    )
+
+    assert result["ok"] is True
+    assert result["accepted"] is False
+    assert result["mode"] == "pending_approval"
+    assert store.load_config().peer_by_id("mac-amo") is None
+    pending = store.list_join_requests(status="pending")
+    assert len(pending) == 1
+    assert pending[0]["peer_card"]["node_id"] == "mac-amo"
+
+
+def test_peer_join_request_rejects_bad_token(tmp_path: Path) -> None:
+    store = PeerStore(make_settings(tmp_path / "initiator"))
+    store.init_config(node_id="zenbook-amo")
+    invite = _save_test_invite(store, auto_approve=True, token="join-secret")
+    peer_card = _peer_card("mac-amo", "12D3KooWMac")
+
+    result = PeerService(store.settings, store=store).receive_netd_envelope(
+        _join_request_envelope(invite=invite, peer_card=peer_card, token="wrong-secret")
+    )
+
+    assert result["ok"] is False
+    assert "token proof" in result["error"]
+    assert store.load_config().peer_by_id("mac-amo") is None
 
 
 def test_trusted_peer_accepts_invite_and_records_messages(tmp_path: Path) -> None:
@@ -491,3 +548,67 @@ class FakeNetdClient:
 
     def rendezvous_discover(self, addr: str, namespace: str, limit: int = 20, connect: bool = True) -> list[dict]:
         return [{"peer_id": "12D3KooWPeer", "addrs": [addr], "namespace": namespace, "connect": connect}]
+
+    def health(self) -> dict:
+        return {
+            "peer_id": "12D3KooWFake",
+            "listen_addrs": ["/ip4/127.0.0.1/tcp/9001/p2p/12D3KooWFake"],
+            "relay_addrs": [],
+        }
+
+
+def _save_test_invite(store: PeerStore, *, auto_approve: bool, token: str) -> dict:
+    card = build_peer_card(
+        config=PeerConfig(node_id="zenbook-amo"),
+        netd_health={
+            "peer_id": "12D3KooWHost",
+            "listen_addrs": ["/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWHost"],
+        },
+    )
+    invite = build_peer_invite(card=card, auto_approve=auto_approve, token=token)
+    store.save_peer_invite_record(
+        {
+            "invite_id": invite["invite_id"],
+            "created_at": invite["created_at"],
+            "expires_at": invite["expires_at"],
+            "created_by_node_id": invite["created_by_node_id"],
+            "recommended_trust": invite["recommended_trust"],
+            "shared_secret_env": invite["shared_secret_env"],
+            "auto_approve": invite["auto_approve"],
+            "max_uses": invite["max_uses"],
+            "used_count": 0,
+            "status": "pending",
+            "token_hash": invite_token_hash(token),
+            "card_sha256": invite["card_sha256"],
+        }
+    )
+    return invite
+
+
+def _peer_card(node_id: str, peer_id: str) -> dict:
+    return build_peer_card(
+        config=PeerConfig(node_id=node_id, capabilities=("graph_retrieval",)),
+        netd_health={
+            "peer_id": peer_id,
+            "listen_addrs": [f"/ip4/127.0.0.1/tcp/9002/p2p/{peer_id}"],
+        },
+    )
+
+
+def _join_request_envelope(*, invite: dict, peer_card: dict, token: str) -> dict:
+    return {
+        "from_node_id": peer_card["node_id"],
+        "payload_sha256": "test",
+        "message": {
+            "type": "peer_join_request",
+            "from_node_id": peer_card["node_id"],
+            "payload": {
+                "type": "peer_join_request",
+                "invite_id": invite["invite_id"],
+                "token_proof": invite_token_proof(token),
+                "peer_card": peer_card,
+                "peer_card_sha256": peer_card_sha256(peer_card),
+                "requested_trust": "trusted",
+            },
+        },
+    }


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced peer invites with automatic approval, configurable expiration times, and usage limits
  * Introduced secure invite tokens for peer discovery with proof-based verification
  * Added join-request workflow: submit requests, manage pending approvals, and auto-accept based on invite settings
  * New peer management commands: `join-requests`, `approve-join`, and `reject-join`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spurbey/agent-memory-orchestrator/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->