### PR TITLE
fix(v2): fail jobs with no work packets

### DIFF
--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
@@ -76,6 +76,9 @@ class V2SessionJobRunner:
         except PendingModel as exc:
             self.job_store.set_pending_model(job_id=job_id, stage=stage, reason=exc.reason, diagnostics=exc.diagnostics)
             return {"ok": True, "ran": True, "job_id": job_id, "stage": stage, "status": "pending_model", "reason": exc.reason}
+        except StageFailed as exc:
+            self.job_store.fail_stage(job_id=job_id, stage=stage, reason=exc.reason, diagnostics=exc.diagnostics)
+            return {"ok": False, "ran": True, "job_id": job_id, "stage": stage, "status": "failed", "error": exc.reason}
         except Exception as exc:
             self.job_store.fail_stage(
                 job_id=job_id,
@@ -164,6 +167,17 @@ class V2SessionJobRunner:
         output.write_text(json.dumps(list(build.packets), indent=2, ensure_ascii=False), encoding="utf-8")
         (stage_dir / "packet_quality_inventory.json").write_text(json.dumps(build.quality, indent=2, ensure_ascii=False), encoding="utf-8")
         (stage_dir / "quarantined_commits.json").write_text(json.dumps(list(build.quarantined_commits), indent=2), encoding="utf-8")
+        if build.quality.get("stage_acceptance") != "PASS":
+            reason = "no_commit_backed_work_packets" if not build.packets else "work_packets_acceptance_failed"
+            raise StageFailed(
+                reason,
+                {
+                    "quality": build.quality,
+                    "packet_artifact": str(output),
+                    "quarantined_commit_count": len(build.quarantined_commits),
+                    "note": "V2 answer-grade graph output requires at least one resolved Git commit-backed work packet.",
+                },
+            )
         return StageResult(output_path=output, diagnostics={"quality": build.quality})
 
     def _stage_qwen_reasoning(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
@@ -419,6 +433,13 @@ class V2SessionJobRunner:
 
 
 class PendingModel(RuntimeError):
+    def __init__(self, reason: str, diagnostics: dict[str, Any] | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.diagnostics = diagnostics or {}
+
+
+class StageFailed(RuntimeError):
     def __init__(self, reason: str, diagnostics: dict[str, Any] | None = None) -> None:
         super().__init__(reason)
         self.reason = reason

--- a/tests/test_v2_session_jobs.py
+++ b/tests/test_v2_session_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from agent_memory_orchestrator.reasoning_graph.jobs.reset import adopt_existing_
 from agent_memory_orchestrator.reasoning_graph.jobs.reset import initialize_fresh_v2_production_storage
 from agent_memory_orchestrator.reasoning_graph.jobs.reset import reset_production_v2_storage
 from agent_memory_orchestrator.reasoning_graph.jobs.runner import require_complete_v2_reset_marker
+from agent_memory_orchestrator.reasoning_graph.jobs.runner import V2SessionJobRunner
 from agent_memory_orchestrator.reasoning_graph.stage4_contract import STAGE4_CONTRACT_VERSION
 from agent_memory_orchestrator.reasoning_graph.stage4_contract import build_stage4_packet_prompt
 from agent_memory_orchestrator.reasoning_graph.stage4_contract import stage4_contract_hash
@@ -130,6 +132,76 @@ def test_v2_stage_rows_track_hashes_and_config_hash(tmp_path: Path) -> None:
         assert updated["status"] == "pending"
         assert updated["current_stage"] == "work_packets"
         assert updated["last_successful_stage"] == "evidence_view"
+    finally:
+        store.close()
+
+
+def test_v2_runner_fails_instead_of_completing_empty_graph_when_no_work_packets(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    settings.evidence_dir.mkdir(parents=True, exist_ok=True)
+    transcript_path = tmp_path / "transcript.jsonl"
+    transcript_rows = [
+        {
+            "type": "response_item",
+            "timestamp": "2026-05-21T10:00:00Z",
+            "payload": {"type": "message", "role": "user", "content": [{"text": "Explain the installer behavior."}]},
+        },
+        {
+            "type": "response_item",
+            "timestamp": "2026-05-21T10:01:00Z",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"text": "I found the issue and should document the decision, but no git commit was created."}],
+            },
+        },
+    ]
+    transcript_path.write_text("".join(json.dumps(row) + "\n" for row in transcript_rows), encoding="utf-8")
+    evidence_path = settings.evidence_dir / "2026-05-21.jsonl"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "id": "raw_1",
+                "session_id": "s-no-commit",
+                "event_name": "session_start",
+                "transcript_path": str(transcript_path),
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    store = V2SessionJobStore(settings)
+    try:
+        job = store.enqueue_session(
+            session_id="s-no-commit",
+            boundary_event_id="raw_boundary",
+            source_app="codex",
+            repo_path=str(tmp_path),
+            source_evidence_day="2026-05-21",
+        ).job
+        runner = V2SessionJobRunner(settings, job_store=store)
+
+        first = runner.run_next()
+        second = runner.run_next()
+
+        assert first["stage"] == "evidence_view"
+        assert first["status"] == "pending"
+        assert second["stage"] == "work_packets"
+        assert second["status"] == "failed"
+        assert second["error"] == "no_commit_backed_work_packets"
+
+        updated = store.get_job(job["job_id"])
+        assert updated is not None
+        assert updated["status"] == "failed"
+        assert updated["current_stage"] == "work_packets"
+        assert "no_commit_backed_work_packets" in updated["error"]["reason"]
+        stages = store.list_stages(job["job_id"])
+        assert [stage["stage"] for stage in stages] == ["evidence_view", "work_packets"]
+        work_stage = stages[1]
+        assert work_stage["status"] == "failed"
+        assert work_stage["diagnostics"]["quality"]["packet_count"] == 0
+        assert Path(work_stage["diagnostics"]["packet_artifact"]).exists()
     finally:
         store.close()
 


### PR DESCRIPTION
Stops the V2 runner from treating zero commit-backed work packets as a successful empty graph build.

The work_packets stage now writes diagnostic artifacts, fails with no_commit_backed_work_packets, and preserves quality details so operators can see that raw evidence existed but no resolved Git commit-backed packet was available.

## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.
