### PR TITLE
fix(v2): initialize fresh production stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ amo-cli doctor --target codex
 amo-daemon
 ```
 
+Fresh installs initialize an empty V2 production graph marker automatically. The destructive
+`v2-reset-production` command is only for machines that already have old pre-V2 graph/retrieval
+data and need an explicit backup-first cleanup.
+
 Open the local UI:
 
 ```text
@@ -87,6 +91,7 @@ python -m venv .venv
 pip install -e ".[dev,models]"
 amo-cli init-db
 amo-cli init-graph
+amo-cli v2-init-production
 amo-daemon
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,6 +45,9 @@ operator command:
 amo-cli v2-reset-production --backup --clean-graph --clean-retrieval
 ```
 
+Fresh installs do not need this command. Install/init creates a non-destructive
+fresh V2 marker when production graph and retrieval stores are empty.
+
 The reset command never deletes raw JSONL evidence, config, or V2 job tables.
 It writes the production reset marker only after both graph and retrieval/vector
 storage have been cleaned from a verified backup; backup-only runs do not unlock

--- a/docs/reasoning_graph/README.md
+++ b/docs/reasoning_graph/README.md
@@ -49,6 +49,10 @@ cleanup is never automatic on daemon startup. Operators must run:
 amo-cli v2-reset-production --backup --clean-graph --clean-retrieval
 ```
 
+New devices with empty production graph/retrieval stores should use normal
+install/init instead; `amo-cli v2-init-production` writes the fresh-store marker
+without deleting anything.
+
 The command backs up production graph/retrieval/vector stores first, verifies a
 backup manifest, then cleans only graph/retrieval/vector/FAISS storage. Raw JSONL
 evidence, config, and V2 job tables are preserved.

--- a/npm/agent-memory-orchestrator-cli/README.md
+++ b/npm/agent-memory-orchestrator-cli/README.md
@@ -20,6 +20,10 @@ npx agent-memory-orchestrator-cli -- install --target all --preset cpu-balanced 
 
 If `npx` resolves `agent-memory-orchestrator-cli@0.1.1`, that registry package is too old for this command shape. Publish/use `0.1.2` or newer.
 
+On a fresh device, install initializes the empty V2 production marker automatically. The
+`v2-reset-production` command is only for an existing AMO home with old pre-V2 graph/retrieval
+data that must be backed up and cleaned explicitly.
+
 ## Common Options
 
 | Option | Meaning |

--- a/src/agent_memory_orchestrator/app/cli.py
+++ b/src/agent_memory_orchestrator/app/cli.py
@@ -46,6 +46,7 @@ from ..reasoning_graph.session_runtime import build_session_graph
 from ..reasoning_graph.session_runtime import default_session_graph_path
 from ..reasoning_graph.session_runtime import query_session_graph
 from ..reasoning_graph.jobs.reset import adopt_existing_v2_production_storage
+from ..reasoning_graph.jobs.reset import initialize_fresh_v2_production_storage
 from ..reasoning_graph.jobs.reset import reset_production_v2_storage
 from ..skill_checkpoint import DEFAULT_LOCAL_NUM_CTX
 from ..skill_checkpoint import DEFAULT_NUM_PREDICT
@@ -70,6 +71,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("init-db", help="Initialize local database schema")
     sub.add_parser("init-graph", help="Initialize local Kuzu GraphRAG schema")
+    sub.add_parser(
+        "v2-init-production",
+        help="Non-destructively mark empty fresh graph/retrieval stores as production V2-ready",
+    )
 
     v2_reset = sub.add_parser("v2-reset-production", help="Explicitly back up and reset production V2 graph/retrieval stores")
     v2_reset.add_argument("--backup", action="store_true", help="Required. Create a timestamped backup before cleaning.")
@@ -599,6 +604,7 @@ def main(argv: list[str] | None = None) -> int:
                 )
             init_result = None
             init_graph = None
+            init_v2 = None
             if not args.skip_init_db:
                 os.environ["AMO_HOME"] = plan["amo_home"]
                 init_settings = Settings.load()
@@ -614,6 +620,15 @@ def main(argv: list[str] | None = None) -> int:
                     init_graph = {"ok": True, "graph_path": str(init_settings.graph_path)}
                 except GraphBackendUnavailable as exc:
                     init_graph = {"ok": False, "error": str(exc)}
+                if init_graph.get("ok"):
+                    try:
+                        init_v2 = initialize_fresh_v2_production_storage(init_settings)
+                    except Exception as exc:
+                        init_v2 = {
+                            "ok": False,
+                            "error": str(exc),
+                            "note": "Existing non-empty graph/retrieval stores need explicit v2-reset-production or v2-adopt-production.",
+                        }
             _print(
                 {
                     "ok": True,
@@ -622,6 +637,7 @@ def main(argv: list[str] | None = None) -> int:
                     "models": model_result,
                     "init_db": init_result,
                     "init_graph": init_graph,
+                    "init_v2_production": init_v2,
                 }
             )
             return 0
