### PR TITLE
Amo auto drain threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,14 @@ The daemon processes captured sessions in the background:
 ```text
 hook JSONL capture
 -> daemon drain
--> cleaned evidence window when the pending session crosses the token threshold
+-> cleaned evidence window when the next session starts
 -> local Qwen extraction with deterministic fallback
 -> Kuzu graph updates
 -> retrieval document rebuild
 -> small resumable embedding/FAISS refresh batch
 ```
 
-The only raw-to-processing trigger is `drain_token_threshold=6000` approximate tokens. Write, git, test, stop, connector finalize, and "remember this" events remain evidence inside the eventual window; they do not trigger processing by themselves. The automatic loop can be controlled with `auto_drain_enabled`, `auto_drain_interval_seconds`, `auto_drain_record_limit`, and `auto_embedding_batch_size` in `~/.agent-memory-orchestrator/config.json`.
+The only raw-to-processing trigger is a new `session_start` for a different session. The daemon keeps the previous session's pending evidence in `.state/`, closes that session when the next one starts, then builds the cleaned window and graph update. Write, git, test, stop, connector finalize, and "remember this" events remain evidence inside the eventual session window; they do not trigger processing by themselves. The automatic loop can be controlled with `auto_drain_enabled`, `auto_drain_interval_seconds`, `auto_drain_record_limit`, and `auto_embedding_batch_size` in `~/.agent-memory-orchestrator/config.json`.
 
 Retrieval is explicit through CLI or MCP tools such as:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@ AMO is local-first graph memory for AI coding sessions.
 ## Runtime Shape
 
 - Hooks capture evidence and fail open.
-- The daemon owns Kuzu, automatic drain jobs, graph jobs, retrieval, local model calls, and web UI state.
+- The daemon owns session-boundary drain, V2 session jobs, Kuzu, retrieval, local model calls, and web UI state.
 - MCP exposes explicit retrieval tools to agents.
 - Kuzu stores graph truth.
 - SQLite stores retrieval/index ledgers.
@@ -19,14 +19,35 @@ hook evidence
 -> append-only JSONL
 -> daemon drain loop
 -> trigger only when a later session starts
--> cleaned evidence window
--> graph extraction
--> Kuzu graph write
+-> enqueue durable V2 session job in SQLite
+-> evidence view and commit-backed work packets
+-> packet-wise Qwen reasoning extraction when available
+-> deterministic hunks, AST/code nodes, symbols, and code links
+-> V2 Kuzu graph write
 -> retrieval document rebuild
 -> bounded embedding/FAISS refresh
 ```
 
-Hooks never perform graph work directly. Pending evidence windows are persisted under `.state/` so a session can be closed across daemon cycles when the next `session_start` appears. Write, git, test, stop, and connector-finalize events are evidence, not processing triggers.
+Hooks never perform graph work directly. Drain does not run Qwen, Kuzu writes,
+retrieval rebuild, embeddings, or old `GraphDelta` processing. It reads raw
+evidence, tracks cursors/session boundaries, and idempotently enqueues the
+previous session when a new `session_start` appears.
+
+The V2 job runner owns resumable processing and stores job/stage/event state in
+SQLite. If Qwen or the embedding model is unavailable, the job pauses as
+`pending_model`; it does not create fake answer-grade reasoning or hash-vector
+production output.
+
+Old pre-V2 graph/retrieval data is cleaned only through an explicit backup-first
+operator command:
+
+```bash
+amo-cli v2-reset-production --backup --clean-graph --clean-retrieval
+```
+
+The reset command never deletes raw JSONL evidence, config, or V2 job tables.
+The legacy `GraphDelta` path is isolated to `graph-drain-smoke` and writes to a
+disposable graph under `.state/smoke/`, not the production Kuzu path.
 
 ## Retrieval Shape
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@ AMO is local-first graph memory for AI coding sessions.
 hook evidence
 -> append-only JSONL
 -> daemon drain loop
--> trigger only on pending session token threshold
+-> trigger only when a later session starts
 -> cleaned evidence window
 -> graph extraction
 -> Kuzu graph write
@@ -26,7 +26,7 @@ hook evidence
 -> bounded embedding/FAISS refresh
 ```
 
-Hooks never perform graph work directly. Pending evidence windows are persisted under `.state/` so the token threshold works across daemon cycles. Write, git, test, stop, and connector-finalize events are evidence, not processing triggers.
+Hooks never perform graph work directly. Pending evidence windows are persisted under `.state/` so a session can be closed across daemon cycles when the next `session_start` appears. Write, git, test, stop, and connector-finalize events are evidence, not processing triggers.
 
 ## Retrieval Shape
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,9 @@ amo-cli v2-reset-production --backup --clean-graph --clean-retrieval
 ```
 
 The reset command never deletes raw JSONL evidence, config, or V2 job tables.
+It writes the production reset marker only after both graph and retrieval/vector
+storage have been cleaned from a verified backup; backup-only runs do not unlock
+V2 production writes.
 The legacy `GraphDelta` path is isolated to `graph-drain-smoke` and writes to a
 disposable graph under `.state/smoke/`, not the production Kuzu path.
 

--- a/docs/operations/retrieval.md
+++ b/docs/operations/retrieval.md
@@ -72,6 +72,10 @@ drain/enqueue closed sessions
 -> faiss
 ```
 
+The V2 job runner builds retrieval documents only from graph nodes carrying the
+current `pipeline_version` and `graph_schema_version`. This keeps any legacy
+manual/smoke graph output out of the production retrieval ledger.
+
 If the embedding model is unavailable after graph and retrieval docs are built,
 the job pauses as `pending_model`. Graph and lexical retrieval remain available;
 vectors and FAISS resume after the model/runtime is restored and the job is

--- a/docs/operations/retrieval.md
+++ b/docs/operations/retrieval.md
@@ -58,12 +58,35 @@ Current traversal rules:
 - Keep extra packets, commits, evidence, hunks, code nodes, and symbols as
   citation support rather than forcing them into the narrative.
 
-## Build the Retrieval Index
+## Production Refresh
+
+In production, retrieval refresh is a V2 job stage, not a separate daemon side
+effect:
+
+```text
+drain/enqueue closed sessions
+-> V2SessionJobRunner
+-> kuzu_write
+-> retrieval_docs
+-> embeddings
+-> faiss
+```
+
+If the embedding model is unavailable after graph and retrieval docs are built,
+the job pauses as `pending_model`. Graph and lexical retrieval remain available;
+vectors and FAISS resume after the model/runtime is restored and the job is
+retried.
+
+## Manual Retrieval Index Build
 
 ```bash
 amo-cli graph-retrieval-build
 amo-cli graph-retrieval-embed --model BAAI/bge-m3
 ```
+
+These commands are maintenance/smoke tools. The normal closed-session production
+path uses the V2 job runner so stage status, errors, and retries are observable
+from `/api/jobs` and the dashboard Admin view.
 
 ## Retrieve
 

--- a/docs/reasoning_graph/README.md
+++ b/docs/reasoning_graph/README.md
@@ -10,16 +10,21 @@ Git already records what changed. AMO V2 adds the reasoning layer around it: pro
 
 ```text
 raw evidence and transcripts
+-> closed-session V2 job
 -> reasoning evidence view
 -> commit-backed work packets
 -> packet-wise reasoning extraction
 -> Git hunks and AST CodeNodes
 -> reasoning-to-code linking
 -> graph validation
--> isolated Kuzu session graph
+-> V2 Kuzu graph write
 -> retrieval docs, embeddings, graph expansion, reranking
--> central graph merge after acceptance
 ```
+
+Production runs this flow through `V2SessionJobRunner`. Drain only detects that
+a previous session closed and enqueues a job; it does not run extraction or write
+graph nodes. Completed stage artifacts are reused unless their input hash or
+stage configuration hash changes.
 
 ## Source of Truth
 
@@ -32,6 +37,26 @@ V2 uses deterministic facts as the spine:
 - Kuzu stores graph truth.
 - SQLite stores retrieval/index ledgers.
 - FAISS is a rebuildable vector cache.
+- SQLite also stores V2 job state, stage rows, lock leases, retry metadata, and
+  the explicit production reset marker.
+
+## Production Reset
+
+Pre-V2 graph and retrieval rows are treated as scrap after the V2 cutover, but
+cleanup is never automatic on daemon startup. Operators must run:
+
+```bash
+amo-cli v2-reset-production --backup --clean-graph --clean-retrieval
+```
+
+The command backs up production graph/retrieval/vector stores first, verifies a
+backup manifest, then cleans only graph/retrieval/vector/FAISS storage. Raw JSONL
+evidence, config, and V2 job tables are preserved.
+
+Legacy `GraphDelta` generation is available only for `graph-drain-smoke`, which
+writes to a disposable smoke graph. Production closed-session processing writes
+V2 node kinds such as `Packet`, `Commit`, `EvidenceRef`, `ReasoningNode`,
+`CodeHunk`, `CodeNode`, `CodeVersion`, and `Symbol`.
 
 ## Core Concepts
 

--- a/docs/reasoning_graph/README.md
+++ b/docs/reasoning_graph/README.md
@@ -52,6 +52,9 @@ amo-cli v2-reset-production --backup --clean-graph --clean-retrieval
 The command backs up production graph/retrieval/vector stores first, verifies a
 backup manifest, then cleans only graph/retrieval/vector/FAISS storage. Raw JSONL
 evidence, config, and V2 job tables are preserved.
+The production reset marker is written only after both graph and retrieval
+cleanup complete, and the runner refuses production Kuzu/retrieval stages if the
+marker is missing, version-mismatched, or incomplete.
 
 Legacy `GraphDelta` generation is available only for `graph-drain-smoke`, which
 writes to a disposable smoke graph. Production closed-session processing writes

--- a/src/agent_memory_orchestrator/app/cli.py
+++ b/src/agent_memory_orchestrator/app/cli.py
@@ -44,6 +44,7 @@ from ..reasoning_graph.session_runtime import build_and_query_session_graph
 from ..reasoning_graph.session_runtime import build_session_graph
 from ..reasoning_graph.session_runtime import default_session_graph_path
 from ..reasoning_graph.session_runtime import query_session_graph
+from ..reasoning_graph.jobs.reset import reset_production_v2_storage
 from ..skill_checkpoint import DEFAULT_LOCAL_NUM_CTX
 from ..skill_checkpoint import DEFAULT_NUM_PREDICT
 from ..skill_checkpoint import list_skill_checkpoints
@@ -67,6 +68,16 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("init-db", help="Initialize local database schema")
     sub.add_parser("init-graph", help="Initialize local Kuzu GraphRAG schema")
+
+    v2_reset = sub.add_parser("v2-reset-production", help="Explicitly back up and reset production V2 graph/retrieval stores")
+    v2_reset.add_argument("--backup", action="store_true", help="Required. Create a timestamped backup before cleaning.")
+    v2_reset.add_argument("--clean-graph", action="store_true", help="Clean/recreate the production Kuzu graph store.")
+    v2_reset.add_argument("--clean-retrieval", action="store_true", help="Clean retrieval docs/vector ledger and FAISS cache.")
+    v2_reset.add_argument(
+        "--force-if-daemon-running",
+        action="store_true",
+        help="Allow reset even if the daemon health endpoint is reachable.",
+    )
 
     install = sub.add_parser("install", help="Configure Claude/Codex hooks, MCP, and local AMO runtime config")
     install.add_argument("--target", choices=["codex", "claude", "all"], default="all")
@@ -157,6 +168,11 @@ def _build_parser() -> argparse.ArgumentParser:
     graph_drain.add_argument("--limit", type=int, default=500)
     graph_drain.add_argument("--max-windows", type=int, default=None, help="Maximum Qwen trigger windows to process in one request.")
     graph_drain.add_argument("--offline", action="store_true", help="Open Kuzu directly for single-process maintenance.")
+
+    graph_drain_smoke = sub.add_parser("graph-drain-smoke", help="Run legacy GraphDelta drain into a disposable smoke graph")
+    graph_drain_smoke.add_argument("--limit", type=int, default=500)
+    graph_drain_smoke.add_argument("--max-windows", type=int, default=None)
+    graph_drain_smoke.add_argument("--offline", action="store_true", help="Open Kuzu directly for single-process maintenance.")
 
     graph_cleanup = sub.add_parser("graph-cleanup-noisy", help="Find or abandon noisy draft graph answer nodes")
     graph_cleanup.add_argument("--limit", type=int, default=500)
@@ -616,6 +632,18 @@ def main(argv: list[str] | None = None) -> int:
                 graph.close()
             return 0
 
+        if args.command == "v2-reset-production":
+            settings = Settings.load()
+            result = reset_production_v2_storage(
+                settings,
+                backup=args.backup,
+                clean_graph=args.clean_graph,
+                clean_retrieval=args.clean_retrieval,
+                force_if_daemon_running=args.force_if_daemon_running,
+            )
+            _print(result)
+            return 0
+
         if args.command == "models":
             if args.models_command == "list":
                 _print({"ok": True, "presets": list_model_presets()})
@@ -1062,6 +1090,7 @@ def main(argv: list[str] | None = None) -> int:
             "graph-search",
             "graph-status",
             "graph-drain",
+            "graph-drain-smoke",
             "graph-cleanup-noisy",
             "graph-consolidate",
             "graph-cache-status",
@@ -1086,6 +1115,8 @@ def main(argv: list[str] | None = None) -> int:
                         )
                     elif args.command == "graph-drain":
                         result = graph.drain_evidence(limit=args.limit, session_id=args.session_id, max_windows=args.max_windows)
+                    elif args.command == "graph-drain-smoke":
+                        result = graph.drain_evidence_smoke(limit=args.limit, max_windows=args.max_windows)
                     elif args.command == "graph-cleanup-noisy":
                         result = graph.cleanup_noisy_drafts(limit=args.limit, apply=args.apply)
                     elif args.command == "graph-consolidate":
@@ -1150,6 +1181,7 @@ def main(argv: list[str] | None = None) -> int:
                     if args.command
                     in {
                         "graph-drain",
+                        "graph-drain-smoke",
                         "graph-consolidate",
                         "graph-rebuild-cache",
                         "graph-retrieval-build",
@@ -1176,6 +1208,11 @@ def main(argv: list[str] | None = None) -> int:
                         result = client.post(
                             "/graph/drain",
                             {"session_id": args.session_id, "limit": args.limit, "max_windows": args.max_windows},
+                        )
+                    elif args.command == "graph-drain-smoke":
+                        result = client.post(
+                            "/graph/drain-smoke",
+                            {"limit": args.limit, "max_windows": args.max_windows},
                         )
                     elif args.command == "graph-cleanup-noisy":
                         result = client.post("/graph/cleanup-noisy", {"limit": args.limit, "apply": args.apply})

--- a/src/agent_memory_orchestrator/app/daemon.py
+++ b/src/agent_memory_orchestrator/app/daemon.py
@@ -680,21 +680,21 @@ def _run_auto_drain_once(settings: Settings) -> dict[str, Any]:
                 limit=settings.auto_drain_record_limit,
                 max_windows=settings.drain_max_windows_per_run,
             )
-            runner = V2SessionJobRunner(settings)
-            try:
-                job_run = runner.run_next()
-            finally:
-                runner.close()
-            result: dict[str, Any] = {
-                "records_ingested": int(drain.get("records_ingested") or 0),
-                "windows_processed": int(drain.get("windows_processed") or 0),
-                "stopped_reason": drain.get("stopped_reason"),
-                "pending_sessions": drain.get("pending_sessions"),
-                "v2_job_run": job_run,
-            }
-            return result
         finally:
             graph.close()
+        runner = V2SessionJobRunner(settings)
+        try:
+            job_run = runner.run_next()
+        finally:
+            runner.close()
+        result: dict[str, Any] = {
+            "records_ingested": int(drain.get("records_ingested") or 0),
+            "windows_processed": int(drain.get("windows_processed") or 0),
+            "stopped_reason": drain.get("stopped_reason"),
+            "pending_sessions": drain.get("pending_sessions"),
+            "v2_job_run": job_run,
+        }
+        return result
 
 
 def _daemon_log(settings: Settings, event: str, **fields: object) -> None:

--- a/src/agent_memory_orchestrator/app/daemon.py
+++ b/src/agent_memory_orchestrator/app/daemon.py
@@ -142,7 +142,6 @@ class AmoHandler(BaseHTTPRequestHandler):
                     "qwen_compress_timeout_seconds": self.settings.qwen_compress_timeout_seconds,
                     "qwen_num_ctx": self.settings.qwen_num_ctx,
                     "drain_max_windows_per_run": self.settings.drain_max_windows_per_run,
-                    "drain_token_threshold": self.settings.drain_token_threshold,
                     "auto_drain_enabled": self.settings.auto_drain_enabled,
                     "auto_drain_interval_seconds": self.settings.auto_drain_interval_seconds,
                     "auto_drain_record_limit": self.settings.auto_drain_record_limit,
@@ -599,7 +598,6 @@ def _start_auto_drain_worker(settings: Settings) -> threading.Thread | None:
         settings,
         "auto_drain_started",
         interval_seconds=settings.auto_drain_interval_seconds,
-        token_threshold=settings.drain_token_threshold,
         embedding_batch_size=settings.auto_embedding_batch_size,
     )
     return worker

--- a/src/agent_memory_orchestrator/app/daemon.py
+++ b/src/agent_memory_orchestrator/app/daemon.py
@@ -18,6 +18,8 @@ from ..graph.store import GraphBackendUnavailable
 from ..integrations.connectors.slack import SlackConnectorService
 from ..memory import MemoryService
 from ..llm.qwen import QwenUnavailable
+from ..reasoning_graph.jobs import V2SessionJobRunner
+from ..reasoning_graph.jobs import V2SessionJobStore
 
 _CLIENT_ABORT_ERRORS = (BrokenPipeError, ConnectionAbortedError, ConnectionResetError)
 _GRAPH_LOCK = threading.RLock()
@@ -127,6 +129,11 @@ class AmoHandler(BaseHTTPRequestHandler):
             self._write_html(200, GRAPH_WORKBENCH_HTML)
             return
         if path == "/health":
+            job_store = V2SessionJobStore(self.settings)
+            try:
+                reset_marker = job_store.marker()
+            finally:
+                job_store.close()
             self._write_json(
                 200,
                 {
@@ -146,6 +153,7 @@ class AmoHandler(BaseHTTPRequestHandler):
                     "auto_drain_interval_seconds": self.settings.auto_drain_interval_seconds,
                     "auto_drain_record_limit": self.settings.auto_drain_record_limit,
                     "auto_embedding_batch_size": self.settings.auto_embedding_batch_size,
+                    "v2_reset_marker": reset_marker,
                 },
             )
             return
@@ -171,6 +179,32 @@ class AmoHandler(BaseHTTPRequestHandler):
                 )
             except Exception as exc:
                 self._write_json(500, {"ok": False, "error": str(exc)})
+            return
+        if path == "/api/jobs" or path.startswith("/api/jobs/"):
+            raw_limit = (query.get("limit") or ["100"])[0]
+            limit = _bounded_int(raw_limit, default=100, minimum=1, maximum=500)
+            job_store = V2SessionJobStore(self.settings)
+            try:
+                if path == "/api/jobs":
+                    self._write_json(200, {"ok": True, "jobs": job_store.list_jobs(limit=limit), "reset_marker": job_store.marker()})
+                    return
+                job_id = path.removeprefix("/api/jobs/").strip("/")
+                job = job_store.get_job(job_id)
+                if job is None:
+                    self._write_json(404, {"ok": False, "error": "job not found"})
+                    return
+                self._write_json(
+                    200,
+                    {
+                        "ok": True,
+                        "job": job,
+                        "stages": job_store.list_stages(job_id),
+                        "events": job_store.list_events(job_id, limit=limit),
+                        "reset_marker": job_store.marker(),
+                    },
+                )
+            finally:
+                job_store.close()
             return
         if path.startswith("/api/graph/") or path.startswith("/api/debug/") or path == "/api/graph-merge-status":
             try:
@@ -331,6 +365,15 @@ class AmoHandler(BaseHTTPRequestHandler):
             return
 
         try:
+            if self.path.startswith("/api/jobs/") and self.path.endswith("/retry"):
+                job_id = self.path.removeprefix("/api/jobs/").removesuffix("/retry").strip("/")
+                job_store = V2SessionJobStore(self.settings)
+                try:
+                    job = job_store.retry_job(job_id, forced_by=str(payload.get("forced_by") or "daemon-api"))
+                    self._write_json(200, {"ok": True, "job": job})
+                finally:
+                    job_store.close()
+                return
             if self.path == "/hooks/ingest":
                 with _GRAPH_LOCK:
                     graph = GraphRagService(self.settings)
@@ -487,6 +530,21 @@ class AmoHandler(BaseHTTPRequestHandler):
                     finally:
                         graph.close()
                 return
+            if self.path == "/graph/drain-smoke":
+                with _GRAPH_LOCK:
+                    graph = GraphRagService(self.settings)
+                    try:
+                        limit = _bounded_int(str(payload.get("limit") or ""), default=500, minimum=1, maximum=5000)
+                        max_windows = _bounded_int(
+                            str(payload.get("max_windows") or ""),
+                            default=self.settings.drain_max_windows_per_run,
+                            minimum=1,
+                            maximum=25,
+                        )
+                        self._write_json(200, graph.drain_evidence_smoke(limit=limit, max_windows=max_windows))
+                    finally:
+                        graph.close()
+                return
             if self.path == "/graph/finalize-session":
                 with _GRAPH_LOCK:
                     graph = GraphRagService(self.settings)
@@ -608,7 +666,7 @@ def _auto_drain_loop(settings: Settings) -> None:
         time.sleep(settings.auto_drain_interval_seconds)
         try:
             result = _run_auto_drain_once(settings)
-            if result.get("windows_processed") or result.get("records_ingested"):
+            if result.get("windows_processed") or result.get("records_ingested") or result.get("v2_job_run", {}).get("ran"):
                 _daemon_log(settings, "auto_drain_cycle", **result)
         except Exception as exc:
             _daemon_log(settings, "auto_drain_failed", error_type=type(exc).__name__, error=str(exc))
@@ -622,26 +680,18 @@ def _run_auto_drain_once(settings: Settings) -> dict[str, Any]:
                 limit=settings.auto_drain_record_limit,
                 max_windows=settings.drain_max_windows_per_run,
             )
+            runner = V2SessionJobRunner(settings)
+            try:
+                job_run = runner.run_next()
+            finally:
+                runner.close()
             result: dict[str, Any] = {
                 "records_ingested": int(drain.get("records_ingested") or 0),
                 "windows_processed": int(drain.get("windows_processed") or 0),
                 "stopped_reason": drain.get("stopped_reason"),
                 "pending_sessions": drain.get("pending_sessions"),
+                "v2_job_run": job_run,
             }
-            if result["windows_processed"] <= 0:
-                return result
-
-            result["retrieval_index"] = graph.rebuild_retrieval_index(
-                limit=settings.auto_retrieval_node_limit,
-                max_doc_chars=settings.auto_retrieval_max_doc_chars,
-            )
-            if settings.vector_backend != "disabled" and settings.auto_embedding_batch_size > 0:
-                result["retrieval_embedding"] = graph.embed_retrieval_index(
-                    limit=settings.auto_embedding_batch_size,
-                    rebuild_faiss=True,
-                )
-            else:
-                result["retrieval_embedding"] = {"ok": True, "skipped": True, "reason": "disabled"}
             return result
         finally:
             graph.close()

--- a/src/agent_memory_orchestrator/core/config.py
+++ b/src/agent_memory_orchestrator/core/config.py
@@ -81,7 +81,6 @@ class Settings:
     qwen_compress_timeout_seconds: float = 12.0
     qwen_num_ctx: int = 2048
     drain_max_windows_per_run: int = 3
-    drain_token_threshold: int = 6000
     auto_drain_enabled: bool = True
     auto_drain_interval_seconds: float = 8.0
     auto_drain_record_limit: int = 500
