### PR TITLE
fix(installer): select compatible python for kuzu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-0f766e.svg"></a>
-  <img alt="Python 3.10+" src="https://img.shields.io/badge/python-3.10%2B-2563eb.svg">
+  <img alt="Python 3.10-3.13" src="https://img.shields.io/badge/python-3.10--3.13-2563eb.svg">
   <img alt="Local first" src="https://img.shields.io/badge/local--first-yes-16a34a.svg">
   <img alt="GraphRAG V2" src="https://img.shields.io/badge/GraphRAG-V2-7c3aed.svg">
 </p>
@@ -51,7 +51,7 @@ flowchart LR
 
 Prerequisites:
 
-- Python 3.10+
+- Python 3.10, 3.11, 3.12, or 3.13
 - Node.js 18+
 - pipx
 - Ollama for local Qwen reasoning
@@ -62,6 +62,10 @@ npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-bala
 amo-cli doctor --target codex
 amo-daemon
 ```
+
+The `npx` installer automatically chooses a compatible Python for `pipx` and skips
+Python 3.14 when it would force Kuzu to build from source. If a machine has no
+Python 3.10-3.13 interpreter, install Python 3.13 and rerun the same command.
 
 Fresh installs initialize an empty V2 production graph marker automatically. The destructive
 `v2-reset-production` command is only for machines that already have old pre-V2 graph/retrieval

--- a/npm/agent-memory-orchestrator-cli/README.md
+++ b/npm/agent-memory-orchestrator-cli/README.md
@@ -18,7 +18,20 @@ Install for Claude and Codex:
 npx -y agent-memory-orchestrator-cli -- install --target all --preset cpu-balanced --qwen-model qwen3.5:9b
 ```
 
-If `npx` resolves `agent-memory-orchestrator-cli@0.1.1`, that registry package is too old for this command shape. Publish/use `0.1.3` or newer.
+If `npx` resolves `agent-memory-orchestrator-cli@0.1.1`, that registry package is too old for this command shape. Publish/use `0.1.4` or newer.
+
+The wrapper automatically skips Python versions that are too new for AMO's Kuzu
+dependency and asks `pipx` to create the AMO app with Python 3.10, 3.11, 3.12,
+or 3.13. This avoids the common macOS ARM failure where `python3` points to
+Python 3.14 and pip tries to build Kuzu from source. If automatic discovery
+cannot find the right interpreter, install Python 3.13 and rerun the same
+command.
+
+For unusual machines, you can override the interpreter explicitly:
+
+```bash
+npx -y agent-memory-orchestrator-cli -- install --pipx-python /opt/homebrew/bin/python3.13 --target codex
+```
 
 On a fresh device, install initializes the empty V2 production marker automatically. The
 `v2-reset-production` command is only for an existing AMO home with old pre-V2 graph/retrieval
@@ -29,6 +42,7 @@ data that must be backed up and cleaned explicitly.
 | Option | Meaning |
 | --- | --- |
 | `--target codex|claude|all` | Agent configs to patch |
+| `--pipx-python <path>` | Optional override for the Python used by pipx |
 | `--preset cpu-light|cpu-balanced|gpu-quality` | Local model profile |
 | `--qwen-model <model>` | Ollama Qwen model written to config |
 | `--with-models` | Install embedding/vector extras |

--- a/npm/agent-memory-orchestrator-cli/bin/cli.js
+++ b/npm/agent-memory-orchestrator-cli/bin/cli.js
@@ -11,6 +11,8 @@ const DEFAULT_SPEC =
 const PIPX_PACKAGE = process.env.AMO_PIPX_PACKAGE || "agent-memory-orchestrator";
 const MODEL_PACKAGES = ["sentence-transformers", "faiss-cpu"];
 const SLACK_PACKAGES = ["websocket-client"];