@@ -655,6 +671,11 @@ def main(argv: list[str] | None = None) -> int:
                 _print({"ok": True, "graph_path": str(settings.graph_path), "backend": settings.graph_backend})
             finally:
                 graph.close()
+            return 0
+
+        if args.command == "v2-init-production":
+            settings = Settings.load()
+            _print(initialize_fresh_v2_production_storage(settings))
             return 0
 
         if args.command == "v2-reset-production":

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/reset.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/reset.py
@@ -10,10 +10,49 @@ from ...app.client import DaemonClient
 from ...app.client import DaemonUnavailable
 from ...core.config import Settings
 from ...core.db import connect
+from ...graph.store import KuzuGraphStore
 from .constants import GRAPH_SCHEMA_VERSION
 from .constants import PIPELINE_VERSION
 from .constants import RESET_MARKER_KEY
 from .store import V2SessionJobStore
+
+
+def initialize_fresh_v2_production_storage(settings: Settings) -> dict[str, Any]:
+    """Mark a fresh, empty production install as V2-ready.
+
+    This is intentionally non-destructive. It exists for new devices: they have
+    no pre-V2 graph/retrieval data to clean, so forcing the operator through a
+    reset command is wrong. Existing non-empty stores still require explicit
+    backup-first reset/adoption.
+    """
+    store = V2SessionJobStore(settings)
+    try:
+        existing = store.marker(RESET_MARKER_KEY)
+    finally:
+        store.close()
+    if existing is not None:
+        return {"ok": True, "created": False, "reason": "marker_exists", "marker": existing}
+
+    graph = _validate_empty_graph_store(settings)
+    retrieval = _validate_empty_retrieval_store(settings)
+    if not graph.get("empty") or not retrieval.get("empty"):
+        raise RuntimeError(
+            "v2_fresh_init_refused_non_empty_stores:"
+            + json.dumps({"graph": graph, "retrieval": retrieval}, sort_keys=True)
+        )
+
+    marker = {
+        "production_v2_initialized_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "pipeline_version": PIPELINE_VERSION,
+        "graph_schema_version": GRAPH_SCHEMA_VERSION,
+        "fresh_install": True,
+        "backup_path": "",
+        "cleaned": {"graph": True, "retrieval": True, "faiss": True},
+        "validated": {"graph_empty": True, "retrieval_empty": True},
+        "validation": {"graph": graph, "retrieval": retrieval},
+    }
+    _write_marker(settings, marker)
+    return {"ok": True, "created": True, "reason": "fresh_empty_stores", "marker": marker}
 
 
 def reset_production_v2_storage(
@@ -255,6 +294,26 @@ def _validate_existing_graph_store(settings: Settings) -> dict[str, Any]:
     return result
 
 
+def _validate_empty_graph_store(settings: Settings) -> dict[str, Any]:
+    graph = KuzuGraphStore(settings.graph_path)
+    try:
+        graph.init_schema()
+        status = graph.merge_status()
+        counts = status.get("counts") if isinstance(status, dict) else {}
+        node_count = sum(int(value) for value in counts.values()) if isinstance(counts, dict) else 0
+        edge_sample_count = len(graph.list_edges(limit=1))
+    finally:
+        graph.close()
+    return {
+        "ok": node_count == 0 and edge_sample_count == 0,
+        "empty": node_count == 0 and edge_sample_count == 0,
+        "path": str(settings.graph_path),
+        "node_count": node_count,
+        "edge_sample_count": edge_sample_count,
+        "check": "kuzu_node_edge_empty",
+    }
+
+
 def _validate_existing_retrieval_store(settings: Settings) -> dict[str, Any]:
     path = settings.retrieval_db_path
     if not path.exists():
@@ -280,6 +339,35 @@ def _validate_existing_retrieval_store(settings: Settings) -> dict[str, Any]:
     if not result["ok"]:
         raise RuntimeError(f"v2_adopt_retrieval_validation_failed:{json.dumps(result, sort_keys=True)}")
     return result
+
+
+def _validate_empty_retrieval_store(settings: Settings) -> dict[str, Any]:
+    path = settings.retrieval_db_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = connect(path)
+    try:
+        doc_count = _table_count(conn, "retrieval_documents")
+        embedding_count = _table_count(conn, "graph_embeddings")
+    finally:
+        conn.close()
+    return {
+        "ok": doc_count == 0 and embedding_count == 0,
+        "empty": doc_count == 0 and embedding_count == 0,
+        "path": str(path),
+        "retrieval_document_count": doc_count,
+        "embedding_count": embedding_count,
+        "check": "retrieval_and_embedding_tables_empty",
+    }
+
+
+def _table_count(conn: Any, table: str) -> int:
+    exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    if exists is None:
+        return 0
+    return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
 
 
 def _path_has_content(path: Path) -> bool:

--- a/src/agent_memory_orchestrator/web/js/control-room/renderers.js
+++ b/src/agent_memory_orchestrator/web/js/control-room/renderers.js
@@ -314,6 +314,9 @@ function renderJobCard(job) {
 
 function renderMarker(marker) {
   if (!marker) return `<span class="pill warn">V2 production marker missing</span><span class="pill">run reset or adopt before V2 graph writes</span>`;
+  if (marker.fresh_install) {
+    return `<span class="pill good">Fresh V2 stores ready</span><span class="pill blue">${escapeHtml(marker.pipeline_version || "v2")}</span><span class="pill">no pre-V2 graph cleanup needed</span>`;
+  }
   if (marker.adopted_existing_v2) {
     const docs = marker.validation?.retrieval?.retrieval_document_count;
     return `<span class="pill good">V2 adopted existing stores</span><span class="pill blue">${escapeHtml(marker.pipeline_version || "v2")}</span>${docs ? `<span class="pill">${escapeHtml(docs)} retrieval docs at adoption</span>` : ""}`;

--- a/tests/test_v2_session_jobs.py
+++ b/tests/test_v2_session_jobs.py
@@ -13,6 +13,7 @@ from agent_memory_orchestrator.reasoning_graph.jobs import V2SessionJobStore
 from agent_memory_orchestrator.reasoning_graph.jobs.constants import GRAPH_SCHEMA_VERSION
 from agent_memory_orchestrator.reasoning_graph.jobs.constants import PIPELINE_VERSION
 from agent_memory_orchestrator.reasoning_graph.jobs.reset import adopt_existing_v2_production_storage
+from agent_memory_orchestrator.reasoning_graph.jobs.reset import initialize_fresh_v2_production_storage
 from agent_memory_orchestrator.reasoning_graph.jobs.reset import reset_production_v2_storage
 from agent_memory_orchestrator.reasoning_graph.jobs.runner import require_complete_v2_reset_marker
 from agent_memory_orchestrator.reasoning_graph.stage4_contract import STAGE4_CONTRACT_VERSION
@@ -242,6 +243,54 @@ def test_v2_reset_requires_backup_and_preserves_raw_config_and_job_tables(tmp_pa
     assert marker["pipeline_version"] == PIPELINE_VERSION
     assert marker["graph_schema_version"] == GRAPH_SCHEMA_VERSION
     assert marker["cleaned"] == {"graph": True, "retrieval": True, "faiss": True}
+
+
+def test_v2_fresh_init_marks_empty_new_install_without_reset(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    settings.home.mkdir(parents=True, exist_ok=True)
+
+    result = initialize_fresh_v2_production_storage(settings)
+
+    assert result["ok"] is True
+    assert result["created"] is True
+    marker = result["marker"]
+    assert marker["fresh_install"] is True
+    assert marker["pipeline_version"] == PIPELINE_VERSION
+    assert marker["graph_schema_version"] == GRAPH_SCHEMA_VERSION
+    assert marker["cleaned"] == {"graph": True, "retrieval": True, "faiss": True}
+    assert marker["validated"] == {"graph_empty": True, "retrieval_empty": True}
+    assert require_complete_v2_reset_marker(marker) == marker
+
+    again = initialize_fresh_v2_production_storage(settings)
+    assert again["created"] is False
+    assert again["reason"] == "marker_exists"
+
+
+def test_v2_fresh_init_refuses_non_empty_retrieval_store(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    settings.home.mkdir(parents=True, exist_ok=True)
+    settings.retrieval_db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = connect(settings.retrieval_db_path)
+    try:
+        RetrievalIndexStore(conn).replace_documents(
+            [
+                RetrievalDocument(
+                    doc_id="doc:1",
+                    doc_type="packet",
+                    graph_node_id="node:1",
+                    node_kind="Packet",
+                    packet_id="packet:1",
+                    commit_sha="abc123",
+                    title="existing",
+                    body="existing retrieval doc",
+                )
+            ]
+        )
+    finally:
+        conn.close()
+
+    with pytest.raises(RuntimeError, match="refused_non_empty_stores"):
+        initialize_fresh_v2_production_storage(settings)
 
 
 def test_v2_adopt_production_backs_up_and_preserves_existing_v2_stores(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds a non-destructive V2 production marker path for fresh installs so new devices do not need the backup-first reset command intended for old pre-V2 graph cleanup.

Install now attempts fresh V2 marker initialization after DB/graph setup, exposes amo-cli v2-init-production for empty stores, updates dashboard marker wording, and documents reset as migration-only.

## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * V2 production graphs now automatically initialize on fresh installs without requiring manual reset commands.
  * Added `v2-init-production` CLI command for non-destructive fresh store initialization.

* **Documentation**
  * Clarified that fresh installations automatically create empty V2 production markers; the reset command is now limited to machines with pre-V2 data requiring explicit backup cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spurbey/agent-memory-orchestrator/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->