### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/src/agent_memory_orchestrator/peer/agent/llm.py
+++ b/src/agent_memory_orchestrator/peer/agent/llm.py
@@ -53,16 +53,38 @@ class PeerAgentLlmGateway:
         allow_provider: bool = True,
     ) -> dict[str, Any]:
         prompt = final_synthesis_prompt(query=query, local_result=local_result, peer_responses=peer_responses)
-        try:
-            return self._local_json(prompt, schema=FINAL_SYNTHESIS_SCHEMA, num_predict=900)
-        except PeerAgentLlmUnavailable:
-            if not allow_provider or not self.settings.peer_agent_allow_initiator_api_fallback:
-                raise
+        if self.local_ollama_ready():
+            try:
+                return self._local_json(prompt, schema=FINAL_SYNTHESIS_SCHEMA, num_predict=900)
+            except PeerAgentLlmUnavailable:
+                pass
+        if allow_provider and self.settings.peer_agent_allow_initiator_api_fallback and self.provider_configured():
             return self._provider_json(prompt, schema=FINAL_SYNTHESIS_SCHEMA)
+        raise PeerAgentLlmUnavailable("peer_agent_no_synthesis_provider_available")
 
     def summarize_room(self, *, room_context: dict[str, Any]) -> dict[str, Any]:
         prompt = room_summary_prompt(room_context=room_context)
         return self._local_json(prompt, schema=ROOM_SUMMARY_SCHEMA, num_predict=600)
+
+    def local_ollama_ready(self, *, timeout_seconds: float = 0.75) -> bool:
+        if self.settings.peer_agent_runtime != "ollama":
+            return False
+        endpoint = self.settings.peer_agent_endpoint or self.settings.qwen_endpoint
+        model = self.settings.peer_agent_model or self.settings.qwen_model
+        if not endpoint or not model:
+            return False
+        return _ollama_model_loaded(endpoint.rstrip("/"), model, timeout_seconds=timeout_seconds)
+
+    def provider_configured(self) -> bool:
+        if self.settings.peer_agent_api_provider != "openai_compatible":
+            return False
+        key_env = self.settings.peer_agent_api_key_env
+        return bool(
+            self.settings.peer_agent_api_base_url
+            and self.settings.peer_agent_api_model
+            and key_env
+            and os.getenv(key_env, "")
+        )
 
     def _local_json(self, prompt: str, *, schema: dict[str, Any], num_predict: int) -> dict[str, Any]:
         if self.settings.peer_agent_runtime != "ollama":
@@ -135,3 +157,38 @@ class PeerAgentLlmGateway:
         if not isinstance(parsed, dict):
             raise PeerAgentLlmUnavailable("peer_agent_provider_json_must_be_object")
         return parsed
+
+
+def _ollama_model_loaded(endpoint: str, model: str, *, timeout_seconds: float) -> bool:
+    try:
+        with urllib.request.urlopen(f"{endpoint}/api/ps", timeout=timeout_seconds) as response:  # noqa: S310
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return False
+    models = payload.get("models") if isinstance(payload, dict) else []
+    if not isinstance(models, list):
+        return False
+    expected = _model_aliases(model)
+    for item in models:
+        if not isinstance(item, dict):
+            continue
+        names = {
+            str(item.get("name") or "").strip(),
+            str(item.get("model") or "").strip(),
+            str(item.get("digest") or "").strip(),
+        }
+        if any(name in expected for name in names if name):
+            return True
+    return False
+
+
+def _model_aliases(model: str) -> set[str]:
+    text = str(model or "").strip()
+    if not text:
+        return set()
+    aliases = {text}
+    if ":" not in text:
+        aliases.add(f"{text}:latest")
+    else:
+        aliases.add(text.split(":", 1)[0])
+    return aliases

--- a/src/agent_memory_orchestrator/peer/agent/service.py
+++ b/src/agent_memory_orchestrator/peer/agent/service.py
@@ -368,26 +368,26 @@ class PeerAgentService:
         answer_grade = quality.answer_grade
         confidence = quality.confidence
         if support or quality.confidence >= threshold:
-            try:
-                llm_payload = self.llm.generate_peer_answer(
-                    query=query,
-                    retrieval_bundle=bundle,
-                    quality=quality.as_dict(),
-                    room_context=self.peer.store.context_pack(room_id, viewer_node_id=config.node_id),
-                )
-                content = redacted_answer_text(
-                    str(llm_payload.get("answer") or content).strip() or content,
-                    support=support,
-                    include_local_refs=config.share_citations,
-                )
-                confidence = _clamp_float(llm_payload.get("confidence"), default=confidence)
-                answer_grade = bool(llm_payload.get("answer_grade", answer_grade)) and bool(support)
-                mode = RESPONSE_LLM_ANSWER
-            except Exception:
-                if self.settings.peer_agent_allow_retrieval_only_responses:
-                    mode = RESPONSE_RETRIEVAL_BUNDLE
-                    content = content or "Retrieval bundle attached."
-                else:
+            if self.settings.peer_agent_allow_retrieval_only_responses:
+                mode = RESPONSE_RETRIEVAL_BUNDLE
+                content = content or "Retrieval bundle attached."
+            else:
+                try:
+                    llm_payload = self.llm.generate_peer_answer(
+                        query=query,
+                        retrieval_bundle=bundle,
+                        quality=quality.as_dict(),
+                        room_context=self.peer.store.context_pack(room_id, viewer_node_id=config.node_id),
+                    )
+                    content = redacted_answer_text(
+                        str(llm_payload.get("answer") or content).strip() or content,
+                        support=support,
+                        include_local_refs=config.share_citations,
+                    )
+                    confidence = _clamp_float(llm_payload.get("confidence"), default=confidence)
+                    answer_grade = bool(llm_payload.get("answer_grade", answer_grade)) and bool(support)
+                    mode = RESPONSE_LLM_ANSWER
+                except Exception:
                     mode = RESPONSE_LOW_CONFIDENCE
         return self._send_response(
             peer_id=initiator,

--- a/src/agent_memory_orchestrator/peer/agent/service.py
+++ b/src/agent_memory_orchestrator/peer/agent/service.py
@@ -368,10 +368,7 @@ class PeerAgentService:
         answer_grade = quality.answer_grade
         confidence = quality.confidence
         if support or quality.confidence >= threshold:
-            if self.settings.peer_agent_allow_retrieval_only_responses:
-                mode = RESPONSE_RETRIEVAL_BUNDLE
-                content = content or "Retrieval bundle attached."
-            else:
+            if self.llm.local_ollama_ready():
                 try:
                     llm_payload = self.llm.generate_peer_answer(
                         query=query,
@@ -388,7 +385,14 @@ class PeerAgentService:
                     answer_grade = bool(llm_payload.get("answer_grade", answer_grade)) and bool(support)
                     mode = RESPONSE_LLM_ANSWER
                 except Exception:
-                    mode = RESPONSE_LOW_CONFIDENCE
+                    if self.settings.peer_agent_allow_retrieval_only_responses:
+                        mode = RESPONSE_RETRIEVAL_BUNDLE
+                        content = content or "Retrieval bundle attached."
+                    else:
+                        mode = RESPONSE_LOW_CONFIDENCE
+            elif self.settings.peer_agent_allow_retrieval_only_responses:
+                mode = RESPONSE_RETRIEVAL_BUNDLE
+                content = content or "Retrieval bundle attached."
         return self._send_response(
             peer_id=initiator,
             room_id=room_id,

--- a/tests/test_peer_agent.py
+++ b/tests/test_peer_agent.py
@@ -82,7 +82,10 @@ def test_peer_agent_watch_returns_llm_answer_when_peer_ollama_available(tmp_path
     settings = make_settings(tmp_path, peer_agent_allow_retrieval_only_responses=False)
     store = peer_room_with_request(tmp_path, local_node="poco-amo")
     netd = FakeNetdClient()
-    llm = FakeLlm(peer_answer={"answer": "Peer found the local-first decision.", "confidence": 0.91, "answer_grade": True, "gaps": []})
+    llm = FakeLlm(
+        local_ready=True,
+        peer_answer={"answer": "Peer found the local-first decision.", "confidence": 0.91, "answer_grade": True, "gaps": []},
+    )
     svc = PeerAgentService(
         settings,
         peer_service=PeerService(settings, store=store, netd_client=netd),
@@ -103,7 +106,7 @@ def test_peer_agent_watch_returns_retrieval_bundle_without_waiting_for_peer_llm(
     settings = make_settings(tmp_path)
     store = peer_room_with_request(tmp_path, local_node="poco-amo")
     netd = FakeNetdClient()
-    llm = FakeLlm(fail_peer=True)
+    llm = FakeLlm(local_ready=False, fail_peer=True)
     svc = PeerAgentService(
         settings,
         peer_service=PeerService(settings, store=store, netd_client=netd),
@@ -574,15 +577,23 @@ class FakeLlm:
         *,
         peer_answer: dict[str, Any] | None = None,
         final_answer: dict[str, Any] | None = None,
+        local_ready: bool = True,
         fail_peer: bool = False,
         fail_final: bool = False,
     ) -> None:
         self.peer_answer = peer_answer or {"answer": "peer answer", "confidence": 0.9, "answer_grade": True, "gaps": []}
         self.final_answer = final_answer or {"answer": "final answer", "confidence": 0.9, "mode": "peer_assisted", "gaps": []}
+        self.local_ready = local_ready
         self.fail_peer = fail_peer
         self.fail_final = fail_final
         self.peer_calls = 0
         self.final_calls = 0
+
+    def local_ollama_ready(self, **kwargs: Any) -> bool:
+        return self.local_ready
+
+    def provider_configured(self) -> bool:
+        return False
 
     def generate_peer_answer(self, **kwargs: Any) -> dict[str, Any]:
         self.peer_calls += 1

--- a/tests/test_peer_agent.py
+++ b/tests/test_peer_agent.py
@@ -79,7 +79,7 @@ def test_peer_agent_ask_can_target_specific_peer(tmp_path: Path) -> None:
 
 
 def test_peer_agent_watch_returns_llm_answer_when_peer_ollama_available(tmp_path: Path) -> None:
-    settings = make_settings(tmp_path)
+    settings = make_settings(tmp_path, peer_agent_allow_retrieval_only_responses=False)
     store = peer_room_with_request(tmp_path, local_node="poco-amo")
     netd = FakeNetdClient()
     llm = FakeLlm(peer_answer={"answer": "Peer found the local-first decision.", "confidence": 0.91, "answer_grade": True, "gaps": []})
@@ -99,15 +99,16 @@ def test_peer_agent_watch_returns_llm_answer_when_peer_ollama_available(tmp_path
     assert responses[0]["payload"]["metadata"]["answer_grade"] is True
 
 
-def test_peer_agent_watch_returns_retrieval_bundle_without_peer_llm(tmp_path: Path) -> None:
+def test_peer_agent_watch_returns_retrieval_bundle_without_waiting_for_peer_llm(tmp_path: Path) -> None:
     settings = make_settings(tmp_path)
     store = peer_room_with_request(tmp_path, local_node="poco-amo")
     netd = FakeNetdClient()
+    llm = FakeLlm(fail_peer=True)
     svc = PeerAgentService(
         settings,
         peer_service=PeerService(settings, store=store, netd_client=netd),
         graph=FakeGraph(good_retrieval()),
-        llm=FakeLlm(fail_peer=True),
+        llm=llm,
     )
 
     svc.watch_once()
@@ -118,6 +119,7 @@ def test_peer_agent_watch_returns_retrieval_bundle_without_peer_llm(tmp_path: Pa
     assert bundle["answer"]["text"]
     assert bundle["support"]
     assert "retrieval" not in bundle
+    assert llm.peer_calls == 0
 
 
 def test_peer_agent_duplicate_request_is_idempotent(tmp_path: Path) -> None:
@@ -579,9 +581,11 @@ class FakeLlm:
         self.final_answer = final_answer or {"answer": "final answer", "confidence": 0.9, "mode": "peer_assisted", "gaps": []}
         self.fail_peer = fail_peer
         self.fail_final = fail_final
+        self.peer_calls = 0
         self.final_calls = 0
 
     def generate_peer_answer(self, **kwargs: Any) -> dict[str, Any]:
+        self.peer_calls += 1
         if self.fail_peer:
             raise RuntimeError("peer llm unavailable")
         return self.peer_answer


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved peer agent resilience with upfront capability checks before attempting local synthesis.
  * Enhanced fallback handling when local LLM is unavailable, with graceful degradation to retrieval-only responses when configured.
  * Optimized provider API usage by avoiding unnecessary calls when synthesis cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->