@@ -132,7 +131,6 @@ class Settings:
         qwen_compress_timeout_seconds = float(_setting(config, "qwen_compress_timeout_seconds", "12"))
         qwen_num_ctx = int(_setting(config, "qwen_num_ctx", "2048"))
         drain_max_windows_per_run = int(_setting(config, "drain_max_windows_per_run", "3"))
-        drain_token_threshold = int(_setting(config, "drain_token_threshold", "6000"))
         auto_drain_enabled = _parse_bool(_setting(config, "auto_drain_enabled", True), default=True)
         auto_drain_interval_seconds = float(_setting(config, "auto_drain_interval_seconds", "8"))
         auto_drain_record_limit = int(_setting(config, "auto_drain_record_limit", "500"))
@@ -206,8 +204,6 @@ class Settings:
             raise ValueError("AMO_QWEN_NUM_CTX must be positive")
         if drain_max_windows_per_run <= 0:
             raise ValueError("AMO_DRAIN_MAX_WINDOWS_PER_RUN must be positive")
-        if drain_token_threshold < 0:
-            raise ValueError("AMO_DRAIN_TOKEN_THRESHOLD must be zero or positive")
         if auto_drain_interval_seconds <= 0:
             raise ValueError("AMO_AUTO_DRAIN_INTERVAL_SECONDS must be positive")
         if auto_drain_record_limit <= 0:
@@ -258,7 +254,6 @@ class Settings:
             qwen_compress_timeout_seconds=qwen_compress_timeout_seconds,
             qwen_num_ctx=qwen_num_ctx,
             drain_max_windows_per_run=drain_max_windows_per_run,
-            drain_token_threshold=drain_token_threshold,
             auto_drain_enabled=auto_drain_enabled,
             auto_drain_interval_seconds=auto_drain_interval_seconds,
             auto_drain_record_limit=auto_drain_record_limit,

