### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/src/agent_memory_orchestrator/graph/service.py
+++ b/src/agent_memory_orchestrator/graph/service.py
@@ -38,7 +38,6 @@ from .cache import GraphSearchCache
 from .consolidation import DeterministicGraphConsolidator
 from .answer_trace import build_answer_trace
 from .answer_trace import build_central_answer_trace
-from .answer_trace import format_answer_trace
 from .merge import CommitMergeEngine, QwenMergeClassifier
 from .session import QwenGraphExtractor, SessionGraphBuilder
 from .store import GraphEdge, GraphNode, GraphStore, KuzuGraphStore
@@ -1334,18 +1333,19 @@ def _answer_from_retrieval_result(
             "citations": [],
             "node_ids": [],
         }
-    lines = ["AMO indexed graph answer:"]
+    lines = ["Answer from repository memory:"]
     citations: list[dict[str, Any]] = []
     node_ids: list[str] = []
-    for index, hit in enumerate(hits[:5], start=1):
+    answer_rank = 0
+    for index, hit in enumerate(hits[:8], start=1):
         doc = hit.get("document") if isinstance(hit, dict) and isinstance(hit.get("document"), dict) else {}
         graph_node = hit.get("graph_node") if isinstance(hit, dict) and isinstance(hit.get("graph_node"), dict) else {}
         neighbors = hit.get("neighbors") if isinstance(hit, dict) and isinstance(hit.get("neighbors"), list) else []
         node_id = str(doc.get("graph_node_id") or graph_node.get("id") or "")
         node_ids.append(node_id)
-        title = str(doc.get("title") or graph_node.get("label") or node_id)
+        title = _public_answer_title(doc=doc, graph_node=graph_node, fallback=node_id)
         body = str(doc.get("body") or graph_node.get("summary") or "")