+const PYTHON_MIN_MINOR = 10;
+const PYTHON_MAX_MINOR = 13;
 const VALUE_FLAGS = new Set([
   "--target",
   "--user-home",
@@ -33,6 +35,7 @@ Usage:
 
 Wrapper flags:
   --from <pip_spec>     Install AMO from a custom pip spec.
+  --pipx-python <path>  Override the Python interpreter used for the pipx AMO env.
   --with-models         Inject sentence-transformers and faiss-cpu into the pipx app.
   --with-slack          Inject websocket-client into the pipx app.
   --with-all-extras     Enable all optional runtime extras.
@@ -95,12 +98,121 @@ function findPythonLauncher() {
   return null;
 }
 
+function pythonProbeScript() {
+  return [
+    "import json, sys",
+    "print(json.dumps({'major': sys.version_info[0], 'minor': sys.version_info[1], 'executable': sys.executable}))",
+  ].join("; ");
+}
+
+function probePython(cmd, args = []) {
+  const label = [cmd, ...args].join(" ");
+  const result = run(cmd, [...args, "-c", pythonProbeScript()], { silent: true });
+  if (!result.ok) {
+    return { ok: false, label, error: outputTail(`${result.stdout || ""}\n${result.stderr || ""}`, 500) };
+  }
+  try {
+    const parsed = JSON.parse((result.stdout || "").trim());
+    return {
+      ok: true,
+      label,
+      cmd,
+      args,
+      major: Number(parsed.major),
+      minor: Number(parsed.minor),
+      version: `${parsed.major}.${parsed.minor}`,
+      executable: String(parsed.executable || cmd),
+    };
+  } catch (error) {
+    return { ok: false, label, error: `Could not parse Python version output: ${error.message}` };
+  }
+}
+
+function isSupportedPython(info) {
+  return info && info.major === 3 && info.minor >= PYTHON_MIN_MINOR && info.minor <= PYTHON_MAX_MINOR;
+}
+
+function pythonUnsupportedHint(checked) {
+  const seen = checked.length
+    ? ` Checked: ${checked.map((item) => `${item.label}${item.version ? `=${item.version}` : ""}`).join(", ")}.`
+    : "";
+  return (
+    `AMO currently needs Python 3.${PYTHON_MIN_MINOR}-3.${PYTHON_MAX_MINOR} for installation because Kuzu wheels ` +
+    "are not available for every newer Python/platform combination yet. Install Python 3.13, 3.12, 3.11, or 3.10 " +
+    "and rerun the same npx command." +
+    seen
+  );
+}
+
+function addPythonCandidate(candidates, seen, cmd, args = []) {
+  const key = [cmd, ...args].join("\u0000");
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  candidates.push({ cmd, args });
+}
+
+function pythonCandidates() {
+  const candidates = [];
+  const seen = new Set();
+
+  const preferred = [process.env.AMO_PIPX_PYTHON, process.env.PIPX_DEFAULT_PYTHON].filter(Boolean);
+  for (const value of preferred) {
+    addPythonCandidate(candidates, seen, value, []);
+  }
+
+  if (process.platform === "win32") {
+    for (const minor of [13, 12, 11, 10]) {
+      addPythonCandidate(candidates, seen, "py", [`-3.${minor}`]);
+    }
+    for (const minor of [13, 12, 11, 10]) {
+      addPythonCandidate(candidates, seen, `python3.${minor}`, []);
+    }
+    addPythonCandidate(candidates, seen, "python", []);
+    addPythonCandidate(candidates, seen, "python3", []);
+  } else {
+    for (const minor of [13, 12, 11, 10]) {
+      addPythonCandidate(candidates, seen, `python3.${minor}`, []);
+    }
+    addPythonCandidate(candidates, seen, "python3", []);
+    addPythonCandidate(candidates, seen, "python", []);
+  }
+
+  return candidates;
+}
+
+function selectInstallPython(explicitPython) {
+  const checked = [];
+  if (explicitPython) {
+    const info = probePython(explicitPython);
+    checked.push(info);
+    if (info.ok && isSupportedPython(info)) {
+      return info;
+    }
+    throw new Error(`--pipx-python must point to Python 3.${PYTHON_MIN_MINOR}-3.${PYTHON_MAX_MINOR}. ${pythonUnsupportedHint(checked)}`);
+  }
+
+  for (const candidate of pythonCandidates()) {
+    const info = probePython(candidate.cmd, candidate.args);
+    if (!info.ok) {
+      continue;
+    }
+    checked.push(info);
+    if (isSupportedPython(info)) {
+      return info;
+    }
+  }
+
+  throw new Error(pythonUnsupportedHint(checked));
+}
+
 function getPipxRunner(options = {}) {
   const allowBootstrap = options.allowBootstrap !== false;
   if (commandExists("pipx")) {
     return { cmd: "pipx", prefix: [] };
   }
-  const py = findPythonLauncher();
+  const py = options.bootstrapPython || findPythonLauncher();
   if (!py) {
     return null;
   }
@@ -118,6 +230,7 @@ function pipxArgs(runner, args) {
 
 function parseInstallArgs(argv) {
   let spec = DEFAULT_SPEC;
+  let pipxPython = null;
   const amoArgs = [];
   const extras = new Set();
 
@@ -129,6 +242,15 @@ function parseInstallArgs(argv) {
         throw new Error("--from requires a value");
       }
       spec = next;
+      i += 1;
+      continue;
+    }
+    if (arg === "--pipx-python") {
+      const next = argv[i + 1];
+      if (!next) {
+        throw new Error("--pipx-python requires a value");
+      }
+      pipxPython = next;
       i += 1;
       continue;
     }
@@ -161,7 +283,7 @@ function parseInstallArgs(argv) {
     extras.add("models");
   }
 
-  return { spec, amoArgs, extras };
+  return { spec, pipxPython, amoArgs, extras };
 }
 
 function bootstrapPipx(pyCmd) {
@@ -233,11 +355,12 @@ function resolveInstalledApp(runner, appName) {
 }
 
 function runInstall(argv) {
-  const { spec, amoArgs, extras } = parseInstallArgs(argv);
-  const runner = getPipxRunner({ allowBootstrap: true });
+  const { spec, pipxPython, amoArgs, extras } = parseInstallArgs(argv);
+  const installPython = selectInstallPython(pipxPython);
+  const runner = getPipxRunner({ allowBootstrap: true, bootstrapPython: installPython.executable });
   if (!runner) {
     throw new Error(
-      "Python is not available on PATH. Install Python 3.10+ first, then rerun this command."
+      `Python 3.${PYTHON_MIN_MINOR}-3.${PYTHON_MAX_MINOR} is not available. Install a supported Python first, then rerun this command.`
     );
   }
 
@@ -245,8 +368,14 @@ function runInstall(argv) {
     bootstrapPipx(runner.cmd);
   }
 
-  console.log("[3/5] Installing Agent Memory Orchestrator with pipx...");
-  runQuietOrThrow(runner.cmd, pipxArgs(runner, ["install", "--force", spec]), "pipx install failed.");
+  console.log(
+    `[3/5] Installing Agent Memory Orchestrator with pipx using Python ${installPython.version} (${installPython.executable})...`
+  );
+  runQuietOrThrow(
+    runner.cmd,
+    pipxArgs(runner, ["install", "--force", "--python", installPython.executable, spec]),
+    "pipx install failed."
+  );
 
   injectOptionalPackages(runner, extras);
 
@@ -270,6 +399,12 @@ function runInstall(argv) {
 
 function runDoctor(args) {
   const py = findPythonLauncher();
+  let installPython = null;
+  try {
+    installPython = selectInstallPython(null);
+  } catch (_error) {
+    installPython = null;
+  }
   const runner = getPipxRunner({ allowBootstrap: false });
   const amoCli = runner ? resolveInstalledApp(runner, "amo-cli") : commandExists("amo-cli") ? "amo-cli" : null;
   if (amoCli) {
@@ -280,6 +415,9 @@ function runDoctor(args) {
     JSON.stringify(
       {
         python: py || null,
+        compatible_install_python: installPython
+          ? { version: installPython.version, executable: installPython.executable }
+          : null,
         pipx_available: Boolean(runner),
         amo_cli_available: false,
         hint: "Run `npx -y agent-memory-orchestrator-cli -- install --target codex --preset cpu-balanced --qwen-model qwen3.5:9b`.",

--- a/npm/agent-memory-orchestrator-cli/package.json
+++ b/npm/agent-memory-orchestrator-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-memory-orchestrator-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "npx installer wrapper for Agent Memory Orchestrator",
   "license": "MIT",
   "type": "commonjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-memory-orchestrator"
-version = "0.1.3"
+version = "0.1.4"
 description = "Shared persistent memory and multi-agent orchestration over local MCP."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [


### PR DESCRIPTION
Teach the npx wrapper to probe Python 3.10-3.13 and pass the selected interpreter to pipx, skipping Python 3.14 so Kuzu does not fall back to a source build.

Document the supported Python range, keep --pipx-python as an escape hatch, and bump the npm wrapper to 0.1.4 alongside the Python package metadata guard.

## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--pipx-python <path>` option to CLI for explicit Python interpreter selection
  * CLI now validates Python compatibility and auto-selects supported version (3.10–3.13)
  * Doctor command includes compatible Python version in output

* **Documentation**
  * Updated README to clarify Python version support (3.10–3.13)
  * Added guidance on Python version requirements and new CLI option

* **Chores**
  * Version bumped to 0.1.4
  * Updated Python version constraint to 3.10–3.13

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spurbey/agent-memory-orchestrator/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->