### PR TITLE
 fix(peer-netd): added the python module guard

### DIFF
--- a/src/agent_memory_orchestrator/runtime/cli/main.py
+++ b/src/agent_memory_orchestrator/runtime/cli/main.py
@@ -129,3 +129,7 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # pragma: no cover
         print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
         return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_runtime_entrypoints.py
+++ b/tests/test_runtime_entrypoints.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -27,3 +30,30 @@ def test_runtime_adapters_expose_canonical_entrypoints() -> None:
     assert callable(runtime_mcp.main)
     assert callable(runtime_mcp.create_server)
     assert runtime_mcp_tools.MemoryMcpToolService.__name__ == "MemoryMcpToolService"
+
+
+def test_runtime_cli_module_runs_as_python_m_entrypoint() -> None:
+    env = os.environ.copy()
+    src_path = str(Path("src").resolve())
+    env["PYTHONPATH"] = src_path + os.pathsep + env.get("PYTHONPATH", "")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "agent_memory_orchestrator.runtime.cli.main",
+            "peer-agent",
+            "--help",
+        ],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=20,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+    assert "peer-agent" in result.stdout
+    assert "Drain peer inbox and respond/finalize rooms" in result.stdout


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for CLI module execution via Python module invocation.

* **Chores**
  * Improved CLI module initialization to ensure correct process exit behavior when invoked directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->