--- a/src/agent_memory_orchestrator/core/db.py
+++ b/src/agent_memory_orchestrator/core/db.py
@@ -278,6 +278,66 @@ CREATE TABLE IF NOT EXISTS orchestration_decisions (
   FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS v2_session_jobs (
+  job_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  pipeline_version TEXT NOT NULL DEFAULT 'v2-reset-2026-05',
+  graph_schema_version TEXT NOT NULL DEFAULT 'v2',
+  status TEXT NOT NULL DEFAULT 'pending',
+  current_stage TEXT NOT NULL DEFAULT '',
+  last_successful_stage TEXT NOT NULL DEFAULT '',
+  artifact_dir TEXT NOT NULL DEFAULT '',
+  source_app TEXT NOT NULL DEFAULT '',
+  repo_path TEXT NOT NULL DEFAULT '',
+  boundary_event_id TEXT NOT NULL DEFAULT '',
+  source_evidence_day TEXT NOT NULL DEFAULT '',
+  source_evidence_days_json TEXT NOT NULL DEFAULT '[]',
+  lock_owner TEXT NOT NULL DEFAULT '',
+  lock_expires_at TEXT NOT NULL DEFAULT '',
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  last_attempt_at TEXT NOT NULL DEFAULT '',
+  forced_at TEXT NOT NULL DEFAULT '',
+  forced_by TEXT NOT NULL DEFAULT '',
+  error_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(session_id, pipeline_version)
+);
+
+CREATE TABLE IF NOT EXISTS v2_session_job_stages (
+  job_id TEXT NOT NULL,
+  stage TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  input_artifact TEXT NOT NULL DEFAULT '',
+  output_artifact TEXT NOT NULL DEFAULT '',
+  input_hash TEXT NOT NULL DEFAULT '',
+  output_hash TEXT NOT NULL DEFAULT '',
+  stage_config_hash TEXT NOT NULL DEFAULT '',
+  diagnostics_json TEXT NOT NULL DEFAULT '{}',
+  started_at TEXT NOT NULL DEFAULT '',
+  finished_at TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY(job_id, stage),
+  FOREIGN KEY (job_id) REFERENCES v2_session_jobs(job_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS v2_session_job_events (
+  event_id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  stage TEXT NOT NULL DEFAULT '',
+  message TEXT NOT NULL DEFAULT '',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (job_id) REFERENCES v2_session_jobs(job_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS v2_production_markers (
+  marker_key TEXT PRIMARY KEY,
+  value_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_updated
 ON sessions(updated_at DESC);
 
@@ -325,6 +385,15 @@ ON retrieval_runs(started_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_rounds_session_round
 ON orchestration_rounds(session_id, round_index DESC);
+
+CREATE INDEX IF NOT EXISTS idx_v2_session_jobs_status
+ON v2_session_jobs(status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_v2_session_jobs_session
+ON v2_session_jobs(session_id, pipeline_version);
+
+CREATE INDEX IF NOT EXISTS idx_v2_session_job_events_job
+ON v2_session_job_events(job_id, created_at DESC);
 """
 
 
@@ -381,6 +450,13 @@ def _run_light_migrations(conn: sqlite3.Connection) -> None:
 
     _add_column_if_missing(conn, "memory_vectors", "model", "model TEXT NOT NULL DEFAULT 'hash-fallback'")
     _add_column_if_missing(conn, "memory_vectors", "backend", "backend TEXT NOT NULL DEFAULT 'sqlite'")
+
+    _add_column_if_missing(conn, "v2_session_jobs", "last_successful_stage", "last_successful_stage TEXT NOT NULL DEFAULT ''")
+    _add_column_if_missing(conn, "v2_session_jobs", "source_app", "source_app TEXT NOT NULL DEFAULT ''")
+    _add_column_if_missing(conn, "v2_session_jobs", "repo_path", "repo_path TEXT NOT NULL DEFAULT ''")
+    _add_column_if_missing(conn, "v2_session_jobs", "forced_at", "forced_at TEXT NOT NULL DEFAULT ''")
+    _add_column_if_missing(conn, "v2_session_jobs", "forced_by", "forced_by TEXT NOT NULL DEFAULT ''")
+    _add_column_if_missing(conn, "v2_session_job_stages", "stage_config_hash", "stage_config_hash TEXT NOT NULL DEFAULT ''")
 
 
 def init_schema(conn: sqlite3.Connection) -> None:

--- a/src/agent_memory_orchestrator/evidence/__init__.py
+++ b/src/agent_memory_orchestrator/evidence/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .drain import DrainSessionState, EvidenceDrain
 from .raw_store import RawEvidenceRef, RawEvidenceStore
-from .triggers import TriggerDecision, detect_trigger
+from .triggers import TriggerDecision, detect_trigger, is_session_start, record_session_id, session_boundary_trigger
 from .window import MAX_QWEN_RECORDS, clean_evidence_window
 
 __all__ = [
@@ -14,4 +14,7 @@ __all__ = [
     "TriggerDecision",
     "clean_evidence_window",
     "detect_trigger",
+    "is_session_start",
+    "record_session_id",
+    "session_boundary_trigger",
 ]

--- a/src/agent_memory_orchestrator/evidence/drain.py
+++ b/src/agent_memory_orchestrator/evidence/drain.py
@@ -10,6 +10,7 @@ from typing import Any
 from ..core.config import Settings
 from ..graph.session import SessionGraphBuilder
 from ..graph.store import GraphStore
+from ..reasoning_graph.jobs import V2SessionJobStore
 from ..versioning import VersionBackend
 from .triggers import detect_trigger
 from .triggers import is_session_start
@@ -19,8 +20,14 @@ from .triggers import session_boundary_trigger
 
 @dataclass(slots=True)
 class DrainSessionState:
+    pending_count: int = 0
+    first_event_id: str = ""
+    latest_event_id: str = ""
+    source_app: str = ""
+    repo_path: str = ""
+    evidence_days: set[str] = field(default_factory=set)
+    enqueued_windows: int = 0
     pending_records: list[dict[str, Any]] = field(default_factory=list)
-    processed_windows: int = 0
 
 
 @dataclass(slots=True, frozen=True)
@@ -63,12 +70,14 @@ class EvidenceDrain:
         pending_path: Path | None = None,
         evidence_roots: list[Path] | None = None,
         builder: SessionGraphBuilder | None = None,
+        job_store: V2SessionJobStore | None = None,
     ) -> None:
         self.settings = settings
         self.cursor_path = cursor_path or settings.home / ".state" / "evidence_cursors.json"
         self.pending_path = pending_path or settings.home / ".state" / "evidence_pending_windows.json"
         self.evidence_roots = evidence_roots or [settings.evidence_dir]
-        self.builder = builder or SessionGraphBuilder(settings, store, version_backend)
+        self.builder = builder
+        self.job_store = job_store if job_store is not None else (None if builder is not None else V2SessionJobStore(settings))
 
     def drain(self, *, limit: int = 500, session_id: str = "", max_windows: int | None = None) -> dict[str, Any]:
         start = time.monotonic()
@@ -93,6 +102,7 @@ class EvidenceDrain:
         for path in self._evidence_files():
             key = _cursor_key(path, session_filter)
             offset = int(cursors.get(key, 0))
+            evidence_day = path.stem
             for next_offset, record, issue in _iter_jsonl_from(
                 path,
                 offset,
@@ -116,16 +126,19 @@ class EvidenceDrain:
                         previous_state = states.get(previous_session)
                         if (
                             previous_state is not None
-                            and previous_state.pending_records
+                            and previous_state.pending_count
                             and (not session_filter or previous_session == session_filter)
                         ):
                             decision = session_boundary_trigger(previous_session, current_session)
-                            result = self.builder.process_window(
+                            result = self._process_or_enqueue_closed_session(
                                 session_id=previous_session,
-                                records=previous_state.pending_records,
+                                new_session_id=current_session,
+                                boundary_event_id=str(record.get("id") or ""),
+                                state=previous_state,
                                 trigger=decision,
                             )
-                            previous_state.processed_windows += 1
+                            previous_state.enqueued_windows += 1
+                            previous_state.pending_count = 0
                             previous_state.pending_records = []
                             stats["windows_processed"] += 1
                             stats["triggered"].append(
@@ -156,10 +169,11 @@ class EvidenceDrain:
                     continue
 
                 state = states.setdefault(current_session, DrainSessionState())
-                self.builder.ingest_basic_record(record)
+                if self.builder is not None:
+                    self.builder.ingest_basic_record(record)
                 stats["records_ingested"] += 1
                 decision = detect_trigger(record)
-                state.pending_records.append(record)
+                _update_state_from_record(state, record, evidence_day=evidence_day)
                 stats["skipped"].append(
                     {
                         "session_id": current_session,
@@ -247,8 +261,15 @@ class EvidenceDrain:
             if not isinstance(row, dict):
                 continue
             records = row.get("pending_records")
+            days = row.get("evidence_days")
             states[str(session_id)] = DrainSessionState(
-                pending_records=records if isinstance(records, list) else [],
+                pending_count=int(row.get("pending_count", len(records) if isinstance(records, list) else 0)),
+                first_event_id=str(row.get("first_event_id") or ""),
+                latest_event_id=str(row.get("latest_event_id") or ""),
+                source_app=str(row.get("source_app") or ""),
+                repo_path=str(row.get("repo_path") or ""),
+                evidence_days=set(str(item) for item in days if str(item)) if isinstance(days, list) else set(),
+                enqueued_windows=int(row.get("enqueued_windows", row.get("processed_windows", 0))),
             )
         last_active_session_id = str(payload.get("last_active_session_id") or "") if isinstance(payload, dict) else ""
         return states, last_active_session_id
@@ -256,10 +277,16 @@ class EvidenceDrain:
     def _save_pending_states(self, states: dict[str, DrainSessionState], last_active_session_id: str) -> None:
         sessions = {
             session_id: {
-                "pending_records": state.pending_records,
+                "pending_count": state.pending_count,
+                "first_event_id": state.first_event_id,
+                "latest_event_id": state.latest_event_id,
+                "source_app": state.source_app,
+                "repo_path": state.repo_path,
+                "evidence_days": sorted(state.evidence_days),
+                "enqueued_windows": state.enqueued_windows,
             }
             for session_id, state in sorted(states.items())
-            if state.pending_records
+            if state.pending_count
         }
         self.pending_path.parent.mkdir(parents=True, exist_ok=True)
         self.pending_path.write_text(
@@ -283,6 +310,36 @@ class EvidenceDrain:
     ) -> None:
         self._save_cursors(cursors)
         self._save_pending_states(states, last_active_session_id)
+
+    def _process_or_enqueue_closed_session(
+        self,
+        *,
+        session_id: str,
+        new_session_id: str,
+        boundary_event_id: str,
+        state: DrainSessionState,
+        trigger: Any,
+    ) -> dict[str, Any]:
+        if self.builder is not None:
+            return self.builder.process_window(session_id=session_id, records=state.pending_records, trigger=trigger)
+        if self.job_store is None:
+            raise RuntimeError("V2 session job store is required for enqueue-only drain")
+        enqueue = self.job_store.enqueue_session(
+            session_id=session_id,
+            boundary_event_id=boundary_event_id,
+            source_app=state.source_app,
+            repo_path=state.repo_path,
+            source_evidence_day=sorted(state.evidence_days)[-1] if state.evidence_days else "",
+            source_evidence_days=sorted(state.evidence_days),
+        )
+        return {
+            "mode": "v2_job_enqueue",
+            "job_id": enqueue.job.get("job_id"),
+            "created": enqueue.created,
+            "updated": enqueue.updated,
+            "reason": enqueue.reason,
+            "closed_by_session_id": new_session_id,
+        }
 
 
 def _read_jsonl_from(path: Path, offset: int) -> list[tuple[int, dict[str, Any]]]:
@@ -403,6 +460,11 @@ def _cursor_key(path: Path, session_id: str = "") -> str:
 
 def _compact_result(result: dict[str, Any]) -> dict[str, Any]:
     return {
+        "mode": result.get("mode", ""),
+        "job_id": result.get("job_id", ""),
+        "created": result.get("created"),
+        "updated": result.get("updated"),
+        "reason": result.get("reason", ""),
         "processed": bool(result.get("processed")),
         "context_node_id": result.get("context_node_id"),
         "work_node_id": result.get("work_node_id"),
@@ -412,5 +474,38 @@ def _compact_result(result: dict[str, Any]) -> dict[str, Any]:
 
 
 def _pending_session_count(states: dict[str, DrainSessionState]) -> int:
-    return sum(1 for state in states.values() if state.pending_records)
+    return sum(1 for state in states.values() if state.pending_count)
+
+
+def _update_state_from_record(state: DrainSessionState, record: dict[str, Any], *, evidence_day: str) -> None:
+    event_id = str(record.get("id") or "")
+    state.pending_count += 1
+    state.pending_records.append(record)
+    if event_id and not state.first_event_id:
+        state.first_event_id = event_id
+    if event_id:
+        state.latest_event_id = event_id
+    source_app = str(record.get("source_app") or "")
+    if source_app and not state.source_app:
+        state.source_app = source_app
+    repo_path = _record_repo_path(record)
+    if repo_path and not state.repo_path:
+        state.repo_path = repo_path
+    if evidence_day:
+        state.evidence_days.add(evidence_day)
+
+
+def _record_repo_path(record: dict[str, Any]) -> str:
+    payload = record.get("payload") if isinstance(record.get("payload"), dict) else {}
+    for key in ("cwd", "repo_path", "repo_root", "workspace", "workspace_root"):
+        value = payload.get(key, record.get(key))
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("cwd", "repo_path", "repo_root"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
 

--- a/src/agent_memory_orchestrator/evidence/drain.py
+++ b/src/agent_memory_orchestrator/evidence/drain.py
@@ -12,14 +12,15 @@ from ..graph.session import SessionGraphBuilder
 from ..graph.store import GraphStore
 from ..versioning import VersionBackend
 from .triggers import detect_trigger
-from .triggers import estimate_record_tokens
+from .triggers import is_session_start
+from .triggers import record_session_id
+from .triggers import session_boundary_trigger
 
 
 @dataclass(slots=True)
 class DrainSessionState:
     pending_records: list[dict[str, Any]] = field(default_factory=list)
     processed_windows: int = 0
-    pending_approx_tokens: int = 0
 
 
 @dataclass(slots=True, frozen=True)
@@ -74,7 +75,7 @@ class EvidenceDrain:
         safe_max_windows = max(1, int(max_windows or self.settings.drain_max_windows_per_run))
         cursors = self._load_cursors()
         session_filter = str(session_id or "")
-        states = self._load_pending_states()
+        states, last_active_session_id = self._load_pending_states()
         stats: dict[str, Any] = {
             "ok": True,
             "records_seen": 0,
@@ -87,7 +88,7 @@ class EvidenceDrain:
             "skipped": [],
             "cursor_path": str(self.cursor_path),
             "pending_path": str(self.pending_path),
-            "token_threshold": int(self.settings.drain_token_threshold),
+            "processing_trigger": "session_boundary",
         }
         for path in self._evidence_files():
             key = _cursor_key(path, session_filter)
@@ -106,63 +107,81 @@ class EvidenceDrain:
                 if record is None:
                     continue
                 stats["records_seen"] += 1
-                if session_filter and str(record.get("session_id") or "") != session_filter:
+
+                current_session = record_session_id(record)
+                boundary_processed = False
+                if is_session_start(record):
+                    previous_session = last_active_session_id
+                    if previous_session and previous_session != current_session:
+                        previous_state = states.get(previous_session)
+                        if (
+                            previous_state is not None
+                            and previous_state.pending_records
+                            and (not session_filter or previous_session == session_filter)
+                        ):
+                            decision = session_boundary_trigger(previous_session, current_session)
+                            result = self.builder.process_window(
+                                session_id=previous_session,
+                                records=previous_state.pending_records,
+                                trigger=decision,
+                            )
+                            previous_state.processed_windows += 1
+                            previous_state.pending_records = []
+                            stats["windows_processed"] += 1
+                            stats["triggered"].append(
+                                {
+                                    "session_id": previous_session,
+                                    "trigger": decision.as_dict(),
+                                    "result": _compact_result(result),
+                                    "latest_event": {
+                                        "boundary_event_id": record.get("id"),
+                                        "new_session_id": current_session,
+                                    },
+                                }
+                            )
+                            boundary_processed = True
+                    last_active_session_id = current_session
+                elif not last_active_session_id:
+                    last_active_session_id = current_session
+
+                if session_filter and current_session != session_filter:
                     stats["records_skipped"] += 1
-                    continue
-                current_session = str(record.get("session_id") or "default")
-                state = states.setdefault(current_session, DrainSessionState())
-                ingest = self.builder.ingest_basic_record(record)
-                stats["records_ingested"] += 1
-                record_tokens = estimate_record_tokens(record)
-                projected_tokens = state.pending_approx_tokens + record_tokens
-                decision = detect_trigger(
-                    record,
-                    pending_approx_tokens=projected_tokens,
-                    token_threshold=self.settings.drain_token_threshold,
-                )
-                state.pending_records.append(record)
-                state.pending_approx_tokens = projected_tokens
-                if decision.should_process:
-                    result = self.builder.process_window(
-                        session_id=current_session,
-                        records=state.pending_records,
-                        trigger=decision,
-                    )
-                    state.processed_windows += 1
-                    state.pending_records = []
-                    state.pending_approx_tokens = 0
-                    stats["windows_processed"] += 1
-                    stats["triggered"].append(
-                        {
-                            "session_id": current_session,
-                            "trigger": decision.as_dict(),
-                            "result": _compact_result(result),
-                            "latest_event": ingest,
-                        }
-                    )
-                    if stats["windows_processed"] >= safe_max_windows:
-                        self._save_state(cursors, states)
+                    if boundary_processed and stats["windows_processed"] >= safe_max_windows:
+                        self._save_state(cursors, states, last_active_session_id)
                         stats["stopped_reason"] = "max_windows_reached"
                         stats["max_windows"] = safe_max_windows
                         stats["pending_sessions"] = _pending_session_count(states)
                         stats["elapsed_ms"] = int((time.monotonic() - start) * 1000)
                         return stats
-                else:
-                    stats["skipped"].append(
-                        {
-                            "session_id": current_session,
-                            "evidence_id": record.get("id"),
-                            "decision": decision.as_dict(),
-                        }
-                    )
+                    continue
+
+                state = states.setdefault(current_session, DrainSessionState())
+                self.builder.ingest_basic_record(record)
+                stats["records_ingested"] += 1
+                decision = detect_trigger(record)
+                state.pending_records.append(record)
+                stats["skipped"].append(
+                    {
+                        "session_id": current_session,
+                        "evidence_id": record.get("id"),
+                        "decision": decision.as_dict(),
+                    }
+                )
+                if boundary_processed and stats["windows_processed"] >= safe_max_windows:
+                    self._save_state(cursors, states, last_active_session_id)
+                    stats["stopped_reason"] = "max_windows_reached"
+                    stats["max_windows"] = safe_max_windows
+                    stats["pending_sessions"] = _pending_session_count(states)
+                    stats["elapsed_ms"] = int((time.monotonic() - start) * 1000)
+                    return stats
                 if stats["records_ingested"] >= max(1, int(limit)):
-                    self._save_state(cursors, states)
+                    self._save_state(cursors, states, last_active_session_id)
                     stats["stopped_reason"] = "record_limit_reached"
                     stats["max_windows"] = safe_max_windows
                     stats["pending_sessions"] = _pending_session_count(states)
                     stats["elapsed_ms"] = int((time.monotonic() - start) * 1000)
                     return stats
-        self._save_state(cursors, states)
+        self._save_state(cursors, states, last_active_session_id)
         stats["stopped_reason"] = "evidence_exhausted"
         stats["max_windows"] = safe_max_windows
         stats["pending_sessions"] = _pending_session_count(states)
@@ -213,16 +232,16 @@ class EvidenceDrain:
         self.cursor_path.parent.mkdir(parents=True, exist_ok=True)
         self.cursor_path.write_text(json.dumps(cursors, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    def _load_pending_states(self) -> dict[str, DrainSessionState]:
+    def _load_pending_states(self) -> tuple[dict[str, DrainSessionState], str]:
         if not self.pending_path.exists():
-            return {}
+            return {}, ""
         try:
             payload = json.loads(self.pending_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            return {}
+            return {}, ""
         sessions = payload.get("sessions") if isinstance(payload, dict) else {}
         if not isinstance(sessions, dict):
-            return {}
+            return {}, ""
         states: dict[str, DrainSessionState] = {}
         for session_id, row in sessions.items():
             if not isinstance(row, dict):
@@ -230,25 +249,40 @@ class EvidenceDrain:
             records = row.get("pending_records")
             states[str(session_id)] = DrainSessionState(
                 pending_records=records if isinstance(records, list) else [],
-                pending_approx_tokens=max(0, int(row.get("pending_approx_tokens") or 0)),
             )
-        return states
+        last_active_session_id = str(payload.get("last_active_session_id") or "") if isinstance(payload, dict) else ""
+        return states, last_active_session_id
 
-    def _save_pending_states(self, states: dict[str, DrainSessionState]) -> None:
+    def _save_pending_states(self, states: dict[str, DrainSessionState], last_active_session_id: str) -> None:
         sessions = {
             session_id: {
                 "pending_records": state.pending_records,
-                "pending_approx_tokens": state.pending_approx_tokens,
             }
             for session_id, state in sorted(states.items())
             if state.pending_records
         }
         self.pending_path.parent.mkdir(parents=True, exist_ok=True)
-        self.pending_path.write_text(json.dumps({"sessions": sessions}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        self.pending_path.write_text(
+            json.dumps(
+                {
+                    "last_active_session_id": last_active_session_id,
+                    "sessions": sessions,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
-    def _save_state(self, cursors: dict[str, int], states: dict[str, DrainSessionState]) -> None:
+    def _save_state(
+        self,
+        cursors: dict[str, int],
+        states: dict[str, DrainSessionState],
+        last_active_session_id: str,
+    ) -> None:
         self._save_cursors(cursors)
-        self._save_pending_states(states)
+        self._save_pending_states(states, last_active_session_id)
 
 
 def _read_jsonl_from(path: Path, offset: int) -> list[tuple[int, dict[str, Any]]]:

--- a/src/agent_memory_orchestrator/evidence/drain.py
+++ b/src/agent_memory_orchestrator/evidence/drain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from dataclasses import dataclass, field
@@ -19,6 +20,30 @@ class DrainSessionState:
     pending_records: list[dict[str, Any]] = field(default_factory=list)
     processed_windows: int = 0
     pending_approx_tokens: int = 0
+
+
+@dataclass(slots=True, frozen=True)
+class JsonlReadIssue:
+    path: str
+    offset: int
+    next_offset: int
+    error_type: str
+    error: str
+    raw_sha256: str
+    preview: str
+    quarantine_path: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "offset": self.offset,
+            "next_offset": self.next_offset,
+            "error_type": self.error_type,
+            "error": self.error,
+            "raw_sha256": self.raw_sha256,
+            "preview": self.preview,
+            "quarantine_path": self.quarantine_path,
+        }
 
 
 class EvidenceDrain:
@@ -55,6 +80,8 @@ class EvidenceDrain:
             "records_seen": 0,
             "records_ingested": 0,
             "records_skipped": 0,
+            "malformed_records": 0,
+            "malformed": [],
             "windows_processed": 0,
             "triggered": [],
             "skipped": [],
@@ -65,8 +92,19 @@ class EvidenceDrain:
         for path in self._evidence_files():
             key = _cursor_key(path, session_filter)
             offset = int(cursors.get(key, 0))
-            for next_offset, record in _read_jsonl_from(path, offset):
+            for next_offset, record, issue in _iter_jsonl_from(
+                path,
+                offset,
+                quarantine_dir=self.settings.home / ".state" / "malformed_evidence",
+            ):
                 cursors[key] = next_offset
+                if issue is not None:
+                    stats["malformed_records"] += 1
+                    if len(stats["malformed"]) < 20:
+                        stats["malformed"].append(issue.as_dict())
+                    continue
+                if record is None:
+                    continue
                 stats["records_seen"] += 1
                 if session_filter and str(record.get("session_id") or "") != session_filter:
                     stats["records_skipped"] += 1
@@ -214,7 +252,26 @@ class EvidenceDrain:
 
 
 def _read_jsonl_from(path: Path, offset: int) -> list[tuple[int, dict[str, Any]]]:
-    rows: list[tuple[int, dict[str, Any]]] = []
+    """Read valid JSONL rows from an offset.
+
+    Malformed rows are skipped by design. Drain callers use `_iter_jsonl_from`
+    directly so they can advance cursors and quarantine bad lines.
+    """
+
+    return [
+        (next_offset, record)
+        for next_offset, record, issue in _iter_jsonl_from(path, offset)
+        if issue is None and record is not None
+    ]
+
+
+def _iter_jsonl_from(
+    path: Path,
+    offset: int,
+    *,
+    quarantine_dir: Path | None = None,
+) -> list[tuple[int, dict[str, Any] | None, JsonlReadIssue | None]]:
+    rows: list[tuple[int, dict[str, Any] | None, JsonlReadIssue | None]] = []
     with path.open("rb") as handle:
         handle.seek(offset)
         while True:
@@ -225,14 +282,82 @@ def _read_jsonl_from(path: Path, offset: int) -> list[tuple[int, dict[str, Any]]
             next_offset = handle.tell()
             try:
                 payload = json.loads(line.decode("utf-8"))
-            except (UnicodeDecodeError, json.JSONDecodeError):
-                rows.append((next_offset, {"id": "", "hash": "", "offset": start, "path": str(path), "payload": {}}))
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                issue = _jsonl_issue(
+                    path=path,
+                    offset=start,
+                    next_offset=next_offset,
+                    raw=line,
+                    exc=exc,
+                    quarantine_dir=quarantine_dir,
+                )
+                rows.append((next_offset, None, issue))
                 continue
-            if isinstance(payload, dict):
-                payload.setdefault("path", str(path.resolve()))
-                payload.setdefault("offset", start)
-                rows.append((next_offset, payload))
+            if not isinstance(payload, dict):
+                issue = _jsonl_issue(
+                    path=path,
+                    offset=start,
+                    next_offset=next_offset,
+                    raw=line,
+                    exc=TypeError(f"JSONL row must be an object, got {type(payload).__name__}"),
+                    quarantine_dir=quarantine_dir,
+                )
+                rows.append((next_offset, None, issue))
+                continue
+            payload.setdefault("path", str(path.resolve()))
+            payload.setdefault("offset", start)
+            rows.append((next_offset, payload, None))
     return rows
+
+
+def _jsonl_issue(
+    *,
+    path: Path,
+    offset: int,
+    next_offset: int,
+    raw: bytes,
+    exc: BaseException,
+    quarantine_dir: Path | None,
+) -> JsonlReadIssue:
+    digest = hashlib.sha256(raw).hexdigest()
+    decoded = raw.decode("utf-8", errors="replace")
+    preview = decoded[:500].replace("\n", "\\n").replace("\r", "\\r")
+    quarantine_path = ""
+    issue = JsonlReadIssue(
+        path=str(path.resolve()),
+        offset=offset,
+        next_offset=next_offset,
+        error_type=type(exc).__name__,
+        error=str(exc),
+        raw_sha256=digest,
+        preview=preview,
+    )
+    if quarantine_dir is not None:
+        quarantine_path = _quarantine_jsonl_issue(quarantine_dir, path, raw, issue)
+        issue = JsonlReadIssue(
+            path=issue.path,
+            offset=issue.offset,
+            next_offset=issue.next_offset,
+            error_type=issue.error_type,
+            error=issue.error,
+            raw_sha256=issue.raw_sha256,
+            preview=issue.preview,
+            quarantine_path=quarantine_path,
+        )
+    return issue
+
+
+def _quarantine_jsonl_issue(quarantine_dir: Path, source_path: Path, raw: bytes, issue: JsonlReadIssue) -> str:
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    target = quarantine_dir / f"{source_path.name}.bad.jsonl"
+    row = {
+        **issue.as_dict(),
+        "source_file": str(source_path.resolve()),
+        "raw_line": raw.decode("utf-8", errors="replace"),
+    }
+    with target.open("ab") as handle:
+        handle.write((json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8"))
+    return str(target.resolve())
 
 
 def _cursor_key(path: Path, session_id: str = "") -> str:

--- a/src/agent_memory_orchestrator/evidence/raw_store.py
+++ b/src/agent_memory_orchestrator/evidence/raw_store.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
+import os
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from types import TracebackType
 from typing import Any
 
 
@@ -40,8 +44,9 @@ class RawEvidenceStore:
     evidence refs; raw event text is not treated as memory by default.
     """
 
-    def __init__(self, root: Path) -> None:
+    def __init__(self, root: Path, *, lock_timeout_seconds: float = 10.0) -> None:
         self.root = root
+        self.lock_timeout_seconds = lock_timeout_seconds
         self.root.mkdir(parents=True, exist_ok=True)
 
     def append(
@@ -67,9 +72,13 @@ class RawEvidenceStore:
             "payload": payload,
         }
         line = (json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n").encode("utf-8")
-        with path.open("ab") as handle:
-            offset = handle.tell()
-            handle.write(line)
+        with _locked_jsonl_path(path, timeout_seconds=self.lock_timeout_seconds):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("ab") as handle:
+                offset = handle.tell()
+                handle.write(line)
+                handle.flush()
+                os.fsync(handle.fileno())
         return RawEvidenceRef(
             id=evidence_id,
             hash=digest,
@@ -81,3 +90,103 @@ class RawEvidenceStore:
             created_at=created_at,
         )
 
+
+@contextlib.contextmanager
+def _locked_jsonl_path(path: Path, *, timeout_seconds: float) -> Any:
+    """Inter-process lock for appending one JSONL record.
+
+    Codex hooks run as independent processes and can emit large tool responses
+    at nearly the same time. A companion lock file keeps the daily evidence
+    JSONL from receiving interleaved fragments.
+    """
+
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as handle:
+        _ensure_lock_byte(handle)
+        lock = _FileLock(handle, timeout_seconds=timeout_seconds)
+        lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
+
+
+def _ensure_lock_byte(handle: Any) -> None:
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
+    handle.seek(0)
+
+
+class _FileLock:
+    def __init__(self, handle: Any, *, timeout_seconds: float) -> None:
+        self.handle = handle
+        self.timeout_seconds = max(0.1, float(timeout_seconds))
+        self.acquired = False
+
+    def acquire(self) -> None:
+        deadline = time.monotonic() + self.timeout_seconds
+        while True:
+            try:
+                self._try_acquire()
+                self.acquired = True
+                return
+            except BlockingIOError:
+                pass
+            except OSError as exc:
+                if not _is_lock_busy(exc):
+                    raise
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Timed out waiting for evidence JSONL lock: {self.handle.name}")
+            time.sleep(0.025)
+
+    def release(self) -> None:
+        if not self.acquired:
+            return
+        self._release()
+        self.acquired = False
+
+    def __enter__(self) -> "_FileLock":
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, traceback
+        self.release()
+
+    def _try_acquire(self) -> None:
+        if os.name == "nt":
+            import msvcrt
+
+            self.handle.seek(0)
+            msvcrt.locking(self.handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(self.handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _release(self) -> None:
+        if os.name == "nt":
+            import msvcrt
+
+            self.handle.seek(0)
+            msvcrt.locking(self.handle.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+
+
+def _is_lock_busy(exc: OSError) -> bool:
+    if os.name == "nt":
+        return getattr(exc, "winerror", None) in {33} or exc.errno in {13}
+    return exc.errno in {11, 13}

--- a/src/agent_memory_orchestrator/evidence/triggers.py
+++ b/src/agent_memory_orchestrator/evidence/triggers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -14,7 +13,6 @@ class TriggerDecision:
     is_test: bool = False
     is_git: bool = False
     is_commit: bool = False
-    approx_tokens: int = 0
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -25,36 +23,29 @@ class TriggerDecision:
             "is_test": self.is_test,
             "is_git": self.is_git,
             "is_commit": self.is_commit,
-            "approx_tokens": self.approx_tokens,
         }
 
 
-def detect_trigger(
-    record: dict[str, Any],
-    *,
-    pending_approx_tokens: int = 0,
-    token_threshold: int = 0,
-) -> TriggerDecision:
-    safe_tokens = max(0, int(pending_approx_tokens))
-
-    if token_threshold > 0 and safe_tokens >= token_threshold:
-        return TriggerDecision(
-            True,
-            "token_threshold",
-            f"pending evidence window reached {safe_tokens} approx tokens",
-            approx_tokens=safe_tokens,
-        )
-    return TriggerDecision(False, "none", "raw evidence only", approx_tokens=safe_tokens)
+def detect_trigger(record: dict[str, Any]) -> TriggerDecision:
+    _ = record
+    return TriggerDecision(False, "none", "raw evidence pending until next session starts")
 
 
-def estimate_record_tokens(record: dict[str, Any]) -> int:
-    """Cheap token estimate for daemon trigger thresholds.
+def session_boundary_trigger(previous_session_id: str, new_session_id: str) -> TriggerDecision:
+    return TriggerDecision(
+        True,
+        "session_boundary",
+        f"new session {new_session_id} started after session {previous_session_id}",
+    )
 
-    We only need a stable boundary signal here; exact tokenizer accounting would
-    make hooks/drain depend on model packages and slow down background capture.
-    """
 
-    return max(1, len(_record_text(record)) // 4)
+def is_session_start(record: dict[str, Any]) -> bool:
+    return _event_type(record) == "session_start"
+
+
+def record_session_id(record: dict[str, Any]) -> str:
+    payload = _payload(record)
+    return str(record.get("session_id") or payload.get("session_id") or payload.get("sessionId") or "default")
 
 
 def _payload(record: dict[str, Any]) -> dict[str, Any]:
@@ -62,21 +53,28 @@ def _payload(record: dict[str, Any]) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _record_text(record: dict[str, Any]) -> str:
+def _event_type(record: dict[str, Any]) -> str:
     payload = _payload(record)
-    chunks: list[str] = [
+    raw = (
         str(record.get("event_name") or ""),
         str(payload.get("hook_event_name") or ""),
-        str(payload.get("tool") or ""),
-        str(payload.get("tool_name") or ""),
-        str(payload.get("prompt") or ""),
-        str(payload.get("content") or ""),
-        str(payload.get("message") or ""),
-    ]
-    for key in ("tool_input", "tool_response"):
-        value = payload.get(key)
-        if isinstance(value, str):
-            chunks.append(value)
-        elif value:
-            chunks.append(json.dumps(value, ensure_ascii=False, sort_keys=True))
-    return "\n".join(chunks).lower()
+        str(payload.get("event_type") or ""),
+    )
+    return _snake(next((value for value in raw if value), ""))
+
+
+def _snake(value: str) -> str:
+    text = value.strip()
+    out: list[str] = []
+    prev_lower = False
+    for char in text:
+        if char.isupper() and prev_lower:
+            out.append("_")
+        if char.isalnum():
+            out.append(char.lower())
+            prev_lower = char.islower() or char.isdigit()
+        else:
+            if out and out[-1] != "_":
+                out.append("_")
+            prev_lower = False
+    return "".join(out).strip("_")

--- a/src/agent_memory_orchestrator/graph/diagnostics.py
+++ b/src/agent_memory_orchestrator/graph/diagnostics.py
@@ -9,7 +9,9 @@ from ..core.config import Settings
 from ..app.client import DaemonClient, DaemonUnavailable
 from ..evidence.drain import EvidenceDrain
 from ..evidence.triggers import detect_trigger
-from ..evidence.triggers import estimate_record_tokens
+from ..evidence.triggers import is_session_start
+from ..evidence.triggers import record_session_id
+from ..evidence.triggers import session_boundary_trigger
 from ..llm.qwen import OllamaQwenClient, QwenUnavailable
 from .merge import QwenMergeClassifier
 from .service import GraphRagService
@@ -95,18 +97,18 @@ def debug_retrieval(client: DaemonClient, *, query: str, limit: int = 8) -> dict
         return {"ok": False, "error": str(exc), "client_elapsed_ms": _elapsed_ms(start)}
 
 
-def trigger_preview(records: list[dict[str, Any]], *, token_threshold: int = 0) -> list[dict[str, Any]]:
-    pending_approx_tokens = 0
+def trigger_preview(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    last_active_session_id = ""
     decisions: list[dict[str, Any]] = []
     for record in records:
-        pending_approx_tokens += estimate_record_tokens(record)
-        decision = detect_trigger(
-            record,
-            pending_approx_tokens=pending_approx_tokens,
-            token_threshold=token_threshold,
-        )
-        if decision.should_process:
-            pending_approx_tokens = 0
+        current_session = record_session_id(record)
+        if is_session_start(record) and last_active_session_id and last_active_session_id != current_session:
+            decision = session_boundary_trigger(last_active_session_id, current_session)
+            last_active_session_id = current_session
+        else:
+            decision = detect_trigger(record)
+            if is_session_start(record) or not last_active_session_id:
+                last_active_session_id = current_session
         decisions.append(
             {
                 "id": record.get("id"),

--- a/src/agent_memory_orchestrator/graph/service.py
+++ b/src/agent_memory_orchestrator/graph/service.py
@@ -351,6 +351,29 @@ class GraphRagService:
             result["finalizations"] = finalizations
         return result
 
+    def drain_evidence_smoke(self, *, limit: int = 500, max_windows: int | None = None) -> dict[str, Any]:
+        """Run the legacy GraphDelta extractor only into a disposable smoke graph."""
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        smoke_path = self.settings.home / ".state" / "smoke" / f"graph-drain-smoke-{timestamp}.kuzu"
+        if smoke_path.exists():
+            _remove_graph_path(smoke_path)
+        smoke_store = KuzuGraphStore(smoke_path)
+        smoke_store.init_schema()
+        try:
+            result = self._drain_fresh_graph(
+                smoke_store,
+                cursor_path=self.settings.home / ".state" / f"smoke-drain-cursors-{timestamp}.json",
+                limit=limit,
+                max_windows=max_windows,
+            )
+            result["ok"] = True
+            result["mode"] = "legacy_graphdelta_smoke"
+            result["graph_path"] = str(smoke_path)
+            result["production_graph_path"] = str(self.settings.graph_path)
+            return result
+        finally:
+            smoke_store.close()
+
     def pending_evidence(self, *, session_id: str = "") -> dict[str, Any]:
         drain = self._new_drain()
         return drain.pending(session_id=session_id)
@@ -924,14 +947,11 @@ class GraphRagService:
         return {"ok": trace.commit.available, "trace": trace.as_dict()}
 
     def _new_drain(self) -> EvidenceDrain:
-        extractor = QwenGraphExtractor(self.settings)
-        builder = SessionGraphBuilder(self.settings, self.store, self.version_backend, extractor=extractor)
         return EvidenceDrain(
             self.settings,
             self.store,
             self.version_backend,
             evidence_roots=_evidence_roots(self.settings),
-            builder=builder,
         )
 
     def _upsert_basic_nodes(self, normalized: dict[str, Any], *, evidence: RawEvidenceRef, git: dict[str, Any]) -> None:

--- a/src/agent_memory_orchestrator/graph/service.py
+++ b/src/agent_memory_orchestrator/graph/service.py
@@ -17,8 +17,9 @@ from ..evidence.drain import EvidenceDrain
 from ..evidence.drain import _read_jsonl_from
 from ..evidence.raw_store import RawEvidenceRef, RawEvidenceStore
 from ..evidence.triggers import TriggerDecision
-from ..evidence.triggers import detect_trigger
-from ..evidence.triggers import estimate_record_tokens
+from ..evidence.triggers import is_session_start
+from ..evidence.triggers import record_session_id
+from ..evidence.triggers import session_boundary_trigger
 from ..evidence.window import clean_evidence_window
 from ..llm.embeddings import embed_text
 from ..llm.qwen import DeterministicPlanner, OllamaQwenClient, QueryPlan, QwenPlanner, QwenUnavailable
@@ -577,7 +578,7 @@ class GraphRagService:
         nodes = [_sanitize_output_node(node) for node in self.store.list_nodes(session_id=session_id, limit=300)]
         edges = self.store.list_edges(session_id=session_id, limit=500)
         pending = self.pending_evidence(session_id=session_id)
-        windows = _reconstruct_clean_windows(records, nodes, token_threshold=self.settings.drain_token_threshold)
+        windows = _reconstruct_clean_windows(records, nodes)
         merge_preview = CommitMergeEngine(self.settings, self.store, self.version_backend, classifier=None).finalize_session(
             session_id=session_id,
             commit="HEAD",
@@ -1796,25 +1797,27 @@ def _timeline_row(record: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _reconstruct_clean_windows(
-    records: list[dict[str, Any]], nodes: list[dict[str, Any]], *, token_threshold: int
-) -> list[dict[str, Any]]:
-    pending_records: list[dict[str, Any]] = []
-    pending_approx_tokens = 0
+def _reconstruct_clean_windows(records: list[dict[str, Any]], nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    pending_by_session: dict[str, list[dict[str, Any]]] = {}
+    last_active_session_id = ""
     windows: list[dict[str, Any]] = []
     for record in records:
-        pending_approx_tokens += estimate_record_tokens(record)
-        decision = detect_trigger(
-            record,
-            pending_approx_tokens=pending_approx_tokens,
-            token_threshold=token_threshold,
-        )
-        pending_records.append(record)
-        if decision.should_process:
-            windows.append(_window_row(len(windows) + 1, pending_records, decision, nodes))
-            pending_records = []
-            pending_approx_tokens = 0
-    if pending_records:
+        current_session = record_session_id(record)
+        if is_session_start(record):
+            if last_active_session_id and last_active_session_id != current_session:
+                pending = pending_by_session.get(last_active_session_id, [])
+                if pending:
+                    decision = session_boundary_trigger(last_active_session_id, current_session)
+                    windows.append(_window_row(len(windows) + 1, pending, decision, nodes))
+                    pending_by_session[last_active_session_id] = []
+            last_active_session_id = current_session
+        elif not last_active_session_id:
+            last_active_session_id = current_session
+        pending_by_session.setdefault(current_session, []).append(record)
+
+    for pending_records in pending_by_session.values():
+        if not pending_records:
+            continue
         preview_trigger = TriggerDecision(False, "pending", "pending raw evidence window")
         windows.append(
             {

--- a/src/agent_memory_orchestrator/install/service.py
+++ b/src/agent_memory_orchestrator/install/service.py
@@ -273,7 +273,6 @@ def _runtime_config_payload(resolved_models: dict[str, str]) -> dict[str, Any]:
         "qwen_compress_timeout_seconds": 12,
         "qwen_num_ctx": 2048,
         "drain_max_windows_per_run": 3,
-        "drain_token_threshold": 6000,
         "auto_drain_enabled": True,
         "auto_drain_interval_seconds": 8,
         "auto_drain_record_limit": 500,

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/__init__.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from .constants import GRAPH_SCHEMA_VERSION
+from .constants import PIPELINE_VERSION
+from .constants import V2_STAGES
+from .runner import V2SessionJobRunner
+from .store import V2SessionJobStore
+
+__all__ = [
+    "GRAPH_SCHEMA_VERSION",
+    "PIPELINE_VERSION",
+    "V2SessionJobRunner",
+    "V2SessionJobStore",
+    "V2_STAGES",
+]

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/constants.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/constants.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+PIPELINE_VERSION = "v2-reset-2026-05"
+GRAPH_SCHEMA_VERSION = "v2"
+
+V2_STAGES: tuple[str, ...] = (
+    "evidence_view",
+    "work_packets",
+    "qwen_reasoning",
+    "reasoning_review",
+    "git_hunks",
+    "ast_code_nodes",
+    "symbol_versions",
+    "reasoning_code_links",
+    "kuzu_write",
+    "retrieval_docs",
+    "embeddings",
+    "faiss",
+    "quality_eval",
+)
+
+RESET_MARKER_KEY = "production_v2_reset"

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/reset.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/reset.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from ...app.client import DaemonClient
+from ...app.client import DaemonUnavailable
+from ...core.config import Settings
+from ...core.db import connect
+from .constants import GRAPH_SCHEMA_VERSION
+from .constants import PIPELINE_VERSION
+from .constants import RESET_MARKER_KEY
+from .store import V2SessionJobStore
+
+
+def reset_production_v2_storage(
+    settings: Settings,
+    *,
+    backup: bool,
+    clean_graph: bool,
+    clean_retrieval: bool,
+    force_if_daemon_running: bool = False,
+) -> dict[str, Any]:
+    if not backup:
+        raise ValueError("--backup is required for v2-reset-production")
+    daemon = _daemon_status(settings)
+    if daemon.get("running") and not force_if_daemon_running:
+        raise RuntimeError("daemon_running: stop amo-daemon or pass --force-if-daemon-running")
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    backup_dir = settings.home / "backups" / f"v2-reset-production-{timestamp}"
+    backup_dir.mkdir(parents=True, exist_ok=False)
+    manifest: dict[str, Any] = {
+        "created_at": timestamp,
+        "pipeline_version": PIPELINE_VERSION,
+        "graph_schema_version": GRAPH_SCHEMA_VERSION,
+        "source": {
+            "graph_path": str(settings.graph_path),
+            "retrieval_db_path": str(settings.retrieval_db_path),
+            "db_path": str(settings.db_path),
+        },
+        "copied": [],
+        "clean_graph": clean_graph,
+        "clean_retrieval": clean_retrieval,
+    }
+
+    _backup_path(settings.graph_path, backup_dir / "graph", manifest)
+    _backup_path(settings.retrieval_db_path, backup_dir / "retrieval_db", manifest)
+    _backup_path(settings.db_path, backup_dir / "main_db", manifest)
+    _backup_path(settings.home / "config.json", backup_dir / "config.json", manifest)
+    _backup_path(settings.home / ".state" / "production_v2_reset.json", backup_dir / "production_v2_reset.json", manifest)
+    _backup_path(_faiss_index_dir(settings), backup_dir / "faiss_indexes", manifest)
+    _write_manifest(backup_dir, manifest)
+    _verify_manifest(backup_dir)
+
+    cleaned: dict[str, Any] = {"graph": False, "retrieval": False, "faiss": False}
+    if clean_graph:
+        _remove_path(settings.graph_path)
+        settings.graph_path.parent.mkdir(parents=True, exist_ok=True)
+        cleaned["graph"] = True
+    if clean_retrieval:
+        _clean_retrieval_tables(settings.retrieval_db_path)
+        index_dir = _faiss_index_dir(settings)
+        _remove_path(index_dir)
+        cleaned["retrieval"] = True
+        cleaned["faiss"] = True
+
+    marker = {
+        "production_v2_reset_applied_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "pipeline_version": PIPELINE_VERSION,
+        "graph_schema_version": GRAPH_SCHEMA_VERSION,
+        "backup_path": str(backup_dir.resolve()),
+        "cleaned": cleaned,
+    }
+    store = V2SessionJobStore(settings)
+    try:
+        store.upsert_marker(RESET_MARKER_KEY, marker)
+    finally:
+        store.close()
+    (settings.home / ".state").mkdir(parents=True, exist_ok=True)
+    (settings.home / ".state" / "production_v2_reset.json").write_text(
+        json.dumps(marker, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return {"ok": True, "backup_path": str(backup_dir), "marker": marker}
+
+
+def _daemon_status(settings: Settings) -> dict[str, Any]:
+    try:
+        health = DaemonClient.from_settings(settings, timeout_seconds=1.0).health()
+    except DaemonUnavailable:
+        return {"running": False}
+    except Exception:
+        return {"running": False}
+    return {"running": bool(health.get("ok")), "health": health}
+
+
+def _backup_path(source: Path, target: Path, manifest: dict[str, Any]) -> None:
+    source = source.resolve()
+    if not source.exists():
+        return
+    if source.is_dir():
+        shutil.copytree(source, target)
+    else:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+    manifest["copied"].append({"source": str(source), "target": str(target.resolve())})
+
+
+def _write_manifest(backup_dir: Path, manifest: dict[str, Any]) -> None:
+    (backup_dir / "backup_manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _verify_manifest(backup_dir: Path) -> None:
+    manifest_path = backup_dir / "backup_manifest.json"
+    if not manifest_path.exists():
+        raise RuntimeError("backup_manifest_missing")
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    copied = payload.get("copied")
+    if not isinstance(copied, list):
+        raise RuntimeError("backup_manifest_invalid")
+    for row in copied:
+        if isinstance(row, dict) and row.get("target") and not Path(str(row["target"])).exists():
+            raise RuntimeError(f"backup_target_missing:{row['target']}")
+
+
+def _remove_path(path: Path) -> None:
+    resolved = path.resolve()
+    if resolved.is_dir():
+        shutil.rmtree(resolved)
+    elif resolved.exists():
+        resolved.unlink()
+
+
+def _clean_retrieval_tables(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = connect(db_path)
+    try:
+        for table in ("retrieval_documents_fts", "retrieval_documents", "graph_embeddings"):
+            try:
+                conn.execute(f"DELETE FROM {table}")
+            except Exception:
+                continue
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _faiss_index_dir(settings: Settings) -> Path:
+    return settings.retrieval_db_path.parent / "indexes" / settings.retrieval_db_path.stem

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/reset.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/reset.py
@@ -26,6 +26,8 @@ def reset_production_v2_storage(
 ) -> dict[str, Any]:
     if not backup:
         raise ValueError("--backup is required for v2-reset-production")
+    if not clean_graph or not clean_retrieval:
+        raise ValueError("--clean-graph and --clean-retrieval are required to apply production V2 reset")
     daemon = _daemon_status(settings)
     if daemon.get("running") and not force_if_daemon_running:
         raise RuntimeError("daemon_running: stop amo-daemon or pass --force-if-daemon-running")

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
@@ -27,6 +27,9 @@ from ..retrieval import embed_missing_retrieval_documents
 from ..session_graph_writer import build_compact_session_graph
 from ..session_graph_writer import write_compact_session_graph
 from ..session_runtime import StrictTextEmbedder
+from ..stage4_contract import build_stage4_packet_prompt
+from ..stage4_contract import stage4_contract_hash
+from ..stage4_contract import stage4_output_schema
 from ..work_packets import build_reasoning_work_packets_from_view
 from .constants import GRAPH_SCHEMA_VERSION
 from .constants import PIPELINE_VERSION
@@ -175,13 +178,13 @@ class V2SessionJobRunner:
         )
         results: list[dict[str, Any]] = []
         for packet in packets:
-            prompt = _reasoning_prompt(packet)
+            prompt = build_stage4_packet_prompt(packet)
             try:
                 parsed = client.generate_json(
                     prompt,
                     num_predict=900,
                     timeout_seconds=self.settings.qwen_extract_timeout_seconds,
-                    schema=_reasoning_output_schema(),
+                    schema=stage4_output_schema(),
                 )
             except QwenUnavailable as exc:
                 raise PendingModel("qwen_unavailable", {"packet_id": packet.get("packet_id"), "error": str(exc)}) from exc
@@ -287,9 +290,7 @@ class V2SessionJobRunner:
         return StageResult(output_path=output, diagnostics={"edge_count": len(edges)})
 
     def _stage_kuzu_write(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
-        marker = self.job_store.marker(RESET_MARKER_KEY)
-        if marker is None:
-            raise RuntimeError("production_v2_reset_marker_missing")
+        require_complete_v2_reset_marker(self.job_store.marker(RESET_MARKER_KEY))
         packets = _versioned_items(_read_json(_stage_output(artifact_dir, "work_packets")), job)
         reasoning_nodes = _versioned_items(_read_json(_stage_output(artifact_dir, "reasoning_review")), job)
         hunk_nodes = _versioned_items(_read_json(_stage_output(artifact_dir, "git_hunks")), job)
@@ -339,6 +340,7 @@ class V2SessionJobRunner:
 
     def _stage_retrieval_docs(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
         del artifact_dir
+        require_complete_v2_reset_marker(self.job_store.marker(RESET_MARKER_KEY))
         graph = self.graph_store_factory(self.settings.graph_path)
         conn = connect(self.settings.retrieval_db_path)
         try:
@@ -348,6 +350,8 @@ class V2SessionJobRunner:
                 session_id="",
                 node_limit=self.settings.auto_retrieval_node_limit,
                 max_doc_chars=self.settings.auto_retrieval_max_doc_chars,
+                pipeline_version=PIPELINE_VERSION,
+                graph_schema_version=GRAPH_SCHEMA_VERSION,
             )
             index.replace_documents(docs)
         finally:
@@ -421,6 +425,17 @@ class PendingModel(RuntimeError):
         self.diagnostics = diagnostics or {}
 
 
+def require_complete_v2_reset_marker(marker: dict[str, Any] | None) -> dict[str, Any]:
+    if marker is None:
+        raise RuntimeError("production_v2_reset_marker_missing")
+    cleaned = marker.get("cleaned") if isinstance(marker.get("cleaned"), dict) else {}
+    if marker.get("pipeline_version") != PIPELINE_VERSION or marker.get("graph_schema_version") != GRAPH_SCHEMA_VERSION:
+        raise RuntimeError("production_v2_reset_marker_version_mismatch")
+    if cleaned.get("graph") is not True or cleaned.get("retrieval") is not True:
+        raise RuntimeError("production_v2_reset_marker_incomplete")
+    return marker
+
+
 def file_sha256(path: Path) -> str:
     if not path.exists() or path.is_dir():
         return path_hash(path)
@@ -448,6 +463,7 @@ def stage_config_hash(settings: Settings, *, stage: str) -> str:
         "qwen_endpoint": settings.qwen_endpoint,
         "qwen_runtime": settings.qwen_runtime,
         "qwen_num_ctx": settings.qwen_num_ctx,
+        "stage4_contract_hash": stage4_contract_hash(),
         "embedding_model": settings.embedding_model,
         "vector_backend": settings.vector_backend,
         "retrieval_max_doc_chars": settings.auto_retrieval_max_doc_chars,
@@ -512,48 +528,6 @@ def _first_transcript_path(records: list[dict[str, Any]]) -> str:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return ""
-
-
-def _reasoning_prompt(packet: dict[str, Any]) -> str:
-    return (
-        "/no_think\n"
-        "You are extracting answer-grade reasoning graph nodes from one commit-backed work packet. "
-        "Return JSON only. Do not cite raw transcript ids or tool call ids. "
-        "Every evidence_ref must exist in the packet problem_refs, rationale_refs, or validation_refs. "
-        "Support refs are provenance only. If evidence is insufficient, emit no node or mark needs_review. "
-        "Each node statement must be one factual claim. "
-        "Allowed node_type values: Problem, Decision, Cause, Fix, Constraint, OpenQuestion. "
-        "Output shape: {\"packet_id\":\"...\",\"commit_sha\":\"...\",\"nodes\":[{\"node_type\":\"Decision\",\"subject\":\"...\","
-        "\"statement\":\"...\",\"reason\":\"...\",\"confidence\":0.0,\"evidence_refs\":[\"E00001\"],\"status\":\"accepted\"}]}.\n"
-        f"Packet:\n{json.dumps(packet, ensure_ascii=False, indent=2)}"
-    )
-
-
-def _reasoning_output_schema() -> dict[str, Any]:
-    return {
-        "type": "object",
-        "properties": {
-            "packet_id": {"type": "string"},
-            "commit_sha": {"type": "string"},
-            "nodes": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "node_type": {"type": "string"},
-                        "subject": {"type": "string"},
-                        "statement": {"type": "string"},
-                        "reason": {"type": "string"},
-                        "confidence": {"type": "number"},
-                        "evidence_refs": {"type": "array", "items": {"type": "string"}},
-                        "status": {"type": "string"},
-                    },
-                    "required": ["node_type", "subject", "statement", "reason", "confidence", "evidence_refs", "status"],
-                },
-            },
-        },
-        "required": ["packet_id", "commit_sha", "nodes"],
-    }
 
 
 def _packet_commit_sha(packet: dict[str, Any]) -> str:

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
@@ -1,0 +1,813 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from ...core.config import Settings
+from ...core.db import connect
+from ...graph.store import GraphEdge
+from ...graph.store import GraphNode
+from ...graph.store import GraphStore
+from ...graph.store import KuzuGraphStore
+from ...llm.qwen import OllamaQwenClient
+from ...llm.qwen import QwenUnavailable
+from ..code_analysis import extract_code_nodes_from_commit
+from ..embedding_store import GraphEmbeddingStore
+from ..evidence_view import build_reasoning_evidence_view
+from ..evidence_view import write_reasoning_evidence_view_artifacts
+from ..reasoning_extraction import review_reasoning_extraction_results
+from ..retrieval import RETRIEVAL_EMBEDDING_KIND
+from ..retrieval import RetrievalIndexStore
+from ..retrieval import build_retrieval_documents_from_graph
+from ..retrieval import embed_missing_retrieval_documents
+from ..session_graph_writer import build_compact_session_graph
+from ..session_graph_writer import write_compact_session_graph
+from ..session_runtime import StrictTextEmbedder
+from ..work_packets import build_reasoning_work_packets_from_view
+from .constants import GRAPH_SCHEMA_VERSION
+from .constants import PIPELINE_VERSION
+from .constants import RESET_MARKER_KEY
+from .constants import V2_STAGES
+from .store import V2SessionJobStore
+
+
+StageFn = Callable[[dict[str, Any], Path], dict[str, Any]]
+
+
+@dataclass(slots=True, frozen=True)
+class StageResult:
+    output_path: Path
+    diagnostics: dict[str, Any]
+
+
+class V2SessionJobRunner:
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        job_store: V2SessionJobStore | None = None,
+        graph_store_factory: Callable[[Path], GraphStore] = KuzuGraphStore,
+    ) -> None:
+        self.settings = settings
+        self.job_store = job_store or V2SessionJobStore(settings)
+        self.graph_store_factory = graph_store_factory
+
+    def close(self) -> None:
+        self.job_store.close()
+
+    def run_next(self, *, lease_seconds: int = 300) -> dict[str, Any]:
+        owner = f"v2-runner:{uuid.uuid4().hex}"
+        job = self.job_store.acquire_next(owner=owner, lease_seconds=lease_seconds)
+        if job is None:
+            return {"ok": True, "ran": False, "reason": "no_pending_job"}
+        job_id = str(job["job_id"])
+        stage = _current_stage(job)
+        artifact_dir = Path(str(job["artifact_dir"]))
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            result = self._run_stage(job, stage, artifact_dir)
+        except PendingModel as exc:
+            self.job_store.set_pending_model(job_id=job_id, stage=stage, reason=exc.reason, diagnostics=exc.diagnostics)
+            return {"ok": True, "ran": True, "job_id": job_id, "stage": stage, "status": "pending_model", "reason": exc.reason}
+        except Exception as exc:
+            self.job_store.fail_stage(
+                job_id=job_id,
+                stage=stage,
+                reason=f"{type(exc).__name__}: {exc}",
+                diagnostics={"error_type": type(exc).__name__, "error": str(exc)},
+            )
+            return {"ok": False, "ran": True, "job_id": job_id, "stage": stage, "status": "failed", "error": str(exc)}
+        self.job_store.complete_stage(
+            job_id=job_id,
+            stage=stage,
+            output_artifact=str(result.output_path),
+            output_hash=file_sha256(result.output_path),
+            diagnostics=result.diagnostics,
+        )
+        self.job_store.release_lock(job_id=job_id)
+        updated = self.job_store.get_job(job_id) or {}
+        return {
+            "ok": True,
+            "ran": True,
+            "job_id": job_id,
+            "stage": stage,
+            "status": updated.get("status"),
+            "next_stage": updated.get("current_stage"),
+            "output_artifact": str(result.output_path),
+        }
+
+    def _run_stage(self, job: dict[str, Any], stage: str, artifact_dir: Path) -> StageResult:
+        stage_dir = artifact_dir / stage
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        input_artifact = self._stage_input_artifact(job, stage, artifact_dir)
+        input_hash = path_hash(input_artifact)
+        config_hash = stage_config_hash(self.settings, stage=stage)
+        existing = self.job_store.stage_row(job_id=str(job["job_id"]), stage=stage)
+        output = Path(str(existing.get("output_artifact") or "")) if existing else Path()
+        if (
+            existing
+            and existing.get("status") == "complete"
+            and existing.get("input_hash") == input_hash
+            and existing.get("stage_config_hash") == config_hash
+            and output.exists()
+        ):
+            return StageResult(output_path=output, diagnostics={"reused": True})
+        self.job_store.start_stage(
+            job_id=str(job["job_id"]),
+            stage=stage,
+            input_artifact=str(input_artifact),
+            input_hash=input_hash,
+            stage_config_hash=config_hash,
+        )
+        return getattr(self, f"_stage_{stage}")(job, artifact_dir, stage_dir)
+
+    def _stage_input_artifact(self, job: dict[str, Any], stage: str, artifact_dir: Path) -> Path:
+        if stage == V2_STAGES[0]:
+            return self.settings.evidence_dir
+        previous = V2_STAGES[V2_STAGES.index(stage) - 1]
+        row = self.job_store.stage_row(job_id=str(job["job_id"]), stage=previous)
+        if row is None or not row.get("output_artifact"):
+            raise RuntimeError(f"missing_previous_stage:{previous}")
+        return Path(str(row["output_artifact"]))
+
+    def _stage_evidence_view(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        session_jsonl = stage_dir / "session_raw_evidence.jsonl"
+        records = _session_records(self.settings.evidence_dir, str(job["session_id"]))
+        if not records:
+            raise RuntimeError(f"no_raw_evidence_for_session:{job['session_id']}")
+        _write_jsonl(session_jsonl, records)
+        transcript_path = _first_transcript_path(records)
+        build = build_reasoning_evidence_view(
+            session_jsonl,
+            transcript_path=Path(transcript_path) if transcript_path else None,
+            repo_root=Path(str(job.get("repo_path") or ".")).resolve(),
+        )
+        write_reasoning_evidence_view_artifacts(build, stage_dir)
+        output = stage_dir / "reasoning_evidence_view.json"
+        return StageResult(
+            output_path=output,
+            diagnostics={"raw_record_count": len(records), "quality": build.quality},
+        )
+
+    def _stage_work_packets(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        del artifact_dir
+        view = _read_json(self._stage_input_artifact(job, "work_packets", Path(str(job["artifact_dir"]))))
+        build = build_reasoning_work_packets_from_view(view)
+        output = stage_dir / "reasoning_work_packets.json"
+        output.write_text(json.dumps(list(build.packets), indent=2, ensure_ascii=False), encoding="utf-8")
+        (stage_dir / "packet_quality_inventory.json").write_text(json.dumps(build.quality, indent=2, ensure_ascii=False), encoding="utf-8")
+        (stage_dir / "quarantined_commits.json").write_text(json.dumps(list(build.quarantined_commits), indent=2), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"quality": build.quality})
+
+    def _stage_qwen_reasoning(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        packets = _read_json(self._stage_input_artifact(job, "qwen_reasoning", artifact_dir))
+        if not isinstance(packets, list):
+            raise RuntimeError("work_packets_output_must_be_list")
+        client = OllamaQwenClient(
+            endpoint=self.settings.qwen_endpoint,
+            model=self.settings.qwen_model,
+            timeout_seconds=self.settings.qwen_extract_timeout_seconds,
+            num_ctx=self.settings.qwen_num_ctx,
+        )
+        results: list[dict[str, Any]] = []
+        for packet in packets:
+            prompt = _reasoning_prompt(packet)
+            try:
+                parsed = client.generate_json(
+                    prompt,
+                    num_predict=900,
+                    timeout_seconds=self.settings.qwen_extract_timeout_seconds,
+                    schema=_reasoning_output_schema(),
+                )
+            except QwenUnavailable as exc:
+                raise PendingModel("qwen_unavailable", {"packet_id": packet.get("packet_id"), "error": str(exc)}) from exc
+            results.append(
+                {
+                    "packet_id": packet.get("packet_id"),
+                    "commit_sha": _packet_commit_sha(packet),
+                    "model": self.settings.qwen_model,
+                    "runtime": self.settings.qwen_runtime,
+                    "parsed_output": parsed,
+                }
+            )
+        output = stage_dir / "stage4_packet_reasoning_results.json"
+        output.write_text(json.dumps(results, indent=2, ensure_ascii=False), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"packet_count": len(packets), "result_count": len(results)})
+
+    def _stage_reasoning_review(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        packets = _read_json(_stage_output(artifact_dir, "work_packets"))
+        results = _read_json(self._stage_input_artifact(job, "reasoning_review", artifact_dir))
+        review = review_reasoning_extraction_results(
+            packets=packets if isinstance(packets, list) else [],
+            results=results if isinstance(results, list) else [],
+            source_name="v2_session_job",
+        )
+        (stage_dir / "stage4_reasoning_review.json").write_text(json.dumps(review.as_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+        output = stage_dir / "accepted_reasoning_nodes.json"
+        output.write_text(json.dumps(list(review.accepted_nodes), indent=2, ensure_ascii=False), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"summary": review.summary})
+
+    def _stage_git_hunks(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        packets = _read_json(_stage_output(artifact_dir, "work_packets"))
+        repo_root = Path(str(job.get("repo_path") or ".")).resolve()
+        hunks: list[dict[str, Any]] = []
+        errors: list[dict[str, str]] = []
+        for packet in packets if isinstance(packets, list) else []:
+            try:
+                packet_hunks, _nodes = extract_code_nodes_from_commit(
+                    repo_root=repo_root,
+                    commit=_packet_full_sha(packet),
+                    session_id=str(job["session_id"]),
+                    extraction_run_id=str(job["job_id"]),
+                    evidence_ids=tuple(_packet_evidence_refs(packet)),
+                )
+            except Exception as exc:
+                errors.append({"packet_id": str(packet.get("packet_id") or ""), "error": str(exc)})
+                continue
+            for index, hunk in enumerate(packet_hunks, start=1):
+                hunks.append(_hunk_record(packet, hunk.as_dict(), index=index))
+        output = stage_dir / "code_hunks.json"
+        output.write_text(json.dumps(hunks, indent=2, ensure_ascii=False), encoding="utf-8")
+        (stage_dir / "git_hunk_errors.json").write_text(json.dumps(errors, indent=2, ensure_ascii=False), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"hunk_count": len(hunks), "error_count": len(errors), "errors": errors[:20]})
+
+    def _stage_ast_code_nodes(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        packets = _read_json(_stage_output(artifact_dir, "work_packets"))
+        hunk_records = _read_json(_stage_output(artifact_dir, "git_hunks"))
+        hunk_id_map = {str(item.get("original_hunk_id") or ""): str(item.get("hunk_id") or "") for item in hunk_records if isinstance(item, dict)}
+        repo_root = Path(str(job.get("repo_path") or ".")).resolve()
+        code_nodes: list[dict[str, Any]] = []
+        errors: list[dict[str, str]] = []
+        for packet in packets if isinstance(packets, list) else []:
+            try:
+                _hunks, nodes = extract_code_nodes_from_commit(
+                    repo_root=repo_root,
+                    commit=_packet_full_sha(packet),
+                    session_id=str(job["session_id"]),
+                    extraction_run_id=str(job["job_id"]),
+                    evidence_ids=tuple(_packet_evidence_refs(packet)),
+                )
+            except Exception as exc:
+                errors.append({"packet_id": str(packet.get("packet_id") or ""), "error": str(exc)})
+                continue
+            for node in nodes:
+                code_nodes.append(_code_node_record(packet, node.as_dict(), hunk_id_map=hunk_id_map))
+        output = stage_dir / "code_nodes.json"
+        output.write_text(json.dumps(code_nodes, indent=2, ensure_ascii=False), encoding="utf-8")
+        (stage_dir / "ast_code_node_errors.json").write_text(json.dumps(errors, indent=2, ensure_ascii=False), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"code_node_count": len(code_nodes), "error_count": len(errors), "errors": errors[:20]})
+
+    def _stage_symbol_versions(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        del job
+        code_nodes = _read_json(_stage_output(artifact_dir, "ast_code_nodes"))
+        symbols, versions, edges = _symbol_versions(code_nodes if isinstance(code_nodes, list) else [])
+        output = stage_dir / "symbol_versions.json"
+        output.write_text(json.dumps({"symbols": symbols, "code_versions": versions, "edges": edges}, indent=2, ensure_ascii=False), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"symbol_count": len(symbols), "code_version_count": len(versions), "edge_count": len(edges)})
+
+    def _stage_reasoning_code_links(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        packets = _read_json(_stage_output(artifact_dir, "work_packets"))
+        reasoning_nodes = _read_json(_stage_output(artifact_dir, "reasoning_review"))
+        code_hunks = _read_json(_stage_output(artifact_dir, "git_hunks"))
+        code_nodes = _read_json(_stage_output(artifact_dir, "ast_code_nodes"))
+        symbol_versions = _read_json(_stage_output(artifact_dir, "symbol_versions"))
+        edges = _relationship_edges(
+            packets if isinstance(packets, list) else [],
+            reasoning_nodes if isinstance(reasoning_nodes, list) else [],
+            code_hunks if isinstance(code_hunks, list) else [],
+            code_nodes if isinstance(code_nodes, list) else [],
+            symbol_versions if isinstance(symbol_versions, dict) else {},
+        )
+        output = stage_dir / "graph_edges.json"
+        output.write_text(json.dumps(edges, indent=2, ensure_ascii=False), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"edge_count": len(edges)})
+
+    def _stage_kuzu_write(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        marker = self.job_store.marker(RESET_MARKER_KEY)
+        if marker is None:
+            raise RuntimeError("production_v2_reset_marker_missing")
+        packets = _versioned_items(_read_json(_stage_output(artifact_dir, "work_packets")), job)
+        reasoning_nodes = _versioned_items(_read_json(_stage_output(artifact_dir, "reasoning_review")), job)
+        hunk_nodes = _versioned_items(_read_json(_stage_output(artifact_dir, "git_hunks")), job)
+        code_nodes = _versioned_items(_read_json(_stage_output(artifact_dir, "ast_code_nodes")), job)
+        symbol_versions = _read_json(_stage_output(artifact_dir, "symbol_versions"))
+        symbols = _versioned_items(symbol_versions.get("symbols", []) if isinstance(symbol_versions, dict) else [], job)
+        versions = _versioned_items(symbol_versions.get("code_versions", []) if isinstance(symbol_versions, dict) else [], job)
+        raw_edges = _read_json(_stage_output(artifact_dir, "reasoning_code_links"))
+        evidence_refs = _versioned_items(_evidence_ref_nodes(packets), job)
+        commits = _versioned_items(_commit_nodes(packets), job)
+        graph = build_compact_session_graph(
+            packets=packets,
+            reasoning_nodes=reasoning_nodes,
+            evidence_refs=evidence_refs,
+            commit_nodes=commits,
+            code_hunks=hunk_nodes,
+            code_nodes=code_nodes,
+            symbols=symbols,
+            code_versions=versions,
+            raw_edges=raw_edges if isinstance(raw_edges, list) else [],
+        )
+        manifest = stage_dir / "compact_graph_manifest.json"
+        manifest.write_text(json.dumps(graph.as_dict(), indent=2, ensure_ascii=False), encoding="utf-8")
+        artifact_graph_path = stage_dir / "session_graph.kuzu"
+        write_compact_session_graph(graph_path=artifact_graph_path, nodes=list(graph.nodes), edges=list(graph.edges), force=True)
+        central = self.graph_store_factory(self.settings.graph_path)
+        try:
+            central.init_schema()
+            _upsert_compact_graph(central, graph.nodes, graph.edges, job=job)
+        finally:
+            central.close()
+        output = stage_dir / "kuzu_write_result.json"
+        output.write_text(
+            json.dumps(
+                {
+                    "ok": graph.inventory.get("unresolved_edge_count") == 0,
+                    "graph_path": str(self.settings.graph_path),
+                    "artifact_graph_path": str(artifact_graph_path),
+                    "inventory": graph.inventory,
+                },
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        return StageResult(output_path=output, diagnostics=graph.inventory)
+
+    def _stage_retrieval_docs(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        del artifact_dir
+        graph = self.graph_store_factory(self.settings.graph_path)
+        conn = connect(self.settings.retrieval_db_path)
+        try:
+            index = RetrievalIndexStore(conn)
+            docs = build_retrieval_documents_from_graph(
+                graph,
+                session_id="",
+                node_limit=self.settings.auto_retrieval_node_limit,
+                max_doc_chars=self.settings.auto_retrieval_max_doc_chars,
+            )
+            index.replace_documents(docs)
+        finally:
+            graph.close()
+            conn.close()
+        output = stage_dir / "retrieval_docs_result.json"
+        output.write_text(json.dumps({"doc_count": len(docs)}, indent=2), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics={"doc_count": len(docs)})
+
+    def _stage_embeddings(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        del artifact_dir
+        conn = connect(self.settings.retrieval_db_path)
+        try:
+            index = RetrievalIndexStore(conn)
+            embedding_store = GraphEmbeddingStore(conn, db_path=self.settings.retrieval_db_path)
+            try:
+                embedder = StrictTextEmbedder(self.settings.embedding_model)
+            except RuntimeError as exc:
+                raise PendingModel("embedding_model_unavailable", {"error": str(exc), "model": self.settings.embedding_model}) from exc
+            result = embed_missing_retrieval_documents(
+                index_store=index,
+                embedding_store=embedding_store,
+                embedder=embedder,
+                model=self.settings.embedding_model,
+                graph_scope="v2",
+                session_id=str(job["session_id"]),
+                extraction_run_id=str(job["job_id"]),
+                limit=self.settings.auto_embedding_batch_size,
+                embedding_kind=RETRIEVAL_EMBEDDING_KIND,
+            )
+        finally:
+            conn.close()
+        output = stage_dir / "embeddings_result.json"
+        output.write_text(json.dumps(result.as_dict(), indent=2), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics=result.as_dict())
+
+    def _stage_faiss(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        del job, artifact_dir
+        conn = connect(self.settings.retrieval_db_path)
+        try:
+            embedding_store = GraphEmbeddingStore(conn, db_path=self.settings.retrieval_db_path)
+            result = embedding_store.build_faiss_cache(
+                embedding_kind=RETRIEVAL_EMBEDDING_KIND,
+                model=self.settings.embedding_model,
+                graph_scope="v2",
+            )
+        finally:
+            conn.close()
+        output = stage_dir / "faiss_result.json"
+        output.write_text(json.dumps(result.as_dict(), indent=2), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics=result.as_dict())
+
+    def _stage_quality_eval(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
+        del job
+        kuzu_result = _read_json(_stage_output(artifact_dir, "kuzu_write"))
+        retrieval_result = _read_json(_stage_output(artifact_dir, "retrieval_docs"))
+        output = stage_dir / "quality_eval.json"
+        payload = {
+            "ok": True,
+            "kuzu": kuzu_result,
+            "retrieval_docs": retrieval_result,
+        }
+        output.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        return StageResult(output_path=output, diagnostics=payload)
+
+
+class PendingModel(RuntimeError):
+    def __init__(self, reason: str, diagnostics: dict[str, Any] | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.diagnostics = diagnostics or {}
+
+
+def file_sha256(path: Path) -> str:
+    if not path.exists() or path.is_dir():
+        return path_hash(path)
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def path_hash(path: Path) -> str:
+    if path.is_file():
+        return file_sha256(path)
+    if path.is_dir():
+        rows: list[str] = []
+        for child in sorted(path.rglob("*")):
+            if child.is_file():
+                rows.append(f"{child.relative_to(path)}:{hashlib.sha256(child.read_bytes()).hexdigest()}")
+        return hashlib.sha256("\n".join(rows).encode("utf-8")).hexdigest()
+    return ""
+
+
+def stage_config_hash(settings: Settings, *, stage: str) -> str:
+    payload = {
+        "stage": stage,
+        "pipeline_version": PIPELINE_VERSION,
+        "graph_schema_version": GRAPH_SCHEMA_VERSION,
+        "qwen_model": settings.qwen_model,
+        "qwen_endpoint": settings.qwen_endpoint,
+        "qwen_runtime": settings.qwen_runtime,
+        "qwen_num_ctx": settings.qwen_num_ctx,
+        "embedding_model": settings.embedding_model,
+        "vector_backend": settings.vector_backend,
+        "retrieval_max_doc_chars": settings.auto_retrieval_max_doc_chars,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def _current_stage(job: dict[str, Any]) -> str:
+    stage = str(job.get("current_stage") or "")
+    if stage in V2_STAGES:
+        return stage
+    return V2_STAGES[0]
+
+
+def _stage_output(artifact_dir: Path, stage: str) -> Path:
+    candidates = {
+        "evidence_view": "reasoning_evidence_view.json",
+        "work_packets": "reasoning_work_packets.json",
+        "qwen_reasoning": "stage4_packet_reasoning_results.json",
+        "reasoning_review": "accepted_reasoning_nodes.json",
+        "git_hunks": "code_hunks.json",
+        "ast_code_nodes": "code_nodes.json",
+        "symbol_versions": "symbol_versions.json",
+        "reasoning_code_links": "graph_edges.json",
+        "kuzu_write": "kuzu_write_result.json",
+        "retrieval_docs": "retrieval_docs_result.json",
+        "embeddings": "embeddings_result.json",
+        "faiss": "faiss_result.json",
+        "quality_eval": "quality_eval.json",
+    }
+    return artifact_dir / stage / candidates[stage]
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.write_text("".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in records), encoding="utf-8")
+
+
+def _session_records(evidence_dir: Path, session_id: str) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in sorted(evidence_dir.glob("*.jsonl")):
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if str(record.get("session_id") or "") == session_id:
+                    records.append(record)
+    return records
+
+
+def _first_transcript_path(records: list[dict[str, Any]]) -> str:
+    for record in records:
+        payload = record.get("payload") if isinstance(record.get("payload"), dict) else {}
+        value = payload.get("transcript_path") or record.get("transcript_path")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _reasoning_prompt(packet: dict[str, Any]) -> str:
+    return (
+        "/no_think\n"
+        "You are extracting answer-grade reasoning graph nodes from one commit-backed work packet. "
+        "Return JSON only. Do not cite raw transcript ids or tool call ids. "
+        "Every evidence_ref must exist in the packet problem_refs, rationale_refs, or validation_refs. "
+        "Support refs are provenance only. If evidence is insufficient, emit no node or mark needs_review. "
+        "Each node statement must be one factual claim. "
+        "Allowed node_type values: Problem, Decision, Cause, Fix, Constraint, OpenQuestion. "
+        "Output shape: {\"packet_id\":\"...\",\"commit_sha\":\"...\",\"nodes\":[{\"node_type\":\"Decision\",\"subject\":\"...\","
+        "\"statement\":\"...\",\"reason\":\"...\",\"confidence\":0.0,\"evidence_refs\":[\"E00001\"],\"status\":\"accepted\"}]}.\n"
+        f"Packet:\n{json.dumps(packet, ensure_ascii=False, indent=2)}"
+    )
+
+
+def _reasoning_output_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "packet_id": {"type": "string"},
+            "commit_sha": {"type": "string"},
+            "nodes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "node_type": {"type": "string"},
+                        "subject": {"type": "string"},
+                        "statement": {"type": "string"},
+                        "reason": {"type": "string"},
+                        "confidence": {"type": "number"},
+                        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+                        "status": {"type": "string"},
+                    },
+                    "required": ["node_type", "subject", "statement", "reason", "confidence", "evidence_refs", "status"],
+                },
+            },
+        },
+        "required": ["packet_id", "commit_sha", "nodes"],
+    }
+
+
+def _packet_commit_sha(packet: dict[str, Any]) -> str:
+    commit = packet.get("commit") if isinstance(packet.get("commit"), dict) else {}
+    return str(commit.get("short_sha") or "")
+
+
+def _packet_full_sha(packet: dict[str, Any]) -> str:
+    commit = packet.get("commit") if isinstance(packet.get("commit"), dict) else {}
+    return str(commit.get("full_sha") or commit.get("short_sha") or "")
+
+
+def _packet_evidence_refs(packet: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    for key in ("problem_refs", "rationale_refs", "validation_refs"):
+        for item in packet.get(key, []) if isinstance(packet.get(key), list) else []:
+            if isinstance(item, dict) and item.get("ref"):
+                refs.append(str(item["ref"]))
+    return list(dict.fromkeys(refs))
+
+
+def _hunk_record(packet: dict[str, Any], hunk: dict[str, Any], *, index: int) -> dict[str, Any]:
+    commit = packet.get("commit") if isinstance(packet.get("commit"), dict) else {}
+    patch = str(hunk.get("patch") or "")
+    return {
+        "hunk_id": f"hunk:{packet.get('packet_id')}:{commit.get('short_sha')}:{index:04d}",
+        "original_hunk_id": hunk.get("id"),
+        "packet_id": packet.get("packet_id"),
+        "commit_sha": commit.get("short_sha"),
+        "full_sha": commit.get("full_sha"),
+        "commit_message": commit.get("message"),
+        "path": hunk.get("file_path"),
+        "new_start": hunk.get("new_start"),
+        "new_count": hunk.get("new_count"),
+        "old_start": hunk.get("old_start"),
+        "old_count": hunk.get("old_count"),
+        "header": patch.splitlines()[0] if patch else "",
+        "hunk_lines": patch.splitlines()[1:],
+        "status": "M",
+    }
+
+
+def _code_node_record(packet: dict[str, Any], node: dict[str, Any], *, hunk_id_map: dict[str, str]) -> dict[str, Any]:
+    commit = packet.get("commit") if isinstance(packet.get("commit"), dict) else {}
+    metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+    hunk_id = hunk_id_map.get(str(metadata.get("hunk_id") or ""), str(metadata.get("hunk_id") or ""))
+    qualified_name = str(metadata.get("symbol_name") or metadata.get("structural_id") or node.get("ast_type") or "")
+    content = str(node.get("content") or "")
+    digest = hashlib.sha256(f"{packet.get('packet_id')}|{commit.get('short_sha')}|{node.get('id')}".encode("utf-8")).hexdigest()[:20]
+    return {
+        "code_node_id": f"code:{digest}",
+        "packet_id": packet.get("packet_id"),
+        "commit_sha": commit.get("short_sha"),
+        "full_sha": commit.get("full_sha"),
+        "commit_message": commit.get("message"),
+        "path": node.get("file_path"),
+        "node_source": node.get("ast_status"),
+        "symbol_kind": metadata.get("symbol_kind") or node.get("ast_type"),
+        "qualified_name": qualified_name,
+        "line_start": node.get("line_start"),
+        "line_end": node.get("line_end"),
+        "content_hash": hashlib.sha256(content.encode("utf-8")).hexdigest()[:24],
+        "text_excerpt": content[:1800],
+        "hunk_ids": [hunk_id] if hunk_id else [],
+        "mapped_hunk_count": 1 if hunk_id else 0,
+    }
+
+
+def _symbol_versions(code_nodes: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    by_key: dict[str, list[dict[str, Any]]] = {}
+    for node in code_nodes:
+        key = f"{node.get('path')}::{node.get('qualified_name')}"
+        by_key.setdefault(key, []).append(node)
+    symbols: list[dict[str, Any]] = []
+    versions: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+    for key, nodes in sorted(by_key.items()):
+        symbol_id = f"symbol:{hashlib.sha256(key.encode('utf-8')).hexdigest()[:20]}"
+        nodes = sorted(nodes, key=lambda item: (str(item.get("commit_sha") or ""), str(item.get("code_node_id") or "")))
+        symbols.append(
+            {
+                "symbol_id": symbol_id,
+                "symbol_key": key,
+                "qualified_name": str(nodes[-1].get("qualified_name") or ""),
+                "symbol_kind": str(nodes[-1].get("symbol_kind") or ""),
+                "first_packet_id": str(nodes[0].get("packet_id") or ""),
+                "latest_packet_id": str(nodes[-1].get("packet_id") or ""),
+                "first_commit_sha": str(nodes[0].get("commit_sha") or ""),
+                "latest_commit_sha": str(nodes[-1].get("commit_sha") or ""),
+                "version_count": len(nodes),
+            }
+        )
+        previous_version_id = ""
+        for index, node in enumerate(nodes, start=1):
+            version_seed = f"{symbol_id}|{node.get('code_node_id')}"
+            version_id = f"version:{hashlib.sha256(version_seed.encode('utf-8')).hexdigest()[:20]}"
+            versions.append(
+                {
+                    "version_id": version_id,
+                    "symbol_id": symbol_id,
+                    "code_node_id": node.get("code_node_id"),
+                    "packet_id": node.get("packet_id"),
+                    "commit_sha": node.get("commit_sha"),
+                    "path": node.get("path"),
+                    "qualified_name": node.get("qualified_name"),
+                    "symbol_kind": node.get("symbol_kind"),
+                    "version_index": index,
+                }
+            )
+            edges.append({"from_id": symbol_id, "to_id": version_id, "kind": "SYMBOL_HAS_VERSION"})
+            edges.append({"from_id": version_id, "to_id": symbol_id, "kind": "CODE_VERSION_OF_SYMBOL"})
+            edges.append({"from_id": version_id, "to_id": str(node.get("code_node_id") or ""), "kind": "VERSION_CONTAINS_CODE_NODE"})
+            edges.append({"from_id": f"commit:{node.get('commit_sha')}", "to_id": version_id, "kind": "COMMIT_HAS_CODE_VERSION"})
+            if previous_version_id:
+                edges.append({"from_id": previous_version_id, "to_id": version_id, "kind": "VERSION_SUPERSEDED_BY"})
+            previous_version_id = version_id
+    return symbols, versions, edges
+
+
+def _relationship_edges(
+    packets: list[dict[str, Any]],
+    reasoning_nodes: list[dict[str, Any]],
+    code_hunks: list[dict[str, Any]],
+    code_nodes: list[dict[str, Any]],
+    symbol_versions: dict[str, Any],
+) -> list[dict[str, Any]]:
+    edges: list[dict[str, Any]] = []
+    packet_by_id = {str(packet.get("packet_id") or ""): packet for packet in packets}
+    hunks_by_packet: dict[str, list[dict[str, Any]]] = {}
+    nodes_by_packet: dict[str, list[dict[str, Any]]] = {}
+    for hunk in code_hunks:
+        hunks_by_packet.setdefault(str(hunk.get("packet_id") or ""), []).append(hunk)
+    for node in code_nodes:
+        nodes_by_packet.setdefault(str(node.get("packet_id") or ""), []).append(node)
+    symbols = symbol_versions.get("symbols", []) if isinstance(symbol_versions.get("symbols"), list) else []
+    versions = symbol_versions.get("code_versions", []) if isinstance(symbol_versions.get("code_versions"), list) else []
+    for packet in packets:
+        packet_id = str(packet.get("packet_id") or "")
+        commit_id = f"commit:{_packet_commit_sha(packet)}"
+        for hunk in hunks_by_packet.get(packet_id, []):
+            edges.append({"from_id": commit_id, "to_id": hunk.get("hunk_id"), "kind": "COMMIT_PRODUCED_HUNK"})
+    for node in code_nodes:
+        for hunk_id in node.get("hunk_ids", []) if isinstance(node.get("hunk_ids"), list) else []:
+            edges.append({"from_id": hunk_id, "to_id": node.get("code_node_id"), "kind": "HUNK_MAPS_TO_CODE_NODE"})
+    for node in reasoning_nodes:
+        packet_id = str(node.get("source_packet_id") or "")
+        node_id = str(node.get("reasoning_node_id") or node.get("node_id") or "")
+        packet = packet_by_id.get(packet_id, {})
+        edges.append({"from_id": node_id, "to_id": packet_id, "kind": "REASON_NODE_IN_PACKET"})
+        edges.append({"from_id": node_id, "to_id": f"commit:{_packet_commit_sha(packet)}", "kind": "REASON_NODE_EXPLAINS_COMMIT"})
+        for ref in node.get("evidence_refs", []) if isinstance(node.get("evidence_refs"), list) else []:
+            edges.append({"from_id": node_id, "to_id": str(ref), "kind": "REASON_NODE_EVIDENCED_BY"})
+        for hunk in hunks_by_packet.get(packet_id, [])[:12]:
+            edges.append({"from_id": node_id, "to_id": hunk.get("hunk_id"), "kind": "REASON_NODE_LINKED_TO_HUNK"})
+        for code_node in nodes_by_packet.get(packet_id, [])[:12]:
+            edges.append({"from_id": node_id, "to_id": code_node.get("code_node_id"), "kind": "REASON_NODE_LINKED_TO_CODE_NODE"})
+    for symbol in symbols:
+        for node in reasoning_nodes:
+            if str(node.get("source_packet_id") or "") == str(symbol.get("latest_packet_id") or symbol.get("first_packet_id") or ""):
+                edges.append({"from_id": node.get("node_id"), "to_id": symbol.get("symbol_id"), "kind": "REASON_NODE_LINKED_TO_SYMBOL"})
+    for version in versions:
+        for node in reasoning_nodes:
+            if str(node.get("source_packet_id") or "") == str(version.get("packet_id") or ""):
+                edges.append({"from_id": node.get("node_id"), "to_id": version.get("version_id"), "kind": "REASON_NODE_LINKED_TO_CODE_VERSION"})
+    edges.extend(symbol_versions.get("edges", []) if isinstance(symbol_versions.get("edges"), list) else [])
+    return [edge for edge in edges if edge.get("from_id") and edge.get("to_id") and edge.get("kind")]
+
+
+def _versioned_items(value: Any, job: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    out = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        out.append({**item, "pipeline_version": PIPELINE_VERSION, "graph_schema_version": GRAPH_SCHEMA_VERSION, "session_id": job.get("session_id"), "job_id": job.get("job_id")})
+    return out
+
+
+def _evidence_ref_nodes(packets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    refs: dict[str, dict[str, Any]] = {}
+    for packet in packets:
+        for group, kind in (("problem_refs", "problem"), ("rationale_refs", "rationale"), ("validation_refs", "validation")):
+            for ref in packet.get(group, []) if isinstance(packet.get(group), list) else []:
+                if not isinstance(ref, dict) or not ref.get("ref"):
+                    continue
+                refs[str(ref["ref"])] = {
+                    "evidence_ref_id": ref["ref"],
+                    "ref": ref["ref"],
+                    "packet_id": packet.get("packet_id"),
+                    "commit_sha": _packet_commit_sha(packet),
+                    "evidence_kind": kind,
+                    "excerpt": ref.get("excerpt") or ref.get("output_preview") or ref.get("command") or "",
+                }
+    return list(refs.values())
+
+
+def _commit_nodes(packets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    nodes = []
+    for packet in packets:
+        commit = packet.get("commit") if isinstance(packet.get("commit"), dict) else {}
+        nodes.append(
+            {
+                "commit_node_id": f"commit:{commit.get('short_sha')}",
+                "packet_id": packet.get("packet_id"),
+                "short_sha": commit.get("short_sha"),
+                "full_sha": commit.get("full_sha"),
+                "message": commit.get("message"),
+                "changed_files_count": commit.get("changed_files_count"),
+            }
+        )
+    return nodes
+
+
+def _upsert_compact_graph(store: GraphStore, nodes: tuple[dict[str, Any], ...], edges: tuple[dict[str, Any], ...], *, job: dict[str, Any]) -> None:
+    namespace = str(job["job_id"]).rsplit(":", 1)[-1][:12]
+    id_map = {str(node["id"]): f"{namespace}:{node['id']}" for node in nodes}
+    for node in nodes:
+        metadata = json.loads(str(node.get("properties_json") or "{}"))
+        metadata.update(
+            {
+                "original_node_id": node.get("id"),
+                "pipeline_version": PIPELINE_VERSION,
+                "graph_schema_version": GRAPH_SCHEMA_VERSION,
+                "job_id": job.get("job_id"),
+            }
+        )
+        store.upsert_node(
+            GraphNode(
+                id=id_map[str(node["id"])],
+                kind=str(node.get("kind") or ""),
+                label=str(node.get("label") or ""),
+                summary=str(node.get("summary") or ""),
+                status="active",
+                scope="central",
+                session_id=str(job.get("session_id") or ""),
+                source_app=str(job.get("source_app") or ""),
+                commit_id=str(node.get("commit_sha") or ""),
+                metadata=metadata,
+            )
+        )
+    for index, edge in enumerate(edges):
+        source = id_map.get(str(edge.get("from_id") or ""))
+        target = id_map.get(str(edge.get("to_id") or ""))
+        if not source or not target:
+            continue
+        metadata = json.loads(str(edge.get("properties_json") or "{}"))
+        store.upsert_edge(
+            GraphEdge(
+                id=f"v2edge:{namespace}:{index:06d}",
+                source_id=source,
+                target_id=target,
+                kind=str(edge.get("kind") or ""),
+                confidence=1.0,
+                metadata=metadata,
+            )
+        )

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/store.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/store.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from ...core.config import Settings
+from ...core.db import connect
+from ...core.db import init_schema
+from .constants import GRAPH_SCHEMA_VERSION
+from .constants import PIPELINE_VERSION
+from .constants import RESET_MARKER_KEY
+from .constants import V2_STAGES
+
+
+JOB_STATUSES = frozenset({"pending", "running", "pending_model", "failed", "complete"})
+STAGE_STATUSES = frozenset({"pending", "running", "skipped", "pending_model", "failed", "complete"})
+
+
+@dataclass(slots=True, frozen=True)
+class EnqueueResult:
+    job: dict[str, Any]
+    created: bool
+    updated: bool
+    reason: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"job": self.job, "created": self.created, "updated": self.updated, "reason": self.reason}
+
+
+class V2SessionJobStore:
+    def __init__(self, settings: Settings, *, db_path: Path | None = None) -> None:
+        self.settings = settings
+        self.db_path = db_path or settings.db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = connect(self.db_path)
+        init_schema(self.conn)
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def enqueue_session(
+        self,
+        *,
+        session_id: str,
+        boundary_event_id: str,
+        source_app: str = "",
+        repo_path: str = "",
+        source_evidence_day: str = "",
+        source_evidence_days: list[str] | tuple[str, ...] = (),
+        pipeline_version: str = PIPELINE_VERSION,
+        graph_schema_version: str = GRAPH_SCHEMA_VERSION,
+    ) -> EnqueueResult:
+        safe_session = str(session_id or "").strip()
+        if not safe_session:
+            raise ValueError("session_id is required")
+        now = utc_now()
+        job_id = stable_job_id(safe_session, pipeline_version)
+        artifact_dir = str(default_artifact_dir(self.settings.home, pipeline_version, safe_session, job_id))
+        days = _dedupe([source_evidence_day, *[str(item) for item in source_evidence_days if str(item)]])
+        existing = self.get_job_by_session(session_id=safe_session, pipeline_version=pipeline_version)
+        if existing is None:
+            self.conn.execute(
+                """
+                INSERT INTO v2_session_jobs(
+                  job_id, session_id, pipeline_version, graph_schema_version, status,
+                  current_stage, last_successful_stage, artifact_dir, source_app, repo_path,
+                  boundary_event_id, source_evidence_day, source_evidence_days_json,
+                  created_at, updated_at
+                )
+                VALUES(?, ?, ?, ?, 'pending', ?, '', ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job_id,
+                    safe_session,
+                    pipeline_version,
+                    graph_schema_version,
+                    V2_STAGES[0],
+                    artifact_dir,
+                    source_app,
+                    repo_path,
+                    boundary_event_id,
+                    source_evidence_day,
+                    json.dumps(days),
+                    now,
+                    now,
+                ),
+            )
+            self.conn.commit()
+            self.log_event(job_id=job_id, event_type="enqueued", stage="", message="closed session enqueued", metadata={"boundary_event_id": boundary_event_id})
+            return EnqueueResult(self.get_job(job_id) or {}, created=True, updated=False, reason="created")
+
+        if str(existing.get("boundary_event_id") or "") == str(boundary_event_id or ""):
+            return EnqueueResult(existing, created=False, updated=False, reason="already_enqueued")
+
+        self.conn.execute(
+            """
+            UPDATE v2_session_jobs
+            SET status='pending',
+                current_stage=?,
+                last_successful_stage='',
+                source_app=?,
+                repo_path=?,
+                boundary_event_id=?,
+                source_evidence_day=?,
+                source_evidence_days_json=?,
+                lock_owner='',
+                lock_expires_at='',
+                error_json='{}',
+                updated_at=?
+            WHERE job_id=?
+            """,
+            (
+                V2_STAGES[0],
+                source_app or str(existing.get("source_app") or ""),
+                repo_path or str(existing.get("repo_path") or ""),
+                boundary_event_id,
+                source_evidence_day,
+                json.dumps(days),
+                now,
+                existing["job_id"],
+            ),
+        )
+        self.conn.execute("DELETE FROM v2_session_job_stages WHERE job_id = ?", (existing["job_id"],))
+        self.conn.commit()
+        self.log_event(
+            job_id=str(existing["job_id"]),
+            event_type="reenqueued",
+            stage="",
+            message="closed session boundary changed; invalidated V2 stages",
+            metadata={"boundary_event_id": boundary_event_id},
+        )
+        return EnqueueResult(self.get_job(str(existing["job_id"])) or {}, created=False, updated=True, reason="boundary_changed")
+
+    def acquire_next(self, *, owner: str, lease_seconds: int = 300) -> dict[str, Any] | None:
+        now = utc_now()
+        expires = (datetime.now(timezone.utc) + timedelta(seconds=max(30, int(lease_seconds)))).isoformat()
+        cursor = self.conn.execute(
+            """
+            UPDATE v2_session_jobs
+            SET lock_owner = ?,
+                lock_expires_at = ?,
+                status = 'running',
+                attempt_count = attempt_count + CASE WHEN status = 'pending' THEN 1 ELSE 0 END,
+                last_attempt_at = CASE WHEN status = 'pending' THEN ? ELSE last_attempt_at END,
+                updated_at = ?
+            WHERE job_id = (
+              SELECT job_id
+              FROM v2_session_jobs
+              WHERE status = 'pending'
+                 OR (status = 'running' AND lock_expires_at != '' AND lock_expires_at < ?)
+              ORDER BY created_at ASC
+              LIMIT 1
+            )
+            """,
+            (owner, expires, now, now, now),
+        )
+        if cursor.rowcount <= 0:
+            self.conn.commit()
+            return None
+        self.conn.commit()
+        row = self.conn.execute(
+            "SELECT * FROM v2_session_jobs WHERE lock_owner = ? AND lock_expires_at = ? ORDER BY updated_at DESC LIMIT 1",
+            (owner, expires),
+        ).fetchone()
+        return _row(row) if row is not None else None
+
+    def retry_job(self, job_id: str, *, forced_by: str = "manual") -> dict[str, Any]:
+        now = utc_now()
+        row = self.conn.execute("SELECT * FROM v2_session_jobs WHERE job_id = ?", (job_id,)).fetchone()
+        if row is None:
+            raise ValueError(f"unknown_job:{job_id}")
+        if row["status"] not in {"failed", "pending_model"}:
+            raise ValueError(f"job_not_retryable:{row['status']}")
+        self.conn.execute(
+            """
+            UPDATE v2_session_jobs
+            SET status='pending',
+                lock_owner='',
+                lock_expires_at='',
+                forced_at=?,
+                forced_by=?,
+                updated_at=?
+            WHERE job_id=?
+            """,
+            (now, forced_by, now, job_id),
+        )
+        self.conn.commit()
+        self.log_event(job_id=job_id, event_type="retry", stage="", message="job manually retried", metadata={"forced_by": forced_by})
+        return self.get_job(job_id) or {}
+
+    def start_stage(self, *, job_id: str, stage: str, input_artifact: str, input_hash: str, stage_config_hash: str) -> None:
+        now = utc_now()
+        self.conn.execute(
+            """
+            INSERT INTO v2_session_job_stages(
+              job_id, stage, status, input_artifact, input_hash, stage_config_hash, started_at
+            )
+            VALUES(?, ?, 'running', ?, ?, ?, ?)
+            ON CONFLICT(job_id, stage) DO UPDATE SET
+              status='running',
+              input_artifact=excluded.input_artifact,
+              input_hash=excluded.input_hash,
+              stage_config_hash=excluded.stage_config_hash,
+              started_at=excluded.started_at,
+              finished_at='',
+              diagnostics_json='{}'
+            """,
+            (job_id, stage, input_artifact, input_hash, stage_config_hash, now),
+        )
+        self.conn.execute(
+            "UPDATE v2_session_jobs SET status='running', current_stage=?, updated_at=? WHERE job_id=?",
+            (stage, now, job_id),
+        )
+        self.conn.commit()
+        self.log_event(job_id=job_id, event_type="stage_started", stage=stage, message=f"stage started: {stage}", metadata={})
+
+    def complete_stage(
+        self,
+        *,
+        job_id: str,
+        stage: str,
+        output_artifact: str,
+        output_hash: str,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> None:
+        now = utc_now()
+        next_stage = _next_stage(stage)
+        job_status = "complete" if next_stage == "" else "pending"
+        self.conn.execute(
+            """
+            UPDATE v2_session_job_stages
+            SET status='complete',
+                output_artifact=?,
+                output_hash=?,
+                diagnostics_json=?,
+                finished_at=?
+            WHERE job_id=? AND stage=?
+            """,
+            (output_artifact, output_hash, json.dumps(diagnostics or {}, sort_keys=True), now, job_id, stage),
+        )
+        self.conn.execute(
+            """
+            UPDATE v2_session_jobs
+            SET status=?,
+                current_stage=?,
+                last_successful_stage=?,
+                error_json='{}',
+                updated_at=?
+            WHERE job_id=?
+            """,
+            (job_status, next_stage, stage, now, job_id),
+        )
+        self.conn.commit()
+        self.log_event(job_id=job_id, event_type="stage_completed", stage=stage, message=f"stage completed: {stage}", metadata=diagnostics or {})
+
+    def set_pending_model(self, *, job_id: str, stage: str, reason: str, diagnostics: dict[str, Any] | None = None) -> None:
+        self._stop_stage(job_id=job_id, stage=stage, status="pending_model", reason=reason, diagnostics=diagnostics)
+
+    def fail_stage(self, *, job_id: str, stage: str, reason: str, diagnostics: dict[str, Any] | None = None) -> None:
+        self._stop_stage(job_id=job_id, stage=stage, status="failed", reason=reason, diagnostics=diagnostics)
+
+    def release_lock(self, *, job_id: str) -> None:
+        self.conn.execute(
+            "UPDATE v2_session_jobs SET lock_owner='', lock_expires_at='', updated_at=? WHERE job_id=?",
+            (utc_now(), job_id),
+        )
+        self.conn.commit()
+
+    def list_jobs(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self.conn.execute(
+            "SELECT * FROM v2_session_jobs ORDER BY updated_at DESC LIMIT ?",
+            (max(1, int(limit)),),
+        ).fetchall()
+        return [_row(row) for row in rows]
+
+    def get_job(self, job_id: str) -> dict[str, Any] | None:
+        row = self.conn.execute("SELECT * FROM v2_session_jobs WHERE job_id = ?", (job_id,)).fetchone()
+        return _row(row) if row is not None else None
+
+    def get_job_by_session(self, *, session_id: str, pipeline_version: str = PIPELINE_VERSION) -> dict[str, Any] | None:
+        row = self.conn.execute(
+            "SELECT * FROM v2_session_jobs WHERE session_id = ? AND pipeline_version = ?",
+            (session_id, pipeline_version),
+        ).fetchone()
+        return _row(row) if row is not None else None
+
+    def list_stages(self, job_id: str) -> list[dict[str, Any]]:
+        rows = self.conn.execute(
+            "SELECT * FROM v2_session_job_stages WHERE job_id = ? ORDER BY rowid ASC",
+            (job_id,),
+        ).fetchall()
+        return [_row(row) for row in rows]
+
+    def stage_row(self, *, job_id: str, stage: str) -> dict[str, Any] | None:
+        row = self.conn.execute(
+            "SELECT * FROM v2_session_job_stages WHERE job_id = ? AND stage = ?",
+            (job_id, stage),
+        ).fetchone()
+        return _row(row) if row is not None else None
+
+    def list_events(self, job_id: str, *, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self.conn.execute(
+            "SELECT * FROM v2_session_job_events WHERE job_id = ? ORDER BY created_at DESC LIMIT ?",
+            (job_id, max(1, int(limit))),
+        ).fetchall()
+        return [_row(row) for row in rows]
+
+    def log_event(
+        self,
+        *,
+        job_id: str,
+        event_type: str,
+        stage: str = "",
+        message: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO v2_session_job_events(event_id, job_id, event_type, stage, message, metadata_json, created_at)
+            VALUES(?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                f"v2evt:{uuid.uuid4().hex}",
+                job_id,
+                event_type,
+                stage,
+                message,
+                json.dumps(metadata or {}, sort_keys=True),
+                utc_now(),
+            ),
+        )
+        self.conn.commit()
+
+    def marker(self, key: str = RESET_MARKER_KEY) -> dict[str, Any] | None:
+        row = self.conn.execute("SELECT * FROM v2_production_markers WHERE marker_key = ?", (key,)).fetchone()
+        if row is None:
+            return None
+        try:
+            payload = json.loads(row["value_json"])
+        except json.JSONDecodeError:
+            payload = {}
+        return {"marker_key": row["marker_key"], **payload, "created_at": row["created_at"], "updated_at": row["updated_at"]}
+
+    def upsert_marker(self, key: str, value: dict[str, Any]) -> None:
+        now = utc_now()
+        self.conn.execute(
+            """
+            INSERT INTO v2_production_markers(marker_key, value_json, created_at, updated_at)
+            VALUES(?, ?, ?, ?)
+            ON CONFLICT(marker_key) DO UPDATE SET
+              value_json=excluded.value_json,
+              updated_at=excluded.updated_at
+            """,
+            (key, json.dumps(value, sort_keys=True), now, now),
+        )
+        self.conn.commit()
+
+    def _stop_stage(
+        self,
+        *,
+        job_id: str,
+        stage: str,
+        status: str,
+        reason: str,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> None:
+        if status not in {"failed", "pending_model"}:
+            raise ValueError(f"invalid stop status: {status}")
+        now = utc_now()
+        payload = {"reason": reason, **(diagnostics or {})}
+        self.conn.execute(
+            """
+            UPDATE v2_session_job_stages
+            SET status=?,
+                diagnostics_json=?,
+                finished_at=?
+            WHERE job_id=? AND stage=?
+            """,
+            (status, json.dumps(payload, sort_keys=True), now, job_id, stage),
+        )
+        self.conn.execute(
+            """
+            UPDATE v2_session_jobs
+            SET status=?,
+                current_stage=?,
+                lock_owner='',
+                lock_expires_at='',
+                error_json=?,
+                updated_at=?
+            WHERE job_id=?
+            """,
+            (status, stage, json.dumps(payload, sort_keys=True), now, job_id),
+        )
+        self.conn.commit()
+        self.log_event(job_id=job_id, event_type=status, stage=stage, message=reason, metadata=payload)
+
+
+def stable_job_id(session_id: str, pipeline_version: str = PIPELINE_VERSION) -> str:
+    digest = hashlib.sha256(f"{pipeline_version}|{session_id}".encode("utf-8")).hexdigest()[:32]
+    return f"v2job:{digest}"
+
+
+def default_artifact_dir(home: Path, pipeline_version: str, session_id: str, job_id: str) -> Path:
+    return home / ".state" / "v2-jobs" / safe_part(pipeline_version) / f"{safe_part(session_id)[:80]}-{job_id.rsplit(':', 1)[-1][:8]}" / job_id.rsplit(":", 1)[-1]
+
+
+def safe_part(value: str) -> str:
+    out = []
+    for ch in str(value):
+        if ch.isalnum() or ch in {"-", "_", "."}:
+            out.append(ch)
+        else:
+            out.append("_")
+    return "".join(out).strip("_") or "value"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _row(row: sqlite3.Row) -> dict[str, Any]:
+    out = dict(row)
+    for key in ("source_evidence_days_json", "error_json", "diagnostics_json", "metadata_json", "value_json"):
+        if key in out:
+            try:
+                out[key.removesuffix("_json")] = json.loads(out[key])
+            except json.JSONDecodeError:
+                out[key.removesuffix("_json")] = {}
+    return out
+
+
+def _next_stage(stage: str) -> str:
+    try:
+        index = V2_STAGES.index(stage)
+    except ValueError:
+        return ""
+    if index + 1 >= len(V2_STAGES):
+        return ""
+    return V2_STAGES[index + 1]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            out.append(text)
+    return out

--- a/src/agent_memory_orchestrator/reasoning_graph/retrieval.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/retrieval.py
@@ -455,6 +455,8 @@ def build_retrieval_documents_from_graph(
     kinds: list[str] | None = None,
     node_limit: int = 10000,
     max_doc_chars: int = 5000,
+    pipeline_version: str = "",
+    graph_schema_version: str = "",
 ) -> list[RetrievalDocument]:
     nodes = graph_store.list_nodes(
         limit=node_limit,
@@ -463,6 +465,10 @@ def build_retrieval_documents_from_graph(
     )
     docs: list[RetrievalDocument] = []
     for node in nodes:
+        if pipeline_version and _node_version_value(node, "pipeline_version") != pipeline_version:
+            continue
+        if graph_schema_version and _node_version_value(node, "graph_schema_version") != graph_schema_version:
+            continue
         docs.extend(_documents_for_node(node, max_doc_chars=max_doc_chars))
     return docs
 
@@ -802,8 +808,15 @@ def _retrieval_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
         "evidence_refs",
         "version_count",
         "status",
+        "pipeline_version",
+        "graph_schema_version",
     }
     return {key: metadata[key] for key in keep if key in metadata}
+
+
+def _node_version_value(node: dict[str, Any], key: str) -> str:
+    metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+    return str(node.get(key) or metadata.get(key) or "")
 
 
 def _compact_output_node(node: dict[str, Any]) -> dict[str, Any]:

--- a/src/agent_memory_orchestrator/reasoning_graph/stage4_contract.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/stage4_contract.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+STAGE4_CONTRACT_VERSION = "stage4-reset-2026-05-14"
+
+STAGE4_CONTRACT: dict[str, Any] = {
+    "stage": "04_reasoning_node_extraction_sample",
+    "input": "Stage 3B reasoning work packets",
+    "purpose": "Promote packet evidence into answer-grade reasoning graph nodes.",
+    "allowed_node_types": [
+        "Problem",
+        "Decision",
+        "Cause",
+        "Fix",
+        "Constraint",
+        "OpenQuestion",
+    ],
+    "allowed_edge_types": [
+        "DERIVED_FROM_PACKET",
+        "EXPLAINS_COMMIT",
+        "CAUSED_DECISION",
+        "CONSTRAINS_DECISION",
+        "ADDRESSED_BY_FIX",
+        "VALIDATED_BY",
+        "SUPPORTS",
+    ],
+    "node_schema": {
+        "node_id": "stable stage-local id",
+        "packet_id": "source packet id",
+        "commit_sha": "linked short commit sha",
+        "node_type": "Problem|Decision|Cause|Fix|Constraint|OpenQuestion",
+        "subject": "short noun phrase",
+        "statement": "single factual claim extracted from packet evidence",
+        "reason": "why this node should exist in the graph",
+        "confidence": "0.0-1.0",
+        "evidence_refs": "short refs from the packet only",
+        "status": "accepted|needs_review|rejected",
+    },
+    "hard_rules": [
+        "Do not cite raw transcript ids or tool call ids.",
+        "Every evidence_ref must exist in the source packet problem_refs, rationale_refs, or validation_refs.",
+        "Support refs are provenance only and cannot be cited as reasoning evidence in this stage.",
+        "If the packet does not contain enough evidence, emit no node or mark needs_review.",
+        "Each node statement must be one claim, not a mixed paragraph.",
+        "Every accepted node must link to exactly one packet and one commit.",
+    ],
+}
+
+
+def stage4_contract_hash() -> str:
+    payload = {
+        "version": STAGE4_CONTRACT_VERSION,
+        "contract": STAGE4_CONTRACT,
+        "output_schema": stage4_output_schema(),
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def build_stage4_packet_prompt(packet: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            "/no_think",
+            "You are extracting answer-grade reasoning graph nodes from one commit-backed work packet.",
+            "Return JSON only. Do not include markdown fences.",
+            "",
+            "Stage 4 contract:",
+            json.dumps(STAGE4_CONTRACT, ensure_ascii=False, indent=2),
+            "",
+            "Output shape:",
+            json.dumps(_prompt_output_shape(), ensure_ascii=False, separators=(",", ":")),
+            "",
+            "Input packet:",
+            json.dumps(packet, ensure_ascii=False, indent=2),
+        ]
+    )
+
+
+def stage4_output_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "packet_id": {"type": "string"},
+            "commit_sha": {"type": "string"},
+            "nodes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "node_type": {"type": "string"},
+                        "subject": {"type": "string"},
+                        "statement": {"type": "string"},
+                        "reason": {"type": "string"},
+                        "confidence": {"type": "number"},
+                        "evidence_refs": {"type": "array", "items": {"type": "string"}},
+                        "status": {"type": "string"},
+                    },
+                    "required": [
+                        "node_type",
+                        "subject",
+                        "statement",
+                        "reason",
+                        "confidence",
+                        "evidence_refs",
+                        "status",
+                    ],
+                },
+            },
+        },
+        "required": ["packet_id", "commit_sha", "nodes"],
+    }
+
+
+def _prompt_output_shape() -> dict[str, Any]:
+    return {
+        "packet_id": "WP0001",
+        "commit_sha": "abc1234",
+        "nodes": [
+            {
+                "node_type": "Decision",
+                "subject": "...",
+                "statement": "...",
+                "reason": "...",
+                "confidence": 0.0,
+                "evidence_refs": ["E00001"],
+                "status": "accepted",
+            }
+        ],
+    }

--- a/src/agent_memory_orchestrator/web/amo.css
+++ b/src/agent_memory_orchestrator/web/amo.css
@@ -129,6 +129,14 @@ h3 { font-size: 16px; }
 .btn.primary { color: #08110e; background: linear-gradient(135deg, var(--accent), #d7ffa1); border-color: transparent; font-weight: 800; }
 .btn.ghost { color: var(--accent-2); }
 .button-row, .job-grid { display: flex; gap: 10px; flex-wrap: wrap; }
+.job-list { display: grid; gap: 12px; max-height: 520px; overflow: auto; padding-right: 4px; }
+.job-card {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(6, 14, 11, 0.56);
+  padding: 14px;
+}
+.job-meta { display: flex; gap: 9px; flex-wrap: wrap; color: var(--muted); font: 12px var(--mono); }
 
 .view { display: none; animation: reveal 0.24s ease both; }
 .view.active { display: block; }

--- a/src/agent_memory_orchestrator/web/amo.js
+++ b/src/agent_memory_orchestrator/web/amo.js
@@ -44,12 +44,12 @@ const VERSION_EDGES = new Set([
 ]);
 const PIPELINE = [
   ["Raw", "Captured hook events", "raw"],
-  ["Clean", "Bounded evidence windows", "clean"],
-  ["Extract", "Qwen or deterministic GraphDelta", "delta"],
-  ["Draft", "Session graph nodes", "draft"],
-  ["Merge", "Commit/finalize promotion", "merge"],
-  ["Central", "Committed graph memory", "central"],
-  ["Cache", "Retrieval cache", "cache"],
+  ["Queue", "Closed sessions enqueued", "queue"],
+  ["Reason", "Packet-wise Qwen + review", "reason"],
+  ["Graph", "V2 Kuzu graph writes", "graph"],
+  ["Index", "V2 retrieval documents", "index"],
+  ["Vector", "Embeddings / FAISS", "vector"],
+  ["Trace", "Answer provenance", "trace"],
 ];
 
 function $(id) { return document.getElementById(id); }
@@ -236,7 +236,16 @@ function renderDashboard() {
     metric("Graph nodes", nodes.length, graphCaption),
     metric("Edges", edges.length, "visible central relations"),
   ].join("");
-  renderPipeline($("pipelineStrip"), { raw: rawEvents, clean: sessions.reduce((sum, s) => sum + Number(s.graph_counts?.draft || 0), 0), delta: nodes.filter(n => nodeKind(n) === "GraphDelta").length, draft, merge: edges.filter(e => VERSION_EDGES.has(edgeKind(e))).length, central: committed + sessionFinal + nodes.filter(n => n.scope === "central").length, cache: nodes.length });
+  const jobs = AMO.jobs?.jobs || [];
+  renderPipeline($("pipelineStrip"), {
+    raw: rawEvents,
+    queue: jobs.length,
+    reason: nodes.filter(n => ["ReasoningNode", "Problem", "Decision", "Cause", "Fix", "Constraint", "OpenQuestion"].includes(nodeKind(n))).length,
+    graph: nodes.filter(n => metadata(n).graph_schema_version === "v2").length,
+    index: nodes.filter(n => ["Packet", "Commit", "EvidenceRef", "CodeHunk", "CodeNode", "CodeVersion", "Symbol"].includes(nodeKind(n))).length,
+    vector: jobs.some(j => ["embeddings", "faiss", "quality_eval"].includes(text(j.last_successful_stage || j.current_stage))) ? "ready" : "pending",
+    trace: edges.filter(e => VERSION_EDGES.has(edgeKind(e))).length,
+  });
   $("recentSessions").innerHTML = sessions.slice(0, 7).map(sessionCard).join("") || empty("No captured sessions yet.");
 }
 function metric(label, value, caption) { return `<div class="metric"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong><span>${escapeHtml(caption)}</span></div>`; }
@@ -373,9 +382,17 @@ function renderSessionDetail(data) {
   $("sessionSummary").textContent = contextNode?.summary || `${timeline.length} captured events, ${nodes.length} graph nodes, ${edges.length} graph edges.`;
   const windows = data.windows || [];
   const preview = data.merge_preview || {};
-  renderPipeline($("sessionPipeline"), { raw: timeline.length, clean: windows.length, delta: nodes.filter(n => nodeKind(n) === "GraphDelta").length, draft: nodes.filter(n => nodeStatus(n) === "draft").length, merge: (preview.promotions || []).length + (preview.version_edges || []).length, central: nodes.filter(n => nodeStatus(n) === "committed" || n.scope === "central").length, cache: data.pending?.count ? "pending" : "ready" });
+  renderPipeline($("sessionPipeline"), {
+    raw: timeline.length,
+    queue: AMO.jobs?.jobs?.filter(j => j.session_id === data.session_id).length || 0,
+    reason: nodes.filter(n => ["ReasoningNode", "Problem", "Decision", "Cause", "Fix", "Constraint", "OpenQuestion"].includes(nodeKind(n))).length,
+    graph: nodes.filter(n => metadata(n).graph_schema_version === "v2").length,
+    index: nodes.filter(n => ["Packet", "Commit", "EvidenceRef", "CodeHunk", "CodeNode", "CodeVersion", "Symbol"].includes(nodeKind(n))).length,
+    vector: data.pending?.count ? "pending" : "ready",
+    trace: edges.filter(e => VERSION_EDGES.has(edgeKind(e))).length,
+  });
   $("timelineList").innerHTML = timeline.map(renderTimeline).join("") || empty("No raw evidence for this session.");
-  $("cleanedWindows").innerHTML = windows.map(renderWindow).join("") || empty("No cleaned evidence windows yet. A write/test/git/finalize trigger must be drained first.");
+  $("cleanedWindows").innerHTML = windows.map(renderWindow).join("") || empty("No evidence view artifacts yet. A closed-session V2 job must run first.");
   $("draftNodes").innerHTML = nodes.map(renderNodeCard).join("") || empty("No session graph nodes yet.");
   $("mergePreview").innerHTML = renderMergePreview(preview);
 }

--- a/src/agent_memory_orchestrator/web/amo.js
+++ b/src/agent_memory_orchestrator/web/amo.js
@@ -5,6 +5,7 @@ const AMO = {
   selectedSessionId: "",
   selectedSession: null,
   health: null,
+  jobs: { jobs: [], reset_marker: null },
   connectors: { slack: null },
   centralGraph: { nodes: [], edges: [], warnings: [], full: false, limit: 360 },
   versionFlow: { flows: [], nodes: [], edges: [], warnings: [] },
@@ -188,8 +189,16 @@ async function loadConnectorStatus() {
   }
   renderConnectorStatus();
 }
+async function loadJobs() {
+  try {
+    AMO.jobs = await apiGet("/api/jobs?limit=50");
+  } catch (error) {
+    AMO.jobs = { ok: false, error: error.message, jobs: [], reset_marker: null };
+  }
+  renderJobs();
+}
 async function refreshAll() {
-  await Promise.allSettled([loadHealth(), loadSessions(), loadCentralGraph(), loadVersionFlow(), loadConnectorStatus()]);
+  await Promise.allSettled([loadHealth(), loadSessions(), loadCentralGraph(), loadVersionFlow(), loadConnectorStatus(), loadJobs()]);
   if (AMO.selectedSessionId) await selectSession(AMO.selectedSessionId, { silent: true });
 }
 function setView(view) {
@@ -269,6 +278,58 @@ function renderConnectorStatus() {
   </div>`;
   const command = $("slackCommandPanel");
   if (command) command.textContent = data.run_command ? `amo-cli slack setup-wizard\n${data.run_command}` : command.textContent;
+}
+function renderJobs() {
+  const list = $("v2JobsList");
+  if (!list) return;
+  const marker = AMO.jobs?.reset_marker;
+  const markerTarget = $("v2ResetMarker");
+  if (markerTarget) {
+    markerTarget.innerHTML = marker
+      ? `<span class="pill good">V2 reset ${escapeHtml(marker.production_v2_reset_applied_at || marker.updated_at || "applied")}</span><span class="pill blue">${escapeHtml(marker.pipeline_version || "v2")}</span>`
+      : `<span class="pill warn">V2 production reset marker missing</span><span class="pill">run explicit backup-first reset before V2 graph writes</span>`;
+  }
+  if (!AMO.jobs?.ok) {
+    list.innerHTML = `<pre class="code-block">${escapeHtml(AMO.jobs?.error || "Unable to load jobs")}</pre>`;
+    return;
+  }
+  const jobs = AMO.jobs.jobs || [];
+  list.innerHTML = jobs.map(renderJobCard).join("") || empty("No V2 session jobs yet.");
+}
+function renderJobCard(job) {
+  const status = text(job.status || "unknown");
+  const cls = status === "complete" ? "good" : status === "failed" ? "bad" : status === "pending_model" ? "warn" : "blue";
+  const retry = ["failed", "pending_model"].includes(status)
+    ? `<button class="btn ghost retry-job-btn" data-job-id="${escapeHtml(job.job_id)}">Retry</button>`
+    : "";
+  const error = job.error && Object.keys(job.error).length ? `<pre class="code-block small">${escapeHtml(formatJson(job.error))}</pre>` : "";
+  return `<article class="job-card">
+    <div class="panel-head">
+      <div>
+        <p class="eyebrow">${escapeHtml(job.source_app || "session")}</p>
+        <h3>${escapeHtml(job.session_id || job.job_id)}</h3>
+      </div>
+      <div class="button-row"><span class="pill ${cls}">${escapeHtml(status)}</span>${retry}</div>
+    </div>
+    <div class="job-meta">
+      <span>stage ${escapeHtml(job.current_stage || "-")}</span>
+      <span>last ${escapeHtml(job.last_successful_stage || "-")}</span>
+      <span>attempts ${escapeHtml(job.attempt_count || 0)}</span>
+      <span>${escapeHtml(truncate(job.repo_path || job.artifact_dir || "", 92))}</span>
+    </div>
+    ${error}
+  </article>`;
+}
+async function retryJob(jobId) {
+  const output = $("adminOutput");
+  if (output) output.textContent = `Retrying ${jobId}...`;
+  try {
+    const result = await apiPost(`/api/jobs/${encodeURIComponent(jobId)}/retry`, { forced_by: "dashboard" });
+    if (output) output.textContent = formatJson(result);
+    await loadJobs();
+  } catch (error) {
+    if (output) output.textContent = error.stack || error.message;
+  }
 }
 function renderPipeline(target, counts) {
   target.innerHTML = PIPELINE.map(([name, desc, key]) => `<div class="stage-card"><strong>${escapeHtml(name)}</strong><div class="count">${escapeHtml(counts[key] ?? 0)}</div><small>${escapeHtml(desc)}</small></div>`).join("");
@@ -1005,6 +1066,7 @@ function bindEvents() {
   $("cacheBtn").addEventListener("click", () => runAdminJob("cache"));
   $("debugGraphBtn").addEventListener("click", () => runAdminJob("debugGraph"));
   $("debugQwenBtn").addEventListener("click", () => runAdminJob("debugQwen"));
+  $("refreshJobsBtn")?.addEventListener("click", loadJobs);
   document.body.addEventListener("click", event => {
     const sessionEl = event.target.closest(".session-card");
     if (sessionEl) selectSession(sessionEl.dataset.sessionId);
@@ -1024,6 +1086,8 @@ function bindEvents() {
       selectGraphNode(versionNode.dataset.nodeId);
       focusSelectedNeighbors();
     }
+    const retryJobEl = event.target.closest(".retry-job-btn");
+    if (retryJobEl?.dataset.jobId) retryJob(retryJobEl.dataset.jobId);
   });
 }
 async function init() {
@@ -1037,5 +1101,6 @@ async function init() {
   else if (path.includes("dashboard")) setView("dashboard");
   await refreshAll();
   setInterval(() => { if (AMO.view === "dashboard" || AMO.view === "sessions") loadSessions().catch(() => {}); }, 15000);
+  setInterval(() => { if (AMO.view === "admin") loadJobs().catch(() => {}); }, 12000);
 }
 init().catch(error => { setDaemon(false, "ui failed"); console.error(error); });

--- a/src/agent_memory_orchestrator/web/index.html
+++ b/src/agent_memory_orchestrator/web/index.html
@@ -254,6 +254,18 @@ amo-cli slack run --reply-mode answer</pre>
       </section>
 
       <section id="adminView" class="view">
+        <section class="panel">
+          <div class="panel-head">
+            <div>
+              <p class="eyebrow">V2 session jobs</p>
+              <h2>Background production pipeline</h2>
+              <p class="muted">Closed sessions are enqueued here and processed stage by stage. Failed or model-waiting jobs require an explicit retry.</p>
+            </div>
+            <button id="refreshJobsBtn" class="btn ghost">Refresh Jobs</button>
+          </div>
+          <div id="v2ResetMarker" class="warning-list"></div>
+          <div id="v2JobsList" class="job-list"></div>
+        </section>
         <div class="two-col">
           <section class="panel">
             <p class="eyebrow">Graph jobs</p>

--- a/tests/test_evidence_drain.py
+++ b/tests/test_evidence_drain.py
@@ -10,6 +10,7 @@ from agent_memory_orchestrator.graph.store import InMemoryGraphStore
 from agent_memory_orchestrator.evidence.raw_store import RawEvidenceStore
 from agent_memory_orchestrator.graph.session import DeterministicGraphExtractor, SessionGraphBuilder
 from agent_memory_orchestrator.versioning import GitSnapshot
+from agent_memory_orchestrator.reasoning_graph.jobs import V2SessionJobStore
 
 
 class _StaticGitBackend:
@@ -118,8 +119,6 @@ def test_drain_skips_and_quarantines_malformed_jsonl_lines(tmp_path: Path) -> No
 
 def test_drain_session_boundary_persists_pending_window_across_runs(tmp_path: Path) -> None:
     settings = make_settings(tmp_path)
-    store = InMemoryGraphStore()
-    backend = _StaticGitBackend()
     evidence = RawEvidenceStore(settings.evidence_dir)
     _append_session_start(evidence, "s1")
     evidence.append(
@@ -129,19 +128,29 @@ def test_drain_session_boundary_persists_pending_window_across_runs(tmp_path: Pa
         event_name="user_prompt_submit",
     )
 
-    first = _drain(settings, store, backend).drain(limit=2)
+    first = _v2_drain(settings).drain(limit=2)
     assert first["windows_processed"] == 0
     assert first["pending_sessions"] == 1
 
     _append_session_start(evidence, "s2")
 
-    second = _drain(settings, store, backend).drain(limit=1)
+    second = _v2_drain(settings).drain(limit=1)
 
     assert second["windows_processed"] == 1
     assert second["triggered"][0]["session_id"] == "s1"
     assert second["triggered"][0]["trigger"]["trigger_type"] == "session_boundary"
+    assert second["triggered"][0]["result"]["mode"] == "v2_job_enqueue"
+    assert second["triggered"][0]["result"]["created"] is True
     assert second["pending_sessions"] == 1
-    assert store.list_nodes(kinds=["CleanedEvidenceWindow"], session_id="s1")
+    job_store = V2SessionJobStore(settings)
+    try:
+        job = job_store.get_job_by_session(session_id="s1")
+    finally:
+        job_store.close()
+    assert job is not None
+    assert job["status"] == "pending"
+    assert job["current_stage"] == "evidence_view"
+    assert job["source_app"] == "codex"
 
 
 def test_drain_write_window_builds_context_snapshot_and_work_change(tmp_path: Path) -> None:
@@ -359,3 +368,7 @@ def _drain(settings: Settings, store: InMemoryGraphStore, backend: _StaticGitBac
             extractor=DeterministicGraphExtractor(),
         ),
     )
+
+
+def _v2_drain(settings: Settings) -> EvidenceDrain:
+    return EvidenceDrain(settings, InMemoryGraphStore(), _StaticGitBackend())

--- a/tests/test_evidence_drain.py
+++ b/tests/test_evidence_drain.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from dataclasses import replace
 from pathlib import Path
 
 from agent_memory_orchestrator.config import Settings
@@ -117,11 +116,12 @@ def test_drain_skips_and_quarantines_malformed_jsonl_lines(tmp_path: Path) -> No
     assert [row["id"] for _, row in _read_jsonl_from(path, 0)] == ["raw_good_1", "raw_good_2"]
 
 
-def test_drain_token_threshold_persists_pending_window_across_runs(tmp_path: Path) -> None:
-    settings = replace(make_settings(tmp_path), drain_token_threshold=80)
+def test_drain_session_boundary_persists_pending_window_across_runs(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
     store = InMemoryGraphStore()
     backend = _StaticGitBackend()
     evidence = RawEvidenceStore(settings.evidence_dir)
+    _append_session_start(evidence, "s1")
     evidence.append(
         {"hook_event_name": "UserPromptSubmit", "session_id": "s1", "prompt": "short context only"},
         session_id="s1",
@@ -129,34 +129,27 @@ def test_drain_token_threshold_persists_pending_window_across_runs(tmp_path: Pat
         event_name="user_prompt_submit",
     )
 
-    first = _drain(settings, store, backend).drain(limit=1)
+    first = _drain(settings, store, backend).drain(limit=2)
     assert first["windows_processed"] == 0
     assert first["pending_sessions"] == 1
 
-    evidence.append(
-        {
-            "hook_event_name": "UserPromptSubmit",
-            "session_id": "s1",
-            "prompt": " ".join(["more context that pushes this session beyond the automatic token threshold"] * 20),
-        },
-        session_id="s1",
-        source_app="codex",
-        event_name="user_prompt_submit",
-    )
+    _append_session_start(evidence, "s2")
 
     second = _drain(settings, store, backend).drain(limit=1)
 
     assert second["windows_processed"] == 1
-    assert second["triggered"][0]["trigger"]["trigger_type"] == "token_threshold"
-    assert second["pending_sessions"] == 0
+    assert second["triggered"][0]["session_id"] == "s1"
+    assert second["triggered"][0]["trigger"]["trigger_type"] == "session_boundary"
+    assert second["pending_sessions"] == 1
     assert store.list_nodes(kinds=["CleanedEvidenceWindow"], session_id="s1")
 
 
 def test_drain_write_window_builds_context_snapshot_and_work_change(tmp_path: Path) -> None:
-    settings = replace(make_settings(tmp_path), drain_token_threshold=30)
+    settings = make_settings(tmp_path)
     store = InMemoryGraphStore()
     backend = _StaticGitBackend()
     evidence = RawEvidenceStore(settings.evidence_dir)
+    _append_session_start(evidence, "s1")
     evidence.append(
         {"hook_event_name": "UserPromptSubmit", "session_id": "s1", "prompt": "implement capture-only hooks"},
         session_id="s1",
@@ -174,6 +167,7 @@ def test_drain_write_window_builds_context_snapshot_and_work_change(tmp_path: Pa
         source_app="codex",
         event_name="post_tool_use",
     )
+    _append_session_start(evidence, "s2")
     drain = _drain(settings, store, backend)
 
     result = drain.drain()
@@ -195,8 +189,8 @@ def test_drain_write_window_builds_context_snapshot_and_work_change(tmp_path: Pa
     assert {edge["kind"] for edge in edges} >= {"CLEANED_INTO", "EXTRACTED_AS", "CREATED", "MODIFIES", "IMPLEMENTS"}
 
 
-def test_drain_git_commit_links_work_change_when_commit_sha_is_in_threshold_window(tmp_path: Path) -> None:
-    settings = replace(make_settings(tmp_path), drain_token_threshold=1)
+def test_drain_git_commit_links_work_change_when_commit_sha_is_in_closed_session(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
     store = InMemoryGraphStore()
     backend = _StaticGitBackend(
         GitSnapshot(
@@ -206,7 +200,9 @@ def test_drain_git_commit_links_work_change_when_commit_sha_is_in_threshold_wind
             head="abcdef1234567890abcdef1234567890abcdef12",
         )
     )
-    RawEvidenceStore(settings.evidence_dir).append(
+    evidence = RawEvidenceStore(settings.evidence_dir)
+    _append_session_start(evidence, "s1")
+    evidence.append(
         {
             "hook_event_name": "PostToolUse",
             "session_id": "s1",
@@ -216,6 +212,7 @@ def test_drain_git_commit_links_work_change_when_commit_sha_is_in_threshold_wind
         source_app="codex",
         event_name="post_tool_use",
     )
+    _append_session_start(evidence, "s2")
     drain = _drain(settings, store, backend)
 
     result = drain.drain()
@@ -255,7 +252,7 @@ def test_basic_event_git_metadata_is_compact(tmp_path: Path) -> None:
 
 
 def test_session_filtered_drain_uses_session_cursor_and_matching_limit(tmp_path: Path) -> None:
-    settings = replace(make_settings(tmp_path), drain_token_threshold=30)
+    settings = make_settings(tmp_path)
     store = InMemoryGraphStore()
     backend = _StaticGitBackend()
     evidence = RawEvidenceStore(settings.evidence_dir)
@@ -266,6 +263,7 @@ def test_session_filtered_drain_uses_session_cursor_and_matching_limit(tmp_path:
             source_app="codex",
             event_name="user_prompt_submit",
         )
+    _append_session_start(evidence, "target")
     evidence.append(
         {"hook_event_name": "UserPromptSubmit", "session_id": "target", "prompt": "clean write window"},
         session_id="target",
@@ -288,11 +286,12 @@ def test_session_filtered_drain_uses_session_cursor_and_matching_limit(tmp_path:
         source_app="codex",
         event_name="post_tool_use",
     )
+    _append_session_start(evidence, "other-after-target")
 
-    result = _drain(settings, store, backend).drain(session_id="target", limit=2)
+    result = _drain(settings, store, backend).drain(session_id="target", limit=10)
     cursors = json.loads((settings.home / ".state" / "evidence_cursors.json").read_text(encoding="utf-8"))
 
-    assert result["records_ingested"] == 2
+    assert result["records_ingested"] == 3
     assert result["windows_processed"] == 1
     assert store.list_nodes(kinds=["ContextSnapshot"], session_id="target")
     assert cursors
@@ -300,14 +299,15 @@ def test_session_filtered_drain_uses_session_cursor_and_matching_limit(tmp_path:
 
 
 def test_drain_stops_after_max_windows(tmp_path: Path) -> None:
-    settings = replace(make_settings(tmp_path), drain_token_threshold=30)
+    settings = make_settings(tmp_path)
     store = InMemoryGraphStore()
     backend = _StaticGitBackend()
     evidence = RawEvidenceStore(settings.evidence_dir)
     for index in range(2):
+        _append_session_start(evidence, f"s{index + 1}")
         evidence.append(
-            {"hook_event_name": "UserPromptSubmit", "session_id": "s1", "prompt": f"write window {index}"},
-            session_id="s1",
+            {"hook_event_name": "UserPromptSubmit", "session_id": f"s{index + 1}", "prompt": f"write window {index}"},
+            session_id=f"s{index + 1}",
             source_app="codex",
             event_name="user_prompt_submit",
         )
@@ -323,10 +323,11 @@ def test_drain_stops_after_max_windows(tmp_path: Path) -> None:
                     }
                 ),
             },
-            session_id="s1",
+            session_id=f"s{index + 1}",
             source_app="codex",
             event_name="post_tool_use",
         )
+    _append_session_start(evidence, "s3")
 
     result = _drain(settings, store, backend).drain(limit=20, max_windows=1)
     second = _drain(settings, store, backend).drain(limit=20, max_windows=1)
@@ -335,6 +336,15 @@ def test_drain_stops_after_max_windows(tmp_path: Path) -> None:
     assert result["stopped_reason"] == "max_windows_reached"
     assert result["max_windows"] == 1
     assert second["windows_processed"] == 1
+
+
+def _append_session_start(evidence: RawEvidenceStore, session_id: str) -> None:
+    evidence.append(
+        {"hook_event_name": "SessionStart", "session_id": session_id},
+        session_id=session_id,
+        source_app="codex",
+        event_name="session_start",
+    )
 
 
 def _drain(settings: Settings, store: InMemoryGraphStore, backend: _StaticGitBackend) -> EvidenceDrain:

--- a/tests/test_evidence_drain.py
+++ b/tests/test_evidence_drain.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from agent_memory_orchestrator.config import Settings
 from agent_memory_orchestrator.evidence.drain import EvidenceDrain
+from agent_memory_orchestrator.evidence.drain import _read_jsonl_from
 from agent_memory_orchestrator.graph.store import InMemoryGraphStore
 from agent_memory_orchestrator.evidence.raw_store import RawEvidenceStore
 from agent_memory_orchestrator.graph.session import DeterministicGraphExtractor, SessionGraphBuilder
@@ -66,6 +67,54 @@ def test_drain_read_only_prompt_is_evidence_only_and_idempotent(tmp_path: Path) 
     assert second["records_seen"] == 0
     assert store.list_nodes(kinds=["Prompt"], session_id="s1")
     assert not store.list_nodes(kinds=["WorkChange"], session_id="s1")
+
+
+def test_drain_skips_and_quarantines_malformed_jsonl_lines(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    store = InMemoryGraphStore()
+    backend = _StaticGitBackend()
+    path = settings.evidence_dir / "2026-05-20.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    valid_1 = {
+        "id": "raw_good_1",
+        "hash": "h1",
+        "session_id": "s1",
+        "source_app": "codex",
+        "event_name": "user_prompt_submit",
+        "created_at": "2026-05-20T00:00:00+00:00",
+        "payload": {"hook_event_name": "UserPromptSubmit", "session_id": "s1", "prompt": "first valid row"},
+    }
+    valid_2 = {
+        "id": "raw_good_2",
+        "hash": "h2",
+        "session_id": "s1",
+        "source_app": "codex",
+        "event_name": "user_prompt_submit",
+        "created_at": "2026-05-20T00:00:01+00:00",
+        "payload": {"hook_event_name": "UserPromptSubmit", "session_id": "s1", "prompt": "second valid row"},
+    }
+    path.write_bytes(
+        (
+            json.dumps(valid_1)
+            + "\n"
+            + 'broken tool_response fragment", "session_id": "s1"}\n'
+            + json.dumps(valid_2)
+            + "\n"
+        ).encode("utf-8")
+    )
+
+    first = _drain(settings, store, backend).drain()
+    second = _drain(settings, store, backend).drain()
+
+    assert first["records_ingested"] == 2
+    assert first["malformed_records"] == 1
+    assert first["malformed"][0]["error_type"] == "JSONDecodeError"
+    assert first["malformed"][0]["quarantine_path"]
+    assert Path(first["malformed"][0]["quarantine_path"]).exists()
+    assert "broken tool_response fragment" in Path(first["malformed"][0]["quarantine_path"]).read_text(encoding="utf-8")
+    assert second["records_seen"] == 0
+    assert second["malformed_records"] == 0
+    assert [row["id"] for _, row in _read_jsonl_from(path, 0)] == ["raw_good_1", "raw_good_2"]
 
 
 def test_drain_token_threshold_persists_pending_window_across_runs(tmp_path: Path) -> None:

--- a/tests/test_evidence_window.py
+++ b/tests/test_evidence_window.py
@@ -50,7 +50,7 @@ class _FakeQwenClient:
 
 def test_clean_evidence_window_removes_raw_artifacts_and_bounds_records() -> None:
     records = _dirty_records()
-    trigger = TriggerDecision(True, "token_threshold", "pending evidence window reached token threshold")
+    trigger = TriggerDecision(True, "session_boundary", "new session s2 started after session s1")
 
     cleaned = clean_evidence_window(records, trigger)
     encoded = json.dumps(cleaned, ensure_ascii=False).lower()
@@ -67,7 +67,7 @@ def test_qwen_graph_extractor_receives_clean_bounded_prompt(tmp_path: Path) -> N
     fake = _FakeQwenClient()
     extractor = QwenGraphExtractor(settings)
     extractor.client = fake  # type: ignore[assignment]
-    trigger = TriggerDecision(True, "token_threshold", "pending evidence window reached token threshold")
+    trigger = TriggerDecision(True, "session_boundary", "new session s2 started after session s1")
 
     delta = extractor.extract(session_id="s1", records=_dirty_records(), trigger=trigger)
     lowered = fake.prompt.lower()

--- a/tests/test_graph_triggers.py
+++ b/tests/test_graph_triggers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from agent_memory_orchestrator.evidence.triggers import detect_trigger
+from agent_memory_orchestrator.evidence.triggers import is_session_start
+from agent_memory_orchestrator.evidence.triggers import session_boundary_trigger
 
 
 def test_read_only_prompt_does_not_trigger_graph_build() -> None:
@@ -16,7 +18,7 @@ def test_read_only_prompt_does_not_trigger_graph_build() -> None:
     assert decision.trigger_type == "none"
 
 
-def test_apply_patch_tool_does_not_trigger_without_token_threshold() -> None:
+def test_apply_patch_tool_does_not_trigger_processing() -> None:
     decision = detect_trigger(
         {
             "event_name": "post_tool_use",
@@ -29,7 +31,7 @@ def test_apply_patch_tool_does_not_trigger_without_token_threshold() -> None:
     assert decision.trigger_type == "none"
 
 
-def test_test_command_does_not_trigger_without_token_threshold() -> None:
+def test_test_command_does_not_trigger_processing() -> None:
     decision = detect_trigger(
         {
             "event_name": "post_tool_use",
@@ -41,7 +43,7 @@ def test_test_command_does_not_trigger_without_token_threshold() -> None:
     assert decision.trigger_type == "none"
 
 
-def test_finalize_prompt_does_not_trigger_without_token_threshold() -> None:
+def test_finalize_prompt_does_not_trigger_processing() -> None:
     decision = detect_trigger(
         {
             "event_name": "user_prompt_submit",
@@ -53,16 +55,15 @@ def test_finalize_prompt_does_not_trigger_without_token_threshold() -> None:
     assert decision.trigger_type == "none"
 
 
-def test_pending_token_threshold_is_the_only_processing_trigger() -> None:
-    decision = detect_trigger(
-        {
-            "event_name": "post_tool_use",
-            "payload": {"tool": "apply_patch", "content": "Updated src/app.py"},
-        },
-        pending_approx_tokens=100,
-        token_threshold=100,
-    )
+def test_session_start_detection_accepts_codex_event_name_shape() -> None:
+    assert is_session_start({"event_name": "session_start"})
+    assert is_session_start({"payload": {"hook_event_name": "SessionStart"}})
+
+
+def test_session_boundary_is_the_processing_trigger() -> None:
+    decision = session_boundary_trigger("s1", "s2")
 
     assert decision.should_process is True
-    assert decision.trigger_type == "token_threshold"
-    assert decision.approx_tokens == 100
+    assert decision.trigger_type == "session_boundary"
+    assert "s1" in decision.reason
+    assert "s2" in decision.reason

--- a/tests/test_raw_evidence_store.py
+++ b/tests/test_raw_evidence_store.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from agent_memory_orchestrator.evidence.raw_store import RawEvidenceStore
+
+
+def _append_large_record(root: Path, index: int) -> str:
+    evidence = RawEvidenceStore(root)
+    ref = evidence.append(
+        {
+            "hook_event_name": "PostToolUse",
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_response": "line\n" * 2000 + f"record={index}",
+        },
+        session_id="s1",
+        source_app="codex",
+        event_name="post_tool_use",
+    )
+    return ref.id
+
+
+def test_raw_evidence_store_locks_large_jsonl_appends(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    count = 24
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        ids = list(pool.map(lambda index: _append_large_record(root, index), range(count)))
+
+    files = list(root.glob("*.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text(encoding="utf-8").splitlines()
+    rows = [json.loads(line) for line in lines]
+
+    assert len(rows) == count
+    assert {row["id"] for row in rows} == set(ids)
+    assert all(row["event_name"] == "post_tool_use" for row in rows)
+    assert all(row["payload"]["tool_response"].endswith(tuple(f"record={index}" for index in range(count))) for row in rows)
+

--- a/tests/test_reasoning_graph_retrieval.py
+++ b/tests/test_reasoning_graph_retrieval.py
@@ -16,6 +16,8 @@ from agent_memory_orchestrator.graph.store import GraphEdge
 from agent_memory_orchestrator.graph.store import GraphNode
 from agent_memory_orchestrator.graph.store import InMemoryGraphStore
 from agent_memory_orchestrator.llm.qwen import DeterministicPlanner
+from agent_memory_orchestrator.reasoning_graph.jobs.constants import GRAPH_SCHEMA_VERSION
+from agent_memory_orchestrator.reasoning_graph.jobs.constants import PIPELINE_VERSION
 from agent_memory_orchestrator.reasoning_graph import GraphEmbeddingStore
 from agent_memory_orchestrator.reasoning_graph import RetrievalIndexStore
 from agent_memory_orchestrator.reasoning_graph import build_retrieval_documents_from_graph
@@ -141,6 +143,42 @@ def test_retrieval_documents_are_graph_attached_and_fts_indexed(tmp_path: Path) 
     assert {doc.doc_type for doc in docs} == {"reasoning", "code", "symbol"}
     assert hits
     assert hit_docs[hits[0].doc_id].graph_node_id.startswith("reason:")
+
+
+def test_retrieval_document_build_can_filter_to_v2_graph_schema() -> None:
+    graph = InMemoryGraphStore()
+    graph.upsert_node(
+        GraphNode(
+            id="reason:legacy",
+            kind="ReasoningNode",
+            label="legacy graph delta node",
+            summary="Old pre-V2 graph output should not enter V2 retrieval docs.",
+            session_id="s1",
+        )
+    )
+    graph.upsert_node(
+        GraphNode(
+            id="reason:v2",
+            kind="ReasoningNode",
+            label="v2 reasoning node",
+            summary="V2 answer-grade reasoning node.",
+            session_id="s1",
+            metadata={
+                "pipeline_version": PIPELINE_VERSION,
+                "graph_schema_version": GRAPH_SCHEMA_VERSION,
+                "packet_id": "WP0001",
+            },
+        )
+    )
+
+    docs = build_retrieval_documents_from_graph(
+        graph,
+        session_id="s1",
+        pipeline_version=PIPELINE_VERSION,
+        graph_schema_version=GRAPH_SCHEMA_VERSION,
+    )
+
+    assert [doc.graph_node_id for doc in docs] == ["reason:v2"]
 
 
 def test_embedding_missing_retrieval_documents_is_resumable(tmp_path: Path) -> None:

--- a/tests/test_session_cockpit.py
+++ b/tests/test_session_cockpit.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from pathlib import Path
 
 from agent_memory_orchestrator.config import Settings
@@ -22,7 +21,7 @@ class _StaticGitBackend:
 def test_session_cockpit_exposes_timeline_and_cleaned_windows(tmp_path: Path) -> None:
     store = InMemoryGraphStore()
     svc = GraphRagService(
-        replace(make_settings(tmp_path), drain_token_threshold=30),
+        make_settings(tmp_path),
         store=store,
         planner=DeterministicPlanner(),
         version_backend=_StaticGitBackend(),
@@ -55,7 +54,7 @@ def test_session_cockpit_exposes_timeline_and_cleaned_windows(tmp_path: Path) ->
     assert overview["sessions"][0]["raw_events"] == 2
     assert len(detail["timeline"]) == 2
     assert detail["windows"]
-    assert detail["windows"][0]["trigger"]["trigger_type"] == "token_threshold"
+    assert detail["windows"][0]["trigger"]["trigger_type"] == "pending"
     encoded_window = str(detail["windows"][0]["cleaned_evidence"])
     assert "show cleaned session artifacts" in encoded_window
     assert "src/ui.py" in encoded_window

--- a/tests/test_slack_connector.py
+++ b/tests/test_slack_connector.py
@@ -200,7 +200,7 @@ def test_slack_message_evidence_is_local_raw_jsonl(tmp_path) -> None:
     assert rows[-1]["payload"]["message"] == "Keep this Slack decision"
 
 
-def test_slack_finalize_event_waits_for_token_threshold(tmp_path) -> None:
+def test_slack_finalize_event_waits_for_session_boundary(tmp_path) -> None:
     settings = _settings(tmp_path)
     svc = SlackConnectorService(settings, config=SlackConfig(enabled=True))
 
@@ -217,10 +217,6 @@ def test_slack_finalize_event_waits_for_token_threshold(tmp_path) -> None:
     decision = detect_trigger(record)
     assert decision.should_process is False
     assert decision.trigger_type == "none"
-
-    threshold_decision = detect_trigger(record, pending_approx_tokens=100, token_threshold=100)
-    assert threshold_decision.should_process is True
-    assert threshold_decision.trigger_type == "token_threshold"
 
 
 def test_slack_cli_manifest_and_setup(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_v2_session_jobs.py
+++ b/tests/test_v2_session_jobs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from agent_memory_orchestrator.config import Settings
+from agent_memory_orchestrator.app import daemon as daemon_module
 from agent_memory_orchestrator.core.db import connect
 from agent_memory_orchestrator.reasoning_graph.embedding_store import GraphEmbeddingRecord
 from agent_memory_orchestrator.reasoning_graph.embedding_store import GraphEmbeddingStore
@@ -12,6 +13,10 @@ from agent_memory_orchestrator.reasoning_graph.jobs import V2SessionJobStore
 from agent_memory_orchestrator.reasoning_graph.jobs.constants import GRAPH_SCHEMA_VERSION
 from agent_memory_orchestrator.reasoning_graph.jobs.constants import PIPELINE_VERSION
 from agent_memory_orchestrator.reasoning_graph.jobs.reset import reset_production_v2_storage
+from agent_memory_orchestrator.reasoning_graph.jobs.runner import require_complete_v2_reset_marker
+from agent_memory_orchestrator.reasoning_graph.stage4_contract import STAGE4_CONTRACT_VERSION
+from agent_memory_orchestrator.reasoning_graph.stage4_contract import build_stage4_packet_prompt
+from agent_memory_orchestrator.reasoning_graph.stage4_contract import stage4_contract_hash
 from agent_memory_orchestrator.reasoning_graph.retrieval import RetrievalDocument
 from agent_memory_orchestrator.reasoning_graph.retrieval import RetrievalIndexStore
 from agent_memory_orchestrator.graph.service import GraphRagService
@@ -183,6 +188,22 @@ def test_v2_reset_requires_backup_and_preserves_raw_config_and_job_tables(tmp_pa
 
     with pytest.raises(ValueError):
         reset_production_v2_storage(settings, backup=False, clean_graph=True, clean_retrieval=True)
+    with pytest.raises(ValueError, match="clean-graph and --clean-retrieval"):
+        reset_production_v2_storage(
+            settings,
+            backup=True,
+            clean_graph=False,
+            clean_retrieval=True,
+            force_if_daemon_running=True,
+        )
+    with pytest.raises(ValueError, match="clean-graph and --clean-retrieval"):
+        reset_production_v2_storage(
+            settings,
+            backup=True,
+            clean_graph=True,
+            clean_retrieval=False,
+            force_if_daemon_running=True,
+        )
 
     result = reset_production_v2_storage(
         settings,
@@ -219,6 +240,81 @@ def test_v2_reset_requires_backup_and_preserves_raw_config_and_job_tables(tmp_pa
     assert marker is not None
     assert marker["pipeline_version"] == PIPELINE_VERSION
     assert marker["graph_schema_version"] == GRAPH_SCHEMA_VERSION
+    assert marker["cleaned"] == {"graph": True, "retrieval": True, "faiss": True}
+
+
+def test_v2_runner_rejects_missing_incomplete_or_wrong_reset_marker() -> None:
+    complete_marker = {
+        "pipeline_version": PIPELINE_VERSION,
+        "graph_schema_version": GRAPH_SCHEMA_VERSION,
+        "cleaned": {"graph": True, "retrieval": True, "faiss": True},
+    }
+
+    assert require_complete_v2_reset_marker(complete_marker) == complete_marker
+    with pytest.raises(RuntimeError, match="missing"):
+        require_complete_v2_reset_marker(None)
+    with pytest.raises(RuntimeError, match="version_mismatch"):
+        require_complete_v2_reset_marker({**complete_marker, "pipeline_version": "old"})
+    with pytest.raises(RuntimeError, match="incomplete"):
+        require_complete_v2_reset_marker({**complete_marker, "cleaned": {"graph": True, "retrieval": False}})
+
+
+def test_stage4_prompt_uses_reset_contract_module() -> None:
+    prompt = build_stage4_packet_prompt(
+        {
+            "packet_id": "WP0001",
+            "commit": {"short_sha": "abc1234"},
+            "problem_refs": [{"ref": "E00001", "excerpt": "problem"}],
+            "rationale_refs": [],
+            "validation_refs": [],
+        }
+    )
+
+    assert STAGE4_CONTRACT_VERSION == "stage4-reset-2026-05-14"
+    assert len(stage4_contract_hash()) == 64
+    assert "Support refs are provenance only" in prompt
+    assert "Input packet:" in prompt
+
+
+def test_auto_drain_closes_graph_before_v2_runner_opens(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = make_settings(tmp_path)
+    events: list[str] = []
+
+    class FakeGraph:
+        def __init__(self, settings: Settings) -> None:
+            del settings
+            events.append("graph_open")
+
+        def drain_evidence(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            events.append("drain")
+            return {"records_ingested": 1, "windows_processed": 0, "stopped_reason": "done", "pending_sessions": []}
+
+        def close(self) -> None:
+            events.append("graph_close")
+
+    class FakeRunner:
+        def __init__(self, settings: Settings) -> None:
+            del settings
+            events.append("runner_open")
+
+        def run_next(self) -> dict[str, object]:
+            events.append("runner_run")
+            return {"ok": True, "ran": False}
+
+        def close(self) -> None:
+            events.append("runner_close")
+
+    monkeypatch.setattr(daemon_module, "GraphRagService", FakeGraph)
+    monkeypatch.setattr(daemon_module, "V2SessionJobRunner", FakeRunner)
+
+    result = daemon_module._run_auto_drain_once(settings)
+
+    assert result["records_ingested"] == 1
+    assert events == ["graph_open", "drain", "graph_close", "runner_open", "runner_run", "runner_close"]
 
 
 def test_legacy_graphdelta_smoke_uses_disposable_graph_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_v2_session_jobs.py
+++ b/tests/test_v2_session_jobs.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_memory_orchestrator.config import Settings
+from agent_memory_orchestrator.core.db import connect
+from agent_memory_orchestrator.reasoning_graph.embedding_store import GraphEmbeddingRecord
+from agent_memory_orchestrator.reasoning_graph.embedding_store import GraphEmbeddingStore
+from agent_memory_orchestrator.reasoning_graph.jobs import V2SessionJobStore
+from agent_memory_orchestrator.reasoning_graph.jobs.constants import GRAPH_SCHEMA_VERSION
+from agent_memory_orchestrator.reasoning_graph.jobs.constants import PIPELINE_VERSION
+from agent_memory_orchestrator.reasoning_graph.jobs.reset import reset_production_v2_storage
+from agent_memory_orchestrator.reasoning_graph.retrieval import RetrievalDocument
+from agent_memory_orchestrator.reasoning_graph.retrieval import RetrievalIndexStore
+from agent_memory_orchestrator.graph.service import GraphRagService
+from agent_memory_orchestrator.graph.store import InMemoryGraphStore
+
+
+def make_settings(tmp_path: Path) -> Settings:
+    return Settings(
+        home=tmp_path,
+        db_path=tmp_path / ".data" / "main.sqlite",
+        retrieval_db_path=tmp_path / ".data" / "retrieval.sqlite",
+        export_dir=tmp_path / "exports",
+        local_only=True,
+        mcp_transport="stdio",
+        mcp_host="127.0.0.1",
+        mcp_port=8765,
+        embedding_dims=64,
+        embedding_model="hash-fallback",
+        reranker_model="BAAI/bge-reranker-base",
+        vector_backend="disabled",
+        approval_mode="manual",
+        owner_user_id="local",
+        workspace_id="local",
+        project_id="default",
+        visibility_scope="private",
+        sensitivity_level="normal",
+        consensus_threshold=0.7,
+        max_review_rounds=5,
+        graph_path=tmp_path / ".graph" / "amo.kuzu",
+        evidence_dir=tmp_path / ".evidence",
+    )
+
+
+def test_v2_enqueue_is_idempotent_and_atomic_lock_skips_locked_failed_and_pending_model(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    store = V2SessionJobStore(settings)
+    try:
+        first = store.enqueue_session(
+            session_id="s1",
+            boundary_event_id="raw_boundary_1",
+            source_app="codex",
+            repo_path=str(tmp_path),
+            source_evidence_day="2026-05-20",
+        )
+        second = store.enqueue_session(
+            session_id="s1",
+            boundary_event_id="raw_boundary_1",
+            source_app="codex",
+            repo_path=str(tmp_path),
+            source_evidence_day="2026-05-20",
+        )
+
+        assert first.created is True
+        assert second.created is False
+        assert second.reason == "already_enqueued"
+        assert second.job["job_id"] == first.job["job_id"]
+
+        acquired = store.acquire_next(owner="runner-a", lease_seconds=60)
+        assert acquired is not None
+        assert acquired["session_id"] == "s1"
+        assert acquired["status"] == "running"
+        assert acquired["attempt_count"] == 1
+        assert store.acquire_next(owner="runner-b", lease_seconds=60) is None
+
+        store.fail_stage(job_id=acquired["job_id"], stage="evidence_view", reason="boom")
+        assert store.acquire_next(owner="runner-c", lease_seconds=60) is None
+
+        retried = store.retry_job(acquired["job_id"], forced_by="test")
+        assert retried["status"] == "pending"
+        assert retried["forced_by"] == "test"
+
+        reacquired = store.acquire_next(owner="runner-d", lease_seconds=60)
+        assert reacquired is not None
+        store.set_pending_model(job_id=reacquired["job_id"], stage="qwen_reasoning", reason="qwen_unavailable")
+        assert store.acquire_next(owner="runner-e", lease_seconds=60) is None
+    finally:
+        store.close()
+
+
+def test_v2_stage_rows_track_hashes_and_config_hash(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    store = V2SessionJobStore(settings)
+    try:
+        job = store.enqueue_session(session_id="s1", boundary_event_id="raw_boundary").job
+        store.start_stage(
+            job_id=job["job_id"],
+            stage="evidence_view",
+            input_artifact="in.jsonl",
+            input_hash="input-hash",
+            stage_config_hash="config-hash",
+        )
+        store.complete_stage(
+            job_id=job["job_id"],
+            stage="evidence_view",
+            output_artifact="out.json",
+            output_hash="output-hash",
+            diagnostics={"ok": True},
+        )
+        stage = store.stage_row(job_id=job["job_id"], stage="evidence_view")
+        updated = store.get_job(job["job_id"])
+
+        assert stage is not None
+        assert stage["status"] == "complete"
+        assert stage["input_hash"] == "input-hash"
+        assert stage["output_hash"] == "output-hash"
+        assert stage["stage_config_hash"] == "config-hash"
+        assert stage["diagnostics"] == {"ok": True}
+        assert updated is not None
+        assert updated["status"] == "pending"
+        assert updated["current_stage"] == "work_packets"
+        assert updated["last_successful_stage"] == "evidence_view"
+    finally:
+        store.close()
+
+
+def test_v2_reset_requires_backup_and_preserves_raw_config_and_job_tables(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    settings.evidence_dir.mkdir(parents=True)
+    raw_path = settings.evidence_dir / "2026-05-20.jsonl"
+    raw_path.write_text('{"id":"raw_1","session_id":"s1"}\n', encoding="utf-8")
+    settings.home.mkdir(parents=True, exist_ok=True)
+    config_path = settings.home / "config.json"
+    config_path.write_text('{"local_only": true}\n', encoding="utf-8")
+    settings.graph_path.mkdir(parents=True)
+    (settings.graph_path / "graph.bin").write_text("legacy graph", encoding="utf-8")
+    faiss_dir = settings.retrieval_db_path.parent / "indexes" / settings.retrieval_db_path.stem
+    faiss_dir.mkdir(parents=True)
+    (faiss_dir / "index.faiss").write_text("legacy faiss", encoding="utf-8")
+
+    conn = connect(settings.retrieval_db_path)
+    try:
+        RetrievalIndexStore(conn).replace_documents(
+            [
+                RetrievalDocument(
+                    doc_id="doc:1",
+                    doc_type="packet",
+                    graph_node_id="node:1",
+                    node_kind="Packet",
+                    packet_id="packet:1",
+                    commit_sha="abc123",
+                    title="legacy",
+                    body="legacy retrieval doc",
+                )
+            ]
+        )
+        GraphEmbeddingStore(conn, db_path=settings.retrieval_db_path).upsert(
+            GraphEmbeddingRecord.create(
+                node_id="node:1",
+                node_kind="Packet",
+                memory_class="graph_context",
+                graph_scope="default",
+                graph_path=str(settings.graph_path),
+                session_id="s1",
+                extraction_run_id="run",
+                embedding_kind="retrieval_text",
+                model="hash-fallback",
+                text="legacy retrieval doc",
+                vector=[0.1, 0.2],
+            )
+        )
+    finally:
+        conn.close()
+
+    store = V2SessionJobStore(settings)
+    try:
+        job = store.enqueue_session(session_id="s1", boundary_event_id="raw_boundary").job
+    finally:
+        store.close()
+
+    with pytest.raises(ValueError):
+        reset_production_v2_storage(settings, backup=False, clean_graph=True, clean_retrieval=True)
+
+    result = reset_production_v2_storage(
+        settings,
+        backup=True,
+        clean_graph=True,
+        clean_retrieval=True,
+        force_if_daemon_running=True,
+    )
+
+    assert result["ok"] is True
+    backup_dir = Path(result["backup_path"])
+    assert (backup_dir / "backup_manifest.json").exists()
+    assert (backup_dir / "config.json").exists()
+    assert raw_path.exists()
+    assert config_path.exists()
+    assert not settings.graph_path.exists()
+    assert not faiss_dir.exists()
+
+    conn = connect(settings.retrieval_db_path)
+    try:
+        doc_count = conn.execute("SELECT COUNT(*) FROM retrieval_documents").fetchone()[0]
+        embedding_count = conn.execute("SELECT COUNT(*) FROM graph_embeddings").fetchone()[0]
+    finally:
+        conn.close()
+    assert doc_count == 0
+    assert embedding_count == 0
+
+    store = V2SessionJobStore(settings)
+    try:
+        assert store.get_job(job["job_id"]) is not None
+        marker = store.marker()
+    finally:
+        store.close()
+    assert marker is not None
+    assert marker["pipeline_version"] == PIPELINE_VERSION
+    assert marker["graph_schema_version"] == GRAPH_SCHEMA_VERSION
+
+
+def test_legacy_graphdelta_smoke_uses_disposable_graph_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = make_settings(tmp_path)
+    created_paths: list[Path] = []
+
+    class FakeSmokeStore:
+        def __init__(self, path: Path) -> None:
+            self.path = path
+            created_paths.append(path)
+
+        def init_schema(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    def fake_drain_fresh_graph(self: GraphRagService, store: FakeSmokeStore, **kwargs: object) -> dict[str, object]:
+        return {"records_seen": 1, "windows_processed": 1, "cursor_path": str(kwargs["cursor_path"])}
+
+    monkeypatch.setattr("agent_memory_orchestrator.graph.service.KuzuGraphStore", FakeSmokeStore)
+    monkeypatch.setattr(GraphRagService, "_drain_fresh_graph", fake_drain_fresh_graph)
+
+    svc = GraphRagService(settings, store=InMemoryGraphStore())
+    try:
+        result = svc.drain_evidence_smoke(limit=10, max_windows=1)
+    finally:
+        svc.close()
+
+    assert result["mode"] == "legacy_graphdelta_smoke"
+    assert result["graph_path"] != str(settings.graph_path)
+    assert ".state" in str(result["graph_path"])
+    assert created_paths == [Path(str(result["graph_path"]))]


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session-based automatic processing: System now triggers evidence processing when a new session begins instead of token thresholds
  * V2 Job Pipeline: New versioned job system with observable stages, pause/retry capabilities, and progress tracking
  * Job Management API: Added `/api/jobs` endpoints to list, view details, and retry processing jobs
  * Production Reset Utility: New maintenance command for safely resetting graph/retrieval storage with automated backups and validation
  * Job Dashboard: Admin UI panel displaying active jobs, processing status, and reset markers

* **Bug Fixes**
  * Improved evidence durability with concurrent-safe appending

* **Documentation**
  * Updated architecture and operations guides for session-based processing, V2 pipeline stages, and production reset workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spurbey/agent-memory-orchestrator/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->