-        statement = _body_field(body, "statement") or _best_answer_line(body) or str(graph_node.get("summary") or "")
+        statement = _public_answer_statement(doc=doc, graph_node=graph_node, body=body)
         reason = _body_field(body, "reason")
         trace = (
             build_answer_trace(
@@ -1360,15 +1360,19 @@ def _answer_from_retrieval_result(
         support = _answer_support(doc=doc, graph_node=graph_node, neighbors=neighbors, trace=trace)
         if not trace.get("node_count"):
             trace = _fallback_trace_from_retrieval_doc(doc=doc, node_id=node_id, support=support)
-        line = f"{index}. {title}: {statement}".strip()
-        if reason and reason.lower() != statement.lower():
-            line += f" Reason: {reason}"
-        trace_summary = format_answer_trace(trace)
-        if trace_summary:
-            line += f" Trace: {trace_summary}"
-        if support["summary"]:
-            line += f" Support: {support['summary']}"
-        lines.append(line)
+        if str(doc.get("doc_type") or "") not in {"packet", "evidence", "graph_lineage"}:
+            answer_rank += 1
+            line = f"{answer_rank}. {title}: {statement}".strip()
+            public_reason = _public_answer_text(reason)
+            if public_reason and public_reason.lower() != statement.lower():
+                line += f" Reason: {public_reason}"
+            trace_summary = _public_trace_summary(trace)
+            if trace_summary:
+                line += f" Evidence: {trace_summary}"
+            public_support = _public_support_summary(support)
+            if public_support:
+                line += f" Support: {public_support}"
+            lines.append(line)
         citations.append(
             {
                 "rank": index,
@@ -1440,6 +1444,113 @@ def _fallback_trace_from_retrieval_doc(*, doc: dict[str, Any], node_id: str, sup
             "neighbor_node_ids": support.get("neighbor_node_ids", []),
         },
     }
+
+
+def _public_trace_summary(trace: dict[str, Any]) -> str:
+    if not trace or not trace.get("node_count"):
+        return ""
+    chain_parts: list[str] = []
+    for item in trace.get("chain") or []:
+        role = str(item.get("role") or "").strip()
+        kind = str(item.get("kind") or "").strip()
+        public_role = _public_trace_role(role or kind)
+        if public_role == "accepted reasoning":
+            summary = _public_answer_text(str(item.get("summary") or item.get("label") or ""))
+            value = f"{public_role}: {summary}" if summary else public_role
+        else:
+            value = public_role
+        if value and value not in chain_parts:
+            chain_parts.append(value)
+    support_parts: list[str] = []
+    support = trace.get("support") if isinstance(trace.get("support"), dict) else {}
+    if support.get("commit_shas"):
+        support_parts.append("commit-backed")
+    if support.get("evidence_ids"):
+        support_parts.append("evidence-backed")
+    if support.get("code_nodes"):
+        support_parts.append("code-backed")
+    return " -> ".join([*chain_parts[:4], *support_parts])
+
+
+def _public_trace_role(role: str) -> str:
+    normalized = str(role or "").strip().lower()
+    labels = {
+        "central_version": "active memory version",
+        "knowledgeversion": "active memory version",
+        "reasoning": "accepted reasoning",
+        "reasoningnode": "accepted reasoning",
+        "file_impact": "changed file",
+        "fileimpactsummary": "changed file",
+        "code_impact": "implementation change",
+        "codeimpactsummary": "implementation change",
+        "commit": "commit support",
+        "packet": "session support",
+        "evidence": "evidence support",
+        "evidenceref": "evidence support",
+    }
+    return labels.get(normalized, "")
+
+
+def _public_support_summary(support: dict[str, Any]) -> str:
+    parts: list[str] = []
+    if support.get("packet_ids"):
+        parts.append("session context")
+    if support.get("commit_shas"):
+        parts.append("commit-backed")
+    if support.get("evidence_ids"):
+        parts.append("evidence-backed")
+    if support.get("code_nodes") or support.get("code_node_ids"):
+        parts.append("code-linked")
+    return ", ".join(parts)
+
+
+def _public_answer_title(*, doc: dict[str, Any], graph_node: dict[str, Any], fallback: str) -> str:
+    metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+    doc_type = str(doc.get("doc_type") or "").strip().lower()
+    if doc_type == "file_impact":
+        path = str(metadata.get("path") or "").strip()
+        if path:
+            return f"Changes in {path}"
+    if doc_type == "code_impact":
+        commit_messages = metadata.get("commit_messages") if isinstance(metadata.get("commit_messages"), list) else []
+        if commit_messages:
+            return _public_answer_text(str(commit_messages[0]))
+    return _public_answer_text(str(doc.get("title") or graph_node.get("label") or fallback))
+
+
+def _public_answer_statement(*, doc: dict[str, Any], graph_node: dict[str, Any], body: str) -> str:
+    metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
+    doc_type = str(doc.get("doc_type") or "").strip().lower()
+    if doc_type == "file_impact":
+        path = str(metadata.get("path") or "").strip()
+        reasons = metadata.get("reasons") if isinstance(metadata.get("reasons"), list) else []
+        reason = _public_answer_text(str(reasons[0])) if reasons else ""
+        if path and reason:
+            return f"{path} changed because {reason}"
+        if path:
+            return f"{path} changed in the retrieved work."
+    if doc_type == "code_impact":
+        reason = _public_answer_text(str(metadata.get("reason") or ""))
+        if reason:
+            return reason
+    if doc_type == "reasoning":
+        statement = _public_answer_text(str(metadata.get("statement") or ""))
+        if statement:
+            return statement
+    return _public_answer_text(_body_field(body, "statement") or _best_answer_line(body) or str(graph_node.get("summary") or ""))
+
+
+def _public_answer_text(text: str) -> str:
+    cleaned = re.sub(r"\{[^{}]{0,2000}\}", "", str(text or ""))
+    cleaned = re.sub(r"\{.*$", "", cleaned)
+    cleaned = re.sub(r"\b(?:FileImpactSummary|CodeImpactSummary|ReasoningNode):\s*", "", cleaned)
+    cleaned = re.sub(r"\bImpact summary for\s+", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\bWP\d{3,}\b", "work item", cleaned)
+    cleaned = re.sub(r"\bE\d{3,}\b", "evidence record", cleaned)
+    cleaned = re.sub(r"\bpacket\s+work item\b", "work item", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\bwork packet\b", "work item", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"\bevidence\s+evidence record\b", "evidence record", cleaned, flags=re.IGNORECASE)
+    return cleaned
 
 
 def _answer_support(

--- a/src/agent_memory_orchestrator/reasoning_graph/central_merge/applier.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/central_merge/applier.py
@@ -22,7 +22,7 @@ from .models import utc_now
 EXACT_APPLY_ATOM_KINDS = frozenset({"commit", "file"})
 REVIEW_APPLY_ATOM_KINDS = frozenset({"decision", "problem"})
 APPLY_ATOM_KINDS = EXACT_APPLY_ATOM_KINDS | REVIEW_APPLY_ATOM_KINDS
-APPLIER_VERSION = "central-commit-file-decision-review-applier-v1"
+APPLIER_VERSION = "central-commit-file-decision-status-applier-v1"
 
 
 class CentralMergeApplyError(RuntimeError):
@@ -98,7 +98,7 @@ def apply_merge_plan(
         try:
             owned_store.update_central_merge_plan_status(plan_id=plan_id, status="applying", mode="apply_exact_atoms")
             owned_graph.init_schema()
-            added_nodes, added_edges = _write_exact_atoms(
+            added_nodes, added_edges, status_updates = _write_exact_atoms(
                 graph_store=owned_graph,
                 plan=plan,
                 graph_commit_id=graph_commit_id,
@@ -135,6 +135,8 @@ def apply_merge_plan(
                     "applied_version_counts": apply_summary["applied_version_counts"],
                     "deferred_atom_counts": apply_summary["deferred_atom_counts"],
                     "review_relation_edge_count": apply_summary["review_relation_edge_count"],
+                    "status_update_count": len(status_updates),
+                    "status_updates": status_updates,
                 },
             )
             graph_view = owned_store.update_graph_view_head(
@@ -153,6 +155,8 @@ def apply_merge_plan(
                     "added_node_count": len(added_nodes),
                     "added_edge_count": len(added_edges),
                     **apply_summary,
+                    "status_update_count": len(status_updates),
+                    "status_updates": status_updates,
                 },
             )
             result = {
@@ -165,12 +169,16 @@ def apply_merge_plan(
                 "repo_id": str(plan.get("repo_id") or ""),
                 "branch": branch,
                 "view_mode": mode,
+                "graph_commit_id": graph_commit_id,
+                "graph_view_id": str(graph_view.get("view_id") or ""),
                 "graph_commit": graph_commit_row,
                 "graph_view": graph_view,
                 "added_node_count": len(added_nodes),
                 "added_edge_count": len(added_edges),
                 "added_nodes": added_nodes,
                 "added_edges": added_edges,
+                "status_updates": status_updates,
+                "status_update_count": len(status_updates),
                 "input_source": str(plan.get("input_source") or ""),
                 "curated_input_hash": str(plan.get("curated_input_hash") or ""),
                 "trace_input_hash": str(plan.get("trace_input_hash") or ""),
@@ -232,6 +240,8 @@ def _write_merge_result_artifact(*, store: V2SessionJobStore, plan: dict[str, An
             "mode": result.get("mode", ""),
             "branch": result.get("branch", ""),
             "view_mode": result.get("view_mode", ""),
+            "graph_commit_id": result.get("graph_commit_id", ""),
+            "graph_view_id": result.get("graph_view_id", ""),
             "graph_commit": result.get("graph_commit", {}),
             "graph_view": result.get("graph_view", {}),
             "added_node_count": result.get("added_node_count", 0),
@@ -242,6 +252,8 @@ def _write_merge_result_artifact(*, store: V2SessionJobStore, plan: dict[str, An
             "applied_version_counts": result.get("applied_version_counts", {}),
             "deferred_atom_counts": result.get("deferred_atom_counts", {}),
             "review_relation_edge_count": result.get("review_relation_edge_count", 0),
+            "status_update_count": result.get("status_update_count", 0),
+            "status_updates": result.get("status_updates", []),
             "idempotent": result.get("idempotent", False),
             "applied_at": result.get("applied_at", utc_now()),
             "apply_scope": result.get("apply_scope", ["commit", "file", "knowledge_version", "graph_commit", "graph_view"]),
@@ -294,6 +306,195 @@ def _kind_counts(items: list[dict[str, Any]], *, include: set[str] | frozenset[s
     return counts
 
 
+def _write_decision_status_transitions(
+    *,
+    graph_store: GraphStore,
+    plan: dict[str, Any],
+    versions: list[dict[str, Any]],
+    relation_edges: list[dict[str, Any]],
+    graph_commit_id: str,
+    base: dict[str, Any],
+    now: str,
+) -> tuple[list[dict[str, str]], list[str]]:
+    """Apply conservative decision/problem status transitions.
+
+    Review relation edges are useful, but versioning needs a current-state
+    pointer. This policy only promotes accepted decisions that are not involved
+    in ambiguous review relations, and only mutates older statuses when the
+    relation itself carries clear duplicate/refine/supersede/conflict meaning.
+    """
+
+    decision_version_ids = {
+        str(version.get("version_id") or "")
+        for version in versions
+        if str(version.get("atom_kind") or "") in REVIEW_APPLY_ATOM_KINDS and str(version.get("version_id") or "")
+    }
+    if not decision_version_ids:
+        return [], []
+
+    nodes = _nodes_by_id(graph_store.list_nodes(kinds=["KnowledgeVersion"], limit=1_000_000))
+    desired: dict[str, tuple[str, str]] = {}
+    relation_version_ids: set[str] = set()
+    ambiguous_version_ids: set[str] = set()
+
+    for edge in relation_edges:
+        kind = str(edge.get("kind") or "")
+        source_id = str(edge.get("source_id") or "")
+        target_id = str(edge.get("target_id") or "")
+        confidence = float(edge.get("confidence") or 0.0)
+        evidence = _relation_evidence(edge)
+        if not source_id or not target_id or source_id == target_id:
+            continue
+        if source_id in decision_version_ids:
+            relation_version_ids.add(source_id)
+        if target_id in decision_version_ids:
+            relation_version_ids.add(target_id)
+        if kind == "RELATED_REVIEW":
+            ambiguous_version_ids.update(item for item in (source_id, target_id) if item in decision_version_ids)
+            continue
+        if not _relation_targets_central_version(edge):
+            ambiguous_version_ids.update(item for item in (source_id, target_id) if item in decision_version_ids)
+            continue
+        if kind == "DUPLICATE_OF" and confidence >= 0.82:
+            if _is_decision_version(nodes.get(target_id, {})):
+                _choose_status(desired, target_id, "active", "duplicate_canonical")
+            continue
+        if kind == "REFINES" and confidence >= 0.76:
+            if source_id in decision_version_ids:
+                _choose_status(desired, source_id, "active", "refines_newer_version")
+            if _is_decision_version(nodes.get(target_id, {})):
+                _choose_status(desired, target_id, "refined", "refined_by_newer_version")
+            continue
+        if kind == "SUPERSEDES" and _safe_supersedes(confidence=confidence, evidence=evidence):
+            if source_id in decision_version_ids:
+                _choose_status(desired, source_id, "active", "supersedes_prior_version")
+            if _is_decision_version(nodes.get(target_id, {})):
+                _choose_status(desired, target_id, "superseded", "superseded_by_newer_version")
+            continue
+        if kind == "CONFLICTS_WITH" and _safe_conflict(confidence=confidence, evidence=evidence):
+            if source_id in decision_version_ids:
+                _choose_status(desired, source_id, "contested", "conflicts_with_review")
+            if _is_decision_version(nodes.get(target_id, {})):
+                _choose_status(desired, target_id, "contested", "conflicts_with_review")
+
+    for version_id in sorted(decision_version_ids):
+        if version_id not in relation_version_ids and version_id not in ambiguous_version_ids:
+            _choose_status(desired, version_id, "active", "new_decision_no_conflict")
+
+    updates: list[dict[str, str]] = []
+    edge_ids: list[str] = []
+    for version_id, (new_status, reason) in sorted(desired.items()):
+        node = nodes.get(version_id)
+        if not node or not _is_decision_version(node):
+            continue
+        old_status = str(node.get("status") or (node.get("metadata") or {}).get("status") or "review")
+        if old_status == new_status:
+            continue
+        _upsert_node_status(graph_store, node=node, status=new_status)
+        edge_id = _edge_id("STATUS_CHANGED", version_id, version_id, graph_commit_id)
+        graph_store.upsert_edge(
+            GraphEdge(
+                id=edge_id,
+                source_id=version_id,
+                target_id=version_id,
+                kind="STATUS_CHANGED",
+                confidence=1.0,
+                created_at=now,
+                metadata={
+                    **base,
+                    "old_status": old_status,
+                    "new_status": new_status,
+                    "reason": reason,
+                    "idempotency_key": _idempotency_key("edge", edge_id, graph_commit_id),
+                },
+            )
+        )
+        updates.append({"version_id": version_id, "old_status": old_status, "new_status": new_status, "reason": reason})
+        edge_ids.append(edge_id)
+    return updates, edge_ids
+
+
+def _nodes_by_id(nodes: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {str(node.get("id") or ""): node for node in nodes if str(node.get("id") or "")}
+
+
+def _is_decision_version(node: dict[str, Any]) -> bool:
+    metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+    return str(node.get("kind") or node.get("node_kind") or "") == "KnowledgeVersion" and str(metadata.get("atom_kind") or "") in REVIEW_APPLY_ATOM_KINDS
+
+
+def _choose_status(desired: dict[str, tuple[str, str]], version_id: str, status: str, reason: str) -> None:
+    priorities = {"contested": 50, "superseded": 40, "refined": 30, "active": 20, "review": 10}
+    current = desired.get(version_id)
+    if current is None or priorities.get(status, 0) > priorities.get(current[0], 0):
+        desired[version_id] = (status, reason)
+
+
+def _relation_evidence(edge: dict[str, Any]) -> dict[str, Any]:
+    metadata = edge.get("metadata") if isinstance(edge.get("metadata"), dict) else {}
+    score = metadata.get("score") if isinstance(metadata.get("score"), dict) else {}
+    return {
+        "reason": str(metadata.get("reason") or edge.get("reason") or ""),
+        "lexical": float(score.get("lexical") or 0.0),
+        "file_overlap": float(score.get("file_overlap") or 0.0),
+        "code_entity_overlap": float(score.get("code_entity_overlap") or 0.0),
+        "false_positive_risk": bool(score.get("false_positive_risk")),
+        "source_scope": str(score.get("source_scope") or ""),
+        "target_scope": str(score.get("target_scope") or ""),
+    }
+
+
+def _relation_targets_central_version(edge: dict[str, Any]) -> bool:
+    metadata = edge.get("metadata") if isinstance(edge.get("metadata"), dict) else {}
+    score = metadata.get("score") if isinstance(metadata.get("score"), dict) else {}
+    return str(score.get("target_scope") or "").lower() == "central"
+
+
+def _safe_supersedes(*, confidence: float, evidence: dict[str, Any]) -> bool:
+    if confidence >= 0.68:
+        return True
+    return (
+        str(evidence.get("reason") or "") == "new_decision_uses_replacement_language"
+        and float(evidence.get("code_entity_overlap") or 0.0) >= 0.6
+        and float(evidence.get("lexical") or 0.0) >= 0.35
+        and not bool(evidence.get("false_positive_risk"))
+    )
+
+
+def _safe_conflict(*, confidence: float, evidence: dict[str, Any]) -> bool:
+    if confidence >= 0.68:
+        return True
+    return (
+        str(evidence.get("reason") or "") == "incompatible_decision_language"
+        and float(evidence.get("file_overlap") or 0.0) >= 0.6
+        and float(evidence.get("lexical") or 0.0) >= 0.35
+        and not bool(evidence.get("false_positive_risk"))
+    )
+
+
+def _upsert_node_status(graph_store: GraphStore, *, node: dict[str, Any], status: str) -> None:
+    metadata = dict(node.get("metadata") if isinstance(node.get("metadata"), dict) else {})
+    metadata["status"] = status
+    graph_store.upsert_node(
+        GraphNode(
+            id=str(node.get("id") or ""),
+            kind=str(node.get("kind") or node.get("node_kind") or "KnowledgeVersion"),
+            label=str(node.get("label") or ""),
+            summary=str(node.get("summary") or ""),
+            status=status,
+            scope=str(node.get("scope") or "central"),
+            session_id=str(node.get("session_id") or ""),
+            project_id=str(node.get("project_id") or "default"),
+            source_app=str(node.get("source_app") or "v2-central-merge"),
+            evidence_id=str(node.get("evidence_id") or ""),
+            commit_id=str(node.get("commit_id") or ""),
+            created_at=str(node.get("created_at") or ""),
+            updated_at=utc_now(),
+            metadata=metadata,
+        )
+    )
+
+
 def _review_candidate_count(plan: dict[str, Any], kinds: set[str]) -> int:
     candidates = plan.get("review_candidates") if isinstance(plan.get("review_candidates"), list) else []
     count = 0
@@ -313,7 +514,7 @@ def _write_exact_atoms(
     graph_commit_id: str,
     branch: str,
     mode: str,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], list[dict[str, str]]]:
     now = utc_now()
     base = _base_metadata(plan=plan, graph_commit_id=graph_commit_id)
     atoms = [atom for atom in plan.get("new_atoms", []) if isinstance(atom, dict) and atom.get("atom_kind") in APPLY_ATOM_KINDS]
@@ -422,6 +623,7 @@ def _write_exact_atoms(
             added_edges.append(derived_edge_id)
 
     version_ids = {str(version.get("version_id") or "") for version in versions}
+    relation_edges: list[dict[str, Any]] = []
     for relation in plan.get("version_edges", []) if isinstance(plan.get("version_edges"), list) else []:
         if not isinstance(relation, dict):
             continue
@@ -429,6 +631,8 @@ def _write_exact_atoms(
         target_id = str(relation.get("target_id") or "")
         kind = str(relation.get("kind") or "")
         if kind not in {"DUPLICATE_OF", "REFINES", "SUPERSEDES", "CONFLICTS_WITH", "RELATED_REVIEW"}:
+            continue
+        if source_id == target_id:
             continue
         if source_id not in version_ids or (target_id not in version_ids and not target_id.startswith("kver:")):
             continue
@@ -446,6 +650,18 @@ def _write_exact_atoms(
             )
         )
         added_edges.append(edge_id)
+        relation_edges.append({**relation, "edge_id": edge_id, "source_id": source_id, "target_id": target_id, "kind": kind})
+
+    status_updates, status_edges = _write_decision_status_transitions(
+        graph_store=graph_store,
+        plan=plan,
+        versions=versions,
+        relation_edges=relation_edges,
+        graph_commit_id=graph_commit_id,
+        base=base,
+        now=now,
+    )
+    added_edges.extend(status_edges)
 
     graph_store.upsert_node(
         GraphNode(
@@ -464,12 +680,14 @@ def _write_exact_atoms(
                 "parent_graph_commit_id": str(plan.get("parent_graph_commit_id") or ""),
                 "added_node_count": len(added_nodes),
                 "added_edge_count": len(added_edges),
+                "status_update_count": len(status_updates),
+                "status_updates": status_updates,
                 "idempotency_key": _idempotency_key("node", graph_commit_id, graph_commit_id),
             },
         )
     )
     added_nodes.append(graph_commit_id)
-    return _dedupe(added_nodes), _dedupe(added_edges)
+    return _dedupe(added_nodes), _dedupe(added_edges), status_updates
 
 
 def _write_graph_view_node(

--- a/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/jobs/runner.py
@@ -32,6 +32,7 @@ from ..promotion import build_curated_session_graph
 from ..retrieval import RETRIEVAL_EMBEDDING_KIND
 from ..retrieval import RetrievalDocument
 from ..retrieval import RetrievalIndexStore
+from ..retrieval import build_retrieval_documents_from_graph
 from ..retrieval import embed_missing_retrieval_documents
 from ..session_graph_writer import build_compact_session_graph
 from ..session_graph_writer import write_compact_session_graph
@@ -657,7 +658,11 @@ class V2SessionJobRunner:
                     max_doc_chars=self.settings.auto_retrieval_max_doc_chars,
                     limit=self.settings.auto_retrieval_node_limit,
                 )
+                central_docs, central_graph_error = self._central_active_retrieval_docs(repo_id=repo_id)
+                current_docs = [*current_docs, *central_docs]
                 retrieval_source = "curated_graph_manifest"
+                if central_graph_error:
+                    graph_error = central_graph_error
             else:
                 current_docs = []
                 retrieval_source = "curated_graph_manifest_missing"
@@ -709,12 +714,39 @@ class V2SessionJobRunner:
             "active_projection_id": projection.get("projection_id") if activation_gate["passed"] else "",
             "activation_gate": activation_gate,
             "current_doc_count": len(current_docs),
+            "central_active_doc_count": len([doc for doc in current_docs if doc.metadata.get("source") == "central_active_graph_view"]),
             "carried_forward_doc_count": max(0, len(docs) - len(current_docs)),
             "doc_content_hash": doc_content_hash,
             **manifest_info,
         }
         output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return StageResult(output_path=output, diagnostics=payload)
+
+    def _central_active_retrieval_docs(self, *, repo_id: str) -> tuple[list[RetrievalDocument], str]:
+        graph = self.graph_store_factory(repo_central_graph_path(self.settings, repo_id))
+        try:
+            graph.init_schema()
+            docs = build_retrieval_documents_from_graph(
+                graph,
+                node_limit=self.settings.auto_retrieval_node_limit,
+                max_doc_chars=self.settings.auto_retrieval_max_doc_chars,
+                pipeline_version="",
+                graph_schema_version="",
+                repo_id=repo_id,
+            )
+        except Exception as exc:  # pragma: no cover - central graph may be locked by another process
+            return [], f"central_active_graph_view_scan_failed:{type(exc).__name__}:{exc}"
+        finally:
+            graph.close()
+        central_docs = [
+            dataclass_replace(
+                doc,
+                metadata={**doc.metadata, "source": "central_active_graph_view", "repo_id": repo_id},
+            )
+            for doc in docs
+            if doc.doc_type in {"central_version", "central_atom", "graph_lineage"}
+        ]
+        return central_docs, ""
 
     def _stage_embeddings(self, job: dict[str, Any], artifact_dir: Path, stage_dir: Path) -> StageResult:
         del artifact_dir
@@ -1200,9 +1232,12 @@ def _merge_cumulative_retrieval_docs(
 ) -> list[RetrievalDocument]:
     """Build the active repo projection as a cumulative product-memory surface."""
     merged: dict[str, RetrievalDocument] = {}
+    current_has_central_docs = any(str(doc.metadata.get("source") or "") == "central_active_graph_view" for doc in current_docs)
     for doc in existing_docs:
         source = str(doc.metadata.get("source") or "")
         if source not in {"curated_graph_manifest", "central_active_graph_view"}:
+            continue
+        if current_has_central_docs and source == "central_active_graph_view":
             continue
         if doc.node_kind in {"CodeNode", "CodeHunk", "Symbol", "CodeVersion"}:
             continue

--- a/src/agent_memory_orchestrator/reasoning_graph/reasoning_extraction.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/reasoning_extraction.py
@@ -55,6 +55,10 @@ ALIGNMENT_STOPWORDS = {
     "make",
     "new",
     "path",
+    "plan",
+    "plans",
+    "implementation",
+    "reasoning",
     "src",
     "test",
     "tests",
@@ -63,6 +67,17 @@ ALIGNMENT_STOPWORDS = {
     "uses",
     "with",
 }
+
+BLOCKING_REVIEW_DIAGNOSTIC_KINDS = frozenset(
+    {
+        "missing_packet_result",
+        "json_parse_failed",
+        "parsed_output_missing",
+        "packet_id_mismatch",
+        "commit_sha_mismatch",
+        "nodes_not_list",
+    }
+)
 
 
 @dataclass(slots=True, frozen=True)
@@ -126,6 +141,12 @@ def review_reasoning_extraction_results(
         diagnostics_all.extend(reviewed["diagnostics"])
 
     packet_ids = {str(result.get("packet_id") or "") for result in reviewed_results}
+    blocking_diagnostics = [
+        diagnostic
+        for diagnostic in diagnostics_all
+        if str(diagnostic.get("kind") or "") in BLOCKING_REVIEW_DIAGNOSTIC_KINDS
+    ]
+    stage_acceptance = "PASS_WITH_REVIEW_BUCKET" if reviewed_results and accepted_all and not blocking_diagnostics else "FAIL"
     summary = {
         "packet_count": len(reviewed_results),
         "unique_packet_count": len(packet_ids),
@@ -152,9 +173,9 @@ def review_reasoning_extraction_results(
                 if diagnostic.get("level") == "warning" and diagnostic.get("packet_id")
             }
         ),
-        "stage_acceptance": "PASS_WITH_REVIEW_BUCKET"
-        if reviewed_results and not any(d.get("level") == "error" for d in diagnostics_all)
-        else "FAIL",
+        "blocking_diagnostic_count": len(blocking_diagnostics),
+        "blocking_diagnostic_kinds": _diagnostic_counts(blocking_diagnostics, "kind"),
+        "stage_acceptance": stage_acceptance,
     }
     return ReasoningExtractionReview(
         results=tuple(reviewed_results),

--- a/src/agent_memory_orchestrator/reasoning_graph/retrieval.py
+++ b/src/agent_memory_orchestrator/reasoning_graph/retrieval.py
@@ -887,7 +887,11 @@ def _is_active_central_node(node: dict[str, Any], active_graph_commit_ids: set[s
     if node_kind == "GraphCommit":
         return str(node.get("id") or "") in active_graph_commit_ids or graph_commit_id in active_graph_commit_ids
     if node_kind in {"KnowledgeAtom", "KnowledgeVersion"}:
-        return graph_commit_id in active_graph_commit_ids and str(node.get("status") or metadata.get("status") or "active") == "active"
+        # GraphView HEAD identifies the active branch snapshot, not only the
+        # latest GraphCommit's newly-created versions. Older active versions
+        # remain part of the branch until a later STATUS_CHANGED edge refines,
+        # supersedes, contests, or reverts them.
+        return bool(graph_commit_id) and str(node.get("status") or metadata.get("status") or "active") == "active"
     return False
 
 
@@ -1036,6 +1040,8 @@ def retrieve_session_graph(
         max_chars=rerank_max_chars,
     )
 
+    ranked = [item for item in ranked if _meaningful_hit(item[1], item[3])]
+
     graph_nodes = (
         {str(node.get("id")): node for node in graph_store.list_nodes(limit=100000, session_id=session_id)}
         if include_graph_nodes
@@ -1064,6 +1070,16 @@ def retrieve_session_graph(
             "vector": len(vector),
             "fused": len(fused),
         },
+    )
+
+
+def _meaningful_hit(score: float, reasons: tuple[str, ...]) -> bool:
+    if score <= 0:
+        return False
+    return any(
+        str(reason).startswith(("term_overlap:", "topic_focus_overlap:", "central_active_boost:", "version_target_overlap:", "exact:"))
+        or str(reason).startswith("bi_encoder_score:")
+        for reason in reasons
     )
 
 
@@ -1163,10 +1179,16 @@ def _safe_reranker_prefix(value: str) -> str:
 
 def classify_query(query: str) -> str:
     lowered = query.lower()
-    if re.search(r"\b(version flow|version history|version chain|symbol version|symbol history|show versions?)\b", lowered):
+    if re.search(r"\b(version flow|version history|version chain|symbol version|symbol history|show versions?|over time|evolved?|evolution)\b", lowered):
         return "version_flow"
+    if re.search(r"\bwhat changed\b|\bchanges? for\b|\bhow .* changed\b", lowered):
+        return "code_why" if _query_has_code_locator(query) or re.search(r"\b(code|file|function|class|module|ui|graph|service|controls?)\b", lowered) else "semantic_search"
     if "why" in lowered or "reason" in lowered:
-        return "code_why"
+        return (
+            "code_why"
+            if _query_has_code_locator(query) or re.search(r"\b(code|file|function|class|module|ui|service|controls?)\b", lowered)
+            else "decision_history"
+        )
     if "decision" in lowered or "decide" in lowered:
         return "decision_history"
     if "::" in query or re.search(r"\b[\w./-]+\.(py|js|ts|tsx|jsx|md)\b", lowered):
@@ -1189,7 +1211,7 @@ def _documents_for_node(node: dict[str, Any], *, max_doc_chars: int) -> list[Ret
         or node.get("commit_id")
         or ""
     )
-    title = str(node.get("label") or node_id)
+    title = _node_title(node)
     body = _node_body(node)
     chunks = _chunk_text(body, max_doc_chars=max_doc_chars)
     out: list[RetrievalDocument] = []
@@ -1310,6 +1332,10 @@ def _clip(text: str, limit: int) -> str:
 
 def _node_body(node: dict[str, Any]) -> str:
     metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+    if str(node.get("kind") or "") == "KnowledgeVersion":
+        return _central_version_body(node, metadata)
+    if str(node.get("kind") or "") == "KnowledgeAtom":
+        return _central_atom_body(node, metadata)
     fields = [
         f"kind: {node.get('kind') or ''}",
         f"status: {node.get('status') or ''}",
@@ -1355,6 +1381,109 @@ def _node_body(node: dict[str, Any]) -> str:
             fields.append(f"{key}: {value}")
     fields.append("metadata: " + json.dumps(metadata, sort_keys=True))
     return "\n".join(str(field) for field in fields if str(field).strip())
+
+
+def _node_title(node: dict[str, Any]) -> str:
+    metadata = node.get("metadata") if isinstance(node.get("metadata"), dict) else {}
+    kind = str(node.get("kind") or "")
+    if kind == "KnowledgeVersion":
+        version_metadata = metadata.get("version_metadata") if isinstance(metadata.get("version_metadata"), dict) else {}
+        atom_kind = str(metadata.get("atom_kind") or "")
+        if atom_kind in {"decision", "problem"}:
+            subject = str(version_metadata.get("subject") or version_metadata.get("summary") or version_metadata.get("statement") or "").strip()
+            return f"{atom_kind.title()}: {subject}" if subject else f"{atom_kind.title()} version"
+        if atom_kind == "file":
+            path = _central_file_path(metadata, version_metadata)
+            return f"File version: {path}" if path else "File version"
+        if atom_kind == "commit":
+            sha = _central_commit_sha(metadata, version_metadata)
+            return f"Commit version: {sha[:12]}" if sha else "Commit version"
+        return f"{atom_kind.title() or 'Knowledge'} version"
+    if kind == "KnowledgeAtom":
+        atom_kind = str(metadata.get("atom_kind") or "")
+        canonical_key = str(metadata.get("canonical_key") or "")
+        return f"{atom_kind.title() or 'Knowledge'} atom: {canonical_key.rsplit('|', 1)[-1]}"
+    return str(node.get("label") or node.get("id") or "")
+
+
+def _central_version_body(node: dict[str, Any], metadata: dict[str, Any]) -> str:
+    version_metadata = metadata.get("version_metadata") if isinstance(metadata.get("version_metadata"), dict) else {}
+    atom_kind = str(metadata.get("atom_kind") or "")
+    fields = [
+        "kind: KnowledgeVersion",
+        f"atom_kind: {atom_kind}",
+        f"status: {node.get('status') or metadata.get('status') or ''}",
+    ]
+    if atom_kind in {"decision", "problem"}:
+        fields.extend(
+            [
+                f"subject: {version_metadata.get('subject') or ''}",
+                f"summary: {version_metadata.get('summary') or ''}",
+                f"statement: {version_metadata.get('statement') or ''}",
+                f"rationale: {version_metadata.get('rationale') or ''}",
+                "linked_files: " + ", ".join(_string_values(version_metadata.get("linked_files"))[:8]),
+                "linked_commits: " + ", ".join(_string_values(version_metadata.get("linked_commits"))[:6]),
+                "source: active central memory",
+            ]
+        )
+    elif atom_kind == "file":
+        fields.extend(
+            [
+                f"file_path: {_central_file_path(metadata, version_metadata)}",
+                f"producing_commit_sha: {version_metadata.get('producing_commit_sha') or ''}",
+                "source: active central file history",
+            ]
+        )
+    elif atom_kind == "commit":
+        fields.extend(
+            [
+                f"commit_sha: {_central_commit_sha(metadata, version_metadata)}",
+                "source: active central commit history",
+            ]
+        )
+    else:
+        fields.append(f"summary: {node.get('summary') or ''}")
+    return "\n".join(field for field in fields if field and not field.endswith(": "))
+
+
+def _central_atom_body(node: dict[str, Any], metadata: dict[str, Any]) -> str:
+    atom_kind = str(metadata.get("atom_kind") or "")
+    fields = [
+        "kind: KnowledgeAtom",
+        f"atom_kind: {atom_kind}",
+        f"status: {node.get('status') or metadata.get('status') or ''}",
+        f"canonical_key: {metadata.get('canonical_key') or ''}",
+        "source: central canonical identity",
+    ]
+    return "\n".join(field for field in fields if field and not field.endswith(": "))
+
+
+def _central_file_path(metadata: dict[str, Any], version_metadata: dict[str, Any]) -> str:
+    canonical_key = str(version_metadata.get("canonical_key") or metadata.get("canonical_key") or "")
+    if "|file|" in canonical_key:
+        return canonical_key.rsplit("|", 1)[-1]
+    if canonical_key.startswith("file|"):
+        parts = canonical_key.split("|", 2)
+        return parts[-1] if len(parts) == 3 else ""
+    return str(version_metadata.get("file_path") or "")
+
+
+def _central_commit_sha(metadata: dict[str, Any], version_metadata: dict[str, Any]) -> str:
+    canonical_key = str(version_metadata.get("canonical_key") or metadata.get("canonical_key") or "")
+    if "|commit|" in canonical_key:
+        return canonical_key.rsplit("|", 1)[-1]
+    if canonical_key.startswith("commit|"):
+        parts = canonical_key.split("|", 2)
+        return parts[-1] if len(parts) == 3 else ""
+    return str(version_metadata.get("commit_sha") or "")
+
+
+def _string_values(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value if str(item).strip()]
+    if value is None or not str(value).strip():
+        return []
+    return [str(value).strip()]
 
 
 def _chunk_text(text: str, *, max_doc_chars: int) -> list[str]:
@@ -1842,13 +1971,13 @@ def _central_version_boost(
     metadata = doc.metadata.get("node_metadata") if isinstance(doc.metadata, dict) else {}
     atom_kind = str(metadata.get("atom_kind") or "") if isinstance(metadata, dict) else ""
     if atom_kind in {"decision", "problem"}:
-        return 0.45
+        return 0.85
     if intent == "version_flow" or _query_has_code_locator(query):
         return 0.55
     if topic_overlap_ratio >= 0.6:
-        return 0.45
+        return 0.65
     if topic_overlap_ratio >= 0.4:
-        return 0.18
+        return 0.55
     return 0.0
 
 

--- a/tests/test_reasoning_graph_reasoning_extraction.py
+++ b/tests/test_reasoning_graph_reasoning_extraction.py
@@ -129,6 +129,52 @@ def test_reasoning_review_demotes_commit_mismatched_node_to_review() -> None:
     assert result.needs_review_nodes[0]["post_validation"]["semantic_alignment"]["status"] == "low_overlap"
 
 
+def test_reasoning_review_demotes_generic_plan_overlap_to_review() -> None:
+    packet = {
+        "packet_id": "WP0001",
+        "commit": {
+            "short_sha": "abc1234",
+            "message": "feat(reasoning-graph): import real session timelines",
+            "changed_file_sample": [
+                "src/agent_memory_orchestrator/reasoning_graph/timeline.py",
+                "tests/test_reasoning_graph_models.py",
+            ],
+        },
+        "problem_refs": [{"ref": "E0001"}],
+        "rationale_refs": [{"ref": "E0002"}],
+        "validation_refs": [{"ref": "E0003"}],
+    }
+    result = review_reasoning_extraction_results(
+        packets=[packet],
+        results=[
+            {
+                "packet_id": "WP0001",
+                "commit_sha": "abc1234",
+                "parsed_output": {
+                    "packet_id": "WP0001",
+                    "commit_sha": "abc1234",
+                    "nodes": [
+                        {
+                            "node_type": "Decision",
+                            "subject": "Implement Reasoning Graph Documentation System Plan",
+                            "statement": "PLEASE IMPLEMENT THIS PLAN: # AMO Reasoning Graph Documentation System Plan",
+                            "reason": "The prompt outlines a plan.",
+                            "confidence": 0.0,
+                            "evidence_refs": ["E0002"],
+                            "status": "accepted",
+                        }
+                    ],
+                },
+            }
+        ],
+        source_name="unit",
+    )
+
+    assert result.summary["accepted_node_count"] == 0
+    assert result.summary["needs_review_node_count"] == 1
+    assert result.summary["diagnostic_kind_counts"]["semantic_alignment_low_overlap"] == 1
+
+
 def test_reasoning_extraction_rejects_bad_refs_and_raw_ids() -> None:
     node, diagnostics = validate_reasoning_node(
         {
@@ -149,6 +195,49 @@ def test_reasoning_extraction_rejects_bad_refs_and_raw_ids() -> None:
 
     assert node["post_validation"]["action"] == "reject"
     assert {item["kind"] for item in diagnostics} >= {"evidence_refs_not_in_packet", "raw_internal_id_leak"}
+
+
+def test_reasoning_review_allows_rejected_node_when_accepted_nodes_remain() -> None:
+    result = review_reasoning_extraction_results(
+        packets=[_packet()],
+        results=[
+            {
+                "packet_id": "WP0001",
+                "commit_sha": "abc1234",
+                "parsed_output": {
+                    "packet_id": "WP0001",
+                    "commit_sha": "abc1234",
+                    "nodes": [
+                        {
+                            "node_type": "Decision",
+                            "subject": "Local graph",
+                            "statement": "Graph truth is stored locally.",
+                            "reason": "The packet rationale supports local graph storage.",
+                            "confidence": 0.9,
+                            "evidence_refs": ["E0002"],
+                            "status": "accepted",
+                        },
+                        {
+                            "node_type": "Decision",
+                            "subject": "Bad ref",
+                            "statement": "This cites evidence outside the packet.",
+                            "reason": "The model hallucinated a ref.",
+                            "confidence": 0.8,
+                            "evidence_refs": ["E9999"],
+                            "status": "accepted",
+                        },
+                    ],
+                },
+            }
+        ],
+        source_name="unit",
+    )
+
+    assert result.summary["stage_acceptance"] == "PASS_WITH_REVIEW_BUCKET"
+    assert result.summary["accepted_node_count"] == 1
+    assert result.summary["rejected_node_count"] == 1
+    assert result.summary["diagnostic_kind_counts"]["evidence_refs_not_in_packet"] == 1
+    assert result.summary["blocking_diagnostic_count"] == 0
 
 
 def test_reasoning_extraction_demotes_validation_only_fix() -> None:
@@ -192,14 +281,14 @@ def test_real_stage4_final_merge_revalidates_to_expected_counts() -> None:
     assert review.summary["packet_count"] == 59
     assert review.summary["missing_packets"] == []
     assert review.summary["packet_error_ids"] == []
-    assert review.summary["accepted_node_count"] == 236
-    assert review.summary["needs_review_node_count"] == 68
+    assert review.summary["accepted_node_count"] == 224
+    assert review.summary["needs_review_node_count"] == 80
     assert review.summary["rejected_node_count"] == 0
-    assert review.summary["diagnostic_kind_counts"]["semantic_alignment_low_overlap"] == 56
+    assert review.summary["diagnostic_kind_counts"]["semantic_alignment_low_overlap"] == 70
     assert review.summary["accepted_node_type_counts"] == {
-        "Problem": 72,
         "Decision": 53,
-        "Constraint": 14,
-        "Fix": 79,
+        "Constraint": 13,
+        "Fix": 76,
+        "Problem": 64,
         "Cause": 18,
     }

--- a/tests/test_reasoning_graph_retrieval.py
+++ b/tests/test_reasoning_graph_retrieval.py
@@ -528,7 +528,7 @@ def _central_graph() -> InMemoryGraphStore:
             kind="KnowledgeVersion",
             label="Old retrieval projection version",
             summary="Old central memory that should not leak into the active graph view.",
-            status="active",
+            status="superseded",
             scope="central",
             session_id="s1",
             metadata={
@@ -657,6 +657,47 @@ def test_version_flow_query_prefers_active_central_version_for_locator(tmp_path:
     assert result.intent == "version_flow"
     assert result.hits[0].document.graph_node_id == "kver:active-retrieval"
     assert any(reason == "central_active_boost:0.55" for reason in result.hits[0].reasons)
+
+
+def test_central_retrieval_includes_active_versions_from_prior_graph_commits() -> None:
+    graph = InMemoryGraphStore()
+    repo_id = "repo:test"
+    graph.upsert_node(
+        GraphNode(
+            id="v2view:repo_test:main:active",
+            kind="GraphView",
+            label="main active",
+            status="active",
+            metadata={"repo_id": repo_id, "branch": "main", "mode": "active", "graph_commit_id": "gcommit:new"},
+        )
+    )
+    graph.upsert_node(
+        GraphNode(
+            id="kver:decision:old-active",
+            kind="KnowledgeVersion",
+            label="Graph retrieval design",
+            summary="Use central active GraphView retrieval for graph queries.",
+            status="active",
+            metadata={
+                "repo_id": repo_id,
+                "atom_kind": "decision",
+                "status": "superseded",
+                "graph_commit_id": "gcommit:older",
+                "version_metadata": {
+                    "subject": "Graph retrieval design",
+                    "statement": "Use central active GraphView retrieval for graph queries.",
+                },
+            },
+        )
+    )
+
+    docs = build_retrieval_documents_from_graph(graph, repo_id=repo_id)
+
+    central_versions = [doc for doc in docs if doc.doc_type == "central_version"]
+    assert [doc.graph_node_id for doc in central_versions] == ["kver:decision:old-active"]
+    assert central_versions[0].title == "Decision: Graph retrieval design"
+    assert "statement:" in central_versions[0].body
+    assert "source: active central memory" in central_versions[0].body
 
 
 def test_generic_query_does_not_overboost_low_overlap_exact_central_version(tmp_path: Path) -> None:
@@ -814,7 +855,7 @@ def test_retrieve_session_graph_fuses_candidates_and_expands_after_ranking(tmp_p
         expand_neighbors=5,
     )
 
-    assert result.intent == "code_why"
+    assert result.intent == "decision_history"
     assert result.vector_status == "sqlite:completed"
     assert result.reranker == "deterministic+bi_encoder"
     assert result.candidate_counts["bm25"] > 0
@@ -1069,6 +1110,9 @@ def test_version_flow_queries_boost_symbol_or_code_docs(tmp_path: Path) -> None:
     assert classify_query("show version flow for retrieval.py::retrieve_session_graph") == "version_flow"
     assert classify_query("show version flow for graph service rank nodes") == "version_flow"
     assert classify_query("why did we add retrieval.py for graph expansion") == "code_why"
+    assert classify_query("why did we add the daemon-owned Kuzu work ledger?") == "decision_history"
+    assert classify_query("what changed for spatial graph controls?") == "code_why"
+    assert classify_query("what changed over time for graph_service.py?") == "version_flow"
     assert result.hits
     assert result.hits[0].document.doc_type in {"symbol", "code"}
 
@@ -1109,8 +1153,9 @@ def test_graph_service_wires_retrieval_build_embed_and_answer(tmp_path: Path) ->
     assert embed["embedding"]["embedded"] == 3
     assert result["ok"] is True
     assert result["retrieval"]["hits"]
-    assert "AMO indexed graph answer" in result["answer"]["text"]
-    assert "Support: packet WP0001 | commit abc1234 | code retrieve_session_graph" in result["answer"]["text"]
+    assert "Answer from repository memory" in result["answer"]["text"]
+    assert "Support: session context, commit-backed, code-linked" in result["answer"]["text"]
+    assert "WP0001" not in result["answer"]["text"]
     first_citation = result["answer"]["citations"][0]
     assert first_citation["packet_ids"] == ["WP0001"]
     assert first_citation["commit_shas"] == ["abc1234"]
@@ -1541,9 +1586,9 @@ def test_graph_service_answer_includes_multihop_trace(tmp_path: Path) -> None:
         svc.close()
 
     assert result["ok"] is True
-    assert "Trace:" in result["answer"]["text"]
-    assert "Problem: Hook execution timed out" in result["answer"]["text"]
-    assert "Fix: Hooks became capture-only" in result["answer"]["text"]
+    assert "Evidence:" in result["answer"]["text"]
+    assert "commit-backed -> code-backed" in result["answer"]["text"]
+    assert "Hooks became capture-only" in result["answer"]["text"]
     citation = result["answer"]["citations"][0]
     assert citation["trace"]["support"]["packet_ids"] == ["WP0018"]
     assert "code:hook_response" in citation["trace"]["support"]["code_node_ids"]

--- a/tests/test_v2_production_eval.py
+++ b/tests/test_v2_production_eval.py
@@ -154,7 +154,7 @@ def test_production_semantic_eval_reports_stale_full_trace_state(tmp_path: Path)
         assert report["product_ready"] is False
         assert "curated_graph_manifest_missing" in report["blocked_issues"]
         assert "retrieval_full_trace_dominated" in report["blocked_issues"]
-        assert "retrieval_query_raw_trace_top_result" in report["blocked_issues"]
+        assert "retrieval_query_no_hits" in report["blocked_issues"]
         assert "retrieval_query_missing_curated_support" in report["blocked_issues"]
         assert "central_merge_not_applied" in report["blocked_issues"]
         assert report["retrieval"]["legacy_doc_count"] == 1

--- a/tests/test_v2_session_jobs.py
+++ b/tests/test_v2_session_jobs.py
@@ -410,6 +410,8 @@ def test_v2_central_merge_apply_writes_exact_atoms_graph_commit_and_view(tmp_pat
         assert result_artifact.exists()
         merge_result = json.loads(result_artifact.read_text(encoding="utf-8"))
         assert merge_result["status"] == "applied"
+        assert applied["graph_commit_id"] == applied["graph_commit"]["graph_commit_id"]
+        assert merge_result["graph_commit_id"] == applied["graph_commit"]["graph_commit_id"]
         assert merge_result["graph_commit"]["graph_commit_id"] == applied["graph_commit"]["graph_commit_id"]
         assert merge_result["input_source"] == "curated_graph_manifest"
         assert merge_result["curated_input_hash"] == "curated-input"
@@ -698,6 +700,120 @@ def test_v2_central_merge_apply_writes_review_decision_versions_and_relation_edg
         assert {node.status for node in decision_versions} == {"review"}
         assert relation_edges
         assert relation_edges[0].metadata["status"] == "review"
+    finally:
+        store.close()
+
+
+def test_v2_central_merge_apply_status_changes_for_safe_supersedes(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    graph = InMemoryGraphStore()
+    store = V2SessionJobStore(settings)
+    try:
+        job = store.enqueue_session(session_id="s-decision-supersedes", boundary_event_id="raw_boundary", repo_path=str(tmp_path)).job
+        repo_id = str(job["repo_id"])
+        old_metadata = {
+            "repo_id": repo_id,
+            "atom_kind": "decision",
+            "status": "active",
+            "version_metadata": {
+                "node_type": "Decision",
+                "subject": "Graph retrieval design",
+                "statement": "Use session graph retrieval for graph queries.",
+                "linked_files": ["src/agent_memory_orchestrator/graph/service.py"],
+            },
+        }
+        old_central = {
+            "id": "kver:old-central-graph-retrieval",
+            "kind": "KnowledgeVersion",
+            "status": "active",
+            "metadata": old_metadata,
+        }
+        graph.upsert_node(
+            GraphNode(
+                id=old_central["id"],
+                kind="KnowledgeVersion",
+                label="Use session graph retrieval for graph queries.",
+                status="active",
+                scope="central",
+                metadata=old_metadata,
+            )
+        )
+        compact_graph = {
+            "nodes": [
+                {
+                    "id": "reason:new",
+                    "kind": "ReasoningNode",
+                    "properties": {
+                        "node_type": "Decision",
+                        "status": "accepted",
+                        "subject": "Graph retrieval design",
+                        "statement": "Replace session graph retrieval with central active GraphView retrieval.",
+                        "selected_files": ["src/agent_memory_orchestrator/graph/service.py"],
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        plan = build_dry_run_merge_plan(job=job, compact_graph=compact_graph, parent_graph_commit_id="", active_central_versions=[old_central])
+        stored = store.upsert_central_merge_plan(_product_plan(plan))
+
+        applied = apply_merge_plan(settings=settings, plan_id=stored["plan_id"], store=store, graph_store=graph)
+
+        decision_versions = [node for node in graph.nodes.values() if node.kind == "KnowledgeVersion" and node.metadata.get("atom_kind") == "decision"]
+        by_statement = {node.metadata.get("version_metadata", {}).get("statement"): node for node in decision_versions}
+        status_edges = [edge for edge in graph.edges.values() if edge.kind == "STATUS_CHANGED"]
+        assert applied["status_update_count"] == 2
+        assert by_statement["Replace session graph retrieval with central active GraphView retrieval."].status == "active"
+        assert by_statement["Use session graph retrieval for graph queries."].status == "superseded"
+        assert {edge.metadata["new_status"] for edge in status_edges} == {"active", "superseded"}
+        assert applied["status_updates"]
+    finally:
+        store.close()
+
+
+def test_v2_central_merge_keeps_same_session_refinement_in_review(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    graph = InMemoryGraphStore()
+    store = V2SessionJobStore(settings)
+    try:
+        job = store.enqueue_session(session_id="s-decision-same-session-refines", boundary_event_id="raw_boundary", repo_path=str(tmp_path)).job
+        compact_graph = {
+            "nodes": [
+                {
+                    "id": "reason:old",
+                    "kind": "ReasoningNode",
+                    "properties": {
+                        "node_type": "Decision",
+                        "status": "accepted",
+                        "subject": "Reasoning graph plan",
+                        "statement": "Implement a reasoning graph documentation system.",
+                        "selected_files": ["src/agent_memory_orchestrator/reasoning_graph/timeline.py"],
+                    },
+                },
+                {
+                    "id": "reason:new",
+                    "kind": "ReasoningNode",
+                    "properties": {
+                        "node_type": "Decision",
+                        "status": "accepted",
+                        "subject": "Reasoning graph plan",
+                        "statement": "Implement a tighter reasoning graph documentation system with validation gates.",
+                        "selected_files": ["src/agent_memory_orchestrator/reasoning_graph/timeline.py"],
+                    },
+                },
+            ],
+            "edges": [],
+        }
+        plan = build_dry_run_merge_plan(job=job, compact_graph=compact_graph, parent_graph_commit_id="")
+        stored = store.upsert_central_merge_plan(_product_plan(plan))
+
+        applied = apply_merge_plan(settings=settings, plan_id=stored["plan_id"], store=store, graph_store=graph)
+
+        decision_versions = [node for node in graph.nodes.values() if node.kind == "KnowledgeVersion" and node.metadata.get("atom_kind") == "decision"]
+        relation_edges = [edge for edge in graph.edges.values() if edge.kind in {"REFINES", "DUPLICATE_OF", "RELATED_REVIEW"}]
+        assert relation_edges
+        assert applied["status_update_count"] == 0
+        assert {node.status for node in decision_versions} == {"review"}
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.
