### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/docs/peer_agent/llm-contracts.md
+++ b/docs/peer_agent/llm-contracts.md
@@ -1,0 +1,243 @@
+# Peer-Agent LLM Contracts
+
+This is the peer-agent LLM contract for AMO bot-to-bot rooms. Implementation must not improvise prompt roles, schemas, mutation behavior, or provider ownership outside this document without updating the contract and tests.
+
+## Product Boundary
+
+AMO peer-agent communication is local-first. The Go `amo-peer-netd` sidecar only transports signed/authenticated envelopes. Python AMO owns memory retrieval, room state, policy, prompt construction, summarization, and final synthesis.
+
+Provider credentials are never sent to peers. Responder-side drafting may use that responder device's local Ollama only. Initiator-side planning and final synthesis may use the initiator device's local Ollama first, then the initiator's configured OpenAI-compatible API fallback.
+
+## Context Window Contract
+
+Every peer-agent LLM prompt is built from bounded structured inputs. The room context has three layers:
+
+1. `room_md`: initiator-owned room brief with topic, initiator, participants, share boundary, and desired output.
+2. `rolling_summary_md`: initiator-owned summary of earlier room discussion once transcript size crosses the summary limit.
+3. Recent room exchanges:
+   - `group_recent_messages`: group-visible messages only.
+   - `pairwise_recent_messages`: for initiator, grouped request/response orchestration; for a peer, only tagged initiator-peer exchanges involving that peer.
+   - `recent_messages`: the active scoped view for the current role.
+
+`open_questions` must contain only unanswered request IDs. A `context_request` is answered when a `context_response` references the same `request_id`.
+
+## Contract 1: Peer Responder Answer
+
+Owner: responding peer device.
+
+Provider policy: local Ollama only. No hosted provider fallback is allowed on the peer for another user's request.
+
+Input:
+
+```json
+{
+  "query": "string",
+  "retrieval_bundle": {
+    "answer": {"text": "bounded retrieval text"},
+    "support": []
+  },
+  "quality": {
+    "answer_grade": false,
+    "confidence": 0.0,
+    "reasons": [],
+    "gaps": []
+  },
+  "room_context": {
+    "room_id": "room_...",
+    "role": "peer",
+    "layers": {}
+  }
+}
+```
+
+Output schema:
+
+```json
+{
+  "answer": "string",
+  "confidence": 0.0,
+  "answer_grade": false,
+  "gaps": []
+}
+```
+
+Allowed mutation: may send exactly one `context_response` for the tagged `request_id`. It may not mutate local memory, remote memory, room summary, final synthesis, peer config, or raw evidence.
+
+Fallback: if local Ollama is unavailable or generation fails, AMO sends `retrieval_bundle` when `peer_agent_allow_retrieval_only_responses=true`; otherwise it sends `low_confidence`.
+
+## Contract 2: Initiator Room Continuation Planner
+
+Owner: initiator device.
+
+Provider policy: local Ollama first. If unavailable and `peer_agent_allow_initiator_api_fallback=true`, use the initiator's OpenAI-compatible provider config. API keys never leave the initiator device.
+
+Input:
+
+```json
+{
+  "room_context": {
+    "room_id": "room_...",
+    "role": "initiator",
+    "layers": {}
+  },
+  "peer_responses": [],
+  "agent_state": {
+    "status": "open",
+    "original_query": "string",
+    "peer_requests": [],
+    "planner_actions": []
+  }
+}
+```
+
+Output schema:
+
+```json
+{
+  "action": "finalize|ask_peer|ask_peers|wait",
+  "peer_ids": [],
+  "query": "string",
+  "reason": "string",
+  "confidence": 0.0
+}
+```
+
+Allowed mutation through AMO only:
+
+- `finalize`: write local-only `final_synthesis` on the initiator.
+- `ask_peer`: send one schema-valid `context_request` to one tagged peer.
+- `ask_peers`: send one logical request fan-out to multiple tagged peers.
+- `wait`: no room mutation except planner action audit.
+
+The planner must not request raw evidence by default. It should ask short follow-up questions only when peer responses leave a specific gap.
+
+## Contract 3: Initiator Final Synthesis
+
+Owner: initiator device.
+
+Provider policy: local Ollama first, then initiator-owned provider fallback if configured.
+
+Input:
+
+```json
+{
+  "query": "string",
+  "local_result": {},
+  "peer_responses": []
+}
+```
+
+Output schema:
+
+```json
+{
+  "answer": "string",
+  "confidence": 0.0,
+  "mode": "local_only|peer_assisted|retrieval_only",
+  "gaps": []
+}
+```
+
+Allowed mutation: writes local-only `final_synthesis` by default. It must not broadcast final synthesis unless a later explicit sanitized-broadcast policy is implemented.
+
+## Contract 4: Room Summary
+
+Owner: initiator device.
+
+Provider policy: local Ollama only in v1. If unavailable, AMO uses deterministic summary fallback.
+
+Input:
+
+```json
+{
+  "room_context": {
+    "layers": {
+      "room_md": "string",
+      "rolling_summary_md": "string",
+      "recent_messages": []
+    }
+  }
+}
+```
+
+Output schema:
+
+```json
+{
+  "summary_md": "markdown string"
+}
+```
+
+Allowed mutation: replace initiator-owned `rolling_summary.md` and update summary state. It must preserve unresolved questions and recent decisions.
+
+## Message Contracts
+
+`context_request` metadata must include:
+
+```json
+{
+  "schema_version": 1,
+  "agent_room_schema_version": 1,
+  "logical_request_id": "q_...",
+  "request_id": "req_...",
+  "room_id": "room_...",
+  "audience": "peer",
+  "target_peer_id": "peer-node-id",
+  "query": "string",
+  "deadline_at": "iso8601",
+  "requested_capabilities": ["graph_retrieval", "memory_search", "llm_answer"],
+  "raw_evidence_requested": false
+}
+```
+
+`context_response` metadata must include:
+
+```json
+{
+  "schema_version": 1,
+  "request_id": "req_...",
+  "parent_message_id": "msg_...",
+  "audience": "initiator",
+  "target_peer_id": "initiator-node-id",
+  "mode": "llm_answer|retrieval_bundle|needs_approval|low_confidence",
+  "answer_grade": false,
+  "quality": {},
+  "support": [],
+  "retrieval_bundle": {},
+  "timing": {
+    "retrieval_ms": 0,
+    "quality_support_ms": 0,
+    "llm_ready": false,
+    "llm_ready_ms": 0,
+    "llm_generate_ms": 0,
+    "total_ms": 0
+  }
+}
+```
+
+## Latency Policy
+
+Normal unattended participation should prefer reliable fast responses over forced model generation. A peer may return `retrieval_bundle` when local Ollama is not already loaded. Do not auto-pull or auto-load large models inside a peer response path.
+
+Every peer response should expose timing metadata sufficient to classify latency as:
+
+- retrieval/index latency: `retrieval_ms`
+- support/quality shaping latency: `quality_support_ms`
+- local model readiness probe latency: `llm_ready_ms`
+- local model generation latency: `llm_generate_ms`
+- local response assembly latency: `total_ms`
+
+Network delivery latency is measured by the initiator around send/wait and by sidecar delivery diagnostics.
+
+## Validation Rules
+
+AMO must reject or skip peer-agent requests when:
+
+- `schema_version` is missing or unsupported.
+- `agent_room_schema_version` is missing for automated peer-agent messages.
+- `target_peer_id` does not match the local node.
+- transport identity is not verified by remote libp2p peer ID or signed envelope policy.
+- deadline has expired.
+- raw evidence is requested but policy requires approval.
+
+AMO must not mark a request as sent/responded unless delivery succeeds. Duplicate envelopes must not create duplicate responses for the same `request_id`.

--- a/src/agent_memory_orchestrator/domain/peer/rooms.py
+++ b/src/agent_memory_orchestrator/domain/peer/rooms.py
@@ -247,6 +247,7 @@ def _open_questions(
 ) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     groups: dict[str, dict[str, Any]] = {}
+    answered_request_ids = _answered_request_ids(messages)
     for message in messages:
         if str(message.get("type") or "") != "context_request":
             continue
@@ -255,6 +256,9 @@ def _open_questions(
         if role != "initiator" and not _is_group_visible(message) and sender != viewer_node_id and viewer_node_id not in recipients:
             continue
         metadata = message.get("metadata") if isinstance(message.get("metadata"), dict) else {}
+        request_id = str(metadata.get("request_id") or message.get("message_id") or "")
+        if request_id and request_id in answered_request_ids:
+            continue
         query = str(metadata.get("query") or message.get("content") or "").strip()
         if not query:
             continue
@@ -272,7 +276,6 @@ def _open_questions(
             }
             groups[key] = row
             out.append(row)
-        request_id = str(metadata.get("request_id") or message.get("message_id") or "")
         if request_id and request_id not in row["request_ids"]:
             row["request_ids"].append(request_id)
         for recipient in recipients:
@@ -285,6 +288,19 @@ def _open_questions(
         row["to"] = sorted(row["to"])
         row["request_count"] = len(row["request_ids"]) if row["request_ids"] else max(len(row["to"]), 1)
     return out
+
+
+def _answered_request_ids(messages: list[dict[str, Any]]) -> set[str]:
+    answered: set[str] = set()
+    for message in messages:
+        if str(message.get("type") or "") != "context_response":
+            continue
+        metadata = message.get("metadata") if isinstance(message.get("metadata"), dict) else {}
+        for key in ("request_id", "parent_message_id"):
+            request_id = str(metadata.get(key) or "").strip()
+            if request_id:
+                answered.add(request_id)
+    return answered
 
 
 def _compact_message(message: dict[str, Any]) -> dict[str, Any]:

--- a/src/agent_memory_orchestrator/peer/agent/responses.py
+++ b/src/agent_memory_orchestrator/peer/agent/responses.py
@@ -33,6 +33,7 @@ def peer_responses(room: dict[str, Any]) -> list[dict[str, Any]]:
             "quality": metadata.get("quality") if isinstance(metadata.get("quality"), dict) else {},
             "support": metadata.get("support") if isinstance(metadata.get("support"), list) else [],
             "retrieval_bundle": metadata.get("retrieval_bundle") if isinstance(metadata.get("retrieval_bundle"), dict) else {},
+            "timing": metadata.get("timing") if isinstance(metadata.get("timing"), dict) else {},
             "request_id": metadata.get("request_id", ""),
         }
         response["finalizable"] = bool(metadata.get("finalizable", is_finalizable_response(response)))

--- a/src/agent_memory_orchestrator/peer/agent/service.py
+++ b/src/agent_memory_orchestrator/peer/agent/service.py
@@ -187,6 +187,7 @@ class PeerAgentService:
         min_confidence: float | None = None,
         timeout_seconds: float | None = None,
         reason: str = "manual_followup",
+        wait_for_response: bool = False,
     ) -> dict[str, Any]:
         self._ensure_enabled()
         safe_query = _require_text(query, "query")
@@ -259,7 +260,7 @@ class PeerAgentService:
             )
         state["peer_requests"] = peer_requests
         self.state.save(safe_room_id, state)
-        return {
+        result = {
             "ok": True,
             "room_id": safe_room_id,
             "mode": "room_followup",
@@ -269,6 +270,22 @@ class PeerAgentService:
             "deliveries": deliveries,
             "timing": {"total_ms": _elapsed_ms(started)},
         }
+        if wait_for_response:
+            wait_started = time.monotonic()
+            expected_request_ids = [str(item.get("request_id") or "") for item in result["peer_requests"]]
+            responses = self._wait_for_request_responses(
+                safe_room_id,
+                request_ids=expected_request_ids,
+                timeout_seconds=timeout,
+            )
+            result["peer_responses"] = responses
+            result["response_count"] = len(responses)
+            result["timing"] = {
+                **result["timing"],
+                "wait_ms": _elapsed_ms(wait_started),
+                "total_ms": _elapsed_ms(started),
+            }
+        return result
 
     def continue_room(
         self,
@@ -450,6 +467,8 @@ class PeerAgentService:
         metadata: dict[str, Any],
         request_id: str,
     ) -> dict[str, Any]:
+        started = time.monotonic()
+        timing: dict[str, Any] = {}
         config = self.peer.store.load_config()
         room_id = str(room.get("room_id") or "")
         initiator = str(message.get("from_node_id") or message.get("from") or room.get("initiator_node_id") or "")
@@ -468,6 +487,7 @@ class PeerAgentService:
                 quality={},
                 support=[],
                 retrieval_bundle={},
+                timing={"total_ms": _elapsed_ms(started), "policy_blocked": True},
             )
         if metadata.get("raw_evidence_requested") and config.raw_evidence != "allowed":
             return self._send_response(
@@ -482,8 +502,12 @@ class PeerAgentService:
                 quality={},
                 support=[],
                 retrieval_bundle={},
+                timing={"total_ms": _elapsed_ms(started), "policy_blocked": True},
             )
+        stage_started = time.monotonic()
         retrieval = self._retrieve(query, session_id=str(metadata.get("session_id") or ""))
+        timing["retrieval_ms"] = _elapsed_ms(stage_started)
+        stage_started = time.monotonic()
         quality = self.quality.evaluate(retrieval, query=query, min_confidence=threshold)
         support = support_from_retrieval(
             retrieval,
@@ -496,6 +520,7 @@ class PeerAgentService:
             include_answer_text=config.share_summaries,
             include_local_refs=config.share_citations,
         )
+        timing["quality_support_ms"] = _elapsed_ms(stage_started)
         mode = RESPONSE_LOW_CONFIDENCE
         content = redacted_answer_text(
             _answer_text(retrieval),
@@ -505,14 +530,20 @@ class PeerAgentService:
         answer_grade = quality.answer_grade
         confidence = quality.confidence
         if support or quality.confidence >= threshold:
-            if self.llm.local_ollama_ready():
+            stage_started = time.monotonic()
+            llm_ready = self.llm.local_ollama_ready()
+            timing["llm_ready"] = llm_ready
+            timing["llm_ready_ms"] = _elapsed_ms(stage_started)
+            if llm_ready:
                 try:
+                    stage_started = time.monotonic()
                     llm_payload = self.llm.generate_peer_answer(
                         query=query,
                         retrieval_bundle=bundle,
                         quality=quality.as_dict(),
                         room_context=self.peer.store.context_pack(room_id, viewer_node_id=config.node_id),
                     )
+                    timing["llm_generate_ms"] = _elapsed_ms(stage_started)
                     content = redacted_answer_text(
                         str(llm_payload.get("answer") or content).strip() or content,
                         support=support,
@@ -521,7 +552,8 @@ class PeerAgentService:
                     confidence = _clamp_float(llm_payload.get("confidence"), default=confidence)
                     answer_grade = bool(llm_payload.get("answer_grade", answer_grade)) and bool(support)
                     mode = RESPONSE_LLM_ANSWER
-                except Exception:
+                except Exception as exc:
+                    timing["llm_error"] = type(exc).__name__
                     if self.settings.peer_agent_allow_retrieval_only_responses:
                         mode = RESPONSE_RETRIEVAL_BUNDLE
                         content = content or "Retrieval bundle attached."
@@ -542,6 +574,7 @@ class PeerAgentService:
             quality=quality.as_dict(),
             support=support,
             retrieval_bundle=bundle,
+            timing={**timing, "total_ms": _elapsed_ms(started)},
         )
 
     def _send_response(
@@ -558,7 +591,9 @@ class PeerAgentService:
         quality: dict[str, Any],
         support: list[dict[str, Any]],
         retrieval_bundle: dict[str, Any],
+        timing: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        safe_timing = dict(timing or {})
         metadata = {
             "schema_version": 1,
             "request_id": request_id,
@@ -571,6 +606,7 @@ class PeerAgentService:
             "quality": quality,
             "support": support,
             "retrieval_bundle": retrieval_bundle,
+            "timing": safe_timing,
             "response_hash": stable_json_hash(
                 {
                     "request_id": request_id,
@@ -596,7 +632,9 @@ class PeerAgentService:
                     "metadata": metadata,
                 },
                 "delivery": {"ok": False, "error": "peer_not_configured"},
+                "timing": safe_timing,
             }
+        send_started = time.monotonic()
         delivery = self.peer.send_message_to_peer(
             peer_id=peer_id,
             room_id=room_id,
@@ -607,7 +645,13 @@ class PeerAgentService:
             metadata=metadata,
             append_on_success_only=True,
         )
-        return {"ok": bool(delivery.get("ok")), "mode": mode, "message": delivery.get("message"), "delivery": delivery.get("delivery")}
+        return {
+            "ok": bool(delivery.get("ok")),
+            "mode": mode,
+            "message": delivery.get("message"),
+            "delivery": delivery.get("delivery"),
+            "timing": {**safe_timing, "send_ms": _elapsed_ms(send_started)},
+        }
 
     def _process_initiator_room(self, room: dict[str, Any]) -> list[dict[str, Any]]:
         room_id = str(room.get("room_id") or "")
@@ -805,6 +849,30 @@ class PeerAgentService:
         participants = [str(item) for item in room.get("participants", []) if str(item).strip()]
         room_peer_ids = [node_id for node_id in participants if node_id != config.node_id]
         return self._select_peers(peer_ids=room_peer_ids)
+
+    def _wait_for_request_responses(
+        self,
+        room_id: str,
+        *,
+        request_ids: list[str],
+        timeout_seconds: float,
+    ) -> list[dict[str, Any]]:
+        expected = {str(item).strip() for item in request_ids if str(item).strip()}
+        if not expected:
+            return []
+        deadline = time.monotonic() + max(0.1, float(timeout_seconds))
+        responses: list[dict[str, Any]] = []
+        while time.monotonic() < deadline:
+            self.watch_once(limit=20)
+            responses = [
+                response
+                for response in self._peer_responses(room_id)
+                if str(response.get("request_id") or "") in expected
+            ]
+            if {str(item.get("request_id") or "") for item in responses} >= expected:
+                return responses
+            time.sleep(0.5)
+        return responses
 
     def _plan_room_continuation(
         self,

--- a/src/agent_memory_orchestrator/peer/agent/state.py
+++ b/src/agent_memory_orchestrator/peer/agent/state.py
@@ -64,6 +64,7 @@ class PeerAgentStateStore:
             "last_ok": bool(attempt.get("ok")),
             "last_error": str((attempt.get("delivery") or {}).get("error") or attempt.get("error") or ""),
             "mode": str(attempt.get("mode") or prior.get("mode") or ""),
+            "last_timing": attempt.get("timing") if isinstance(attempt.get("timing"), dict) else {},
         }
         state["response_attempts"] = attempts
         return self.save(room_id, state)

--- a/src/agent_memory_orchestrator/runtime/cli/commands/peer/args.py
+++ b/src/agent_memory_orchestrator/runtime/cli/commands/peer/args.py
@@ -244,6 +244,11 @@ def add_peer_subcommands(sub: Any) -> None:
     peer_agent_ask_room.add_argument("--session-id", default="")
     peer_agent_ask_room.add_argument("--min-confidence", type=float, default=None)
     peer_agent_ask_room.add_argument("--timeout-seconds", type=float, default=None)
+    peer_agent_ask_room.add_argument(
+        "--wait-for-response",
+        action="store_true",
+        help="After sending the follow-up, drain peer-agent inbox until targeted peer responses arrive or timeout.",
+    )
     peer_agent_continue = peer_agent_sub.add_parser("continue", help="Let the initiator planner choose one next room action")
     peer_agent_continue.add_argument("--room-id", required=True)
     peer_agent_continue.add_argument("--min-confidence", type=float, default=None)

--- a/src/agent_memory_orchestrator/runtime/cli/commands/peer/handlers.py
+++ b/src/agent_memory_orchestrator/runtime/cli/commands/peer/handlers.py
@@ -393,6 +393,7 @@ def handle_peer_command(
                 session_id=args.session_id,
                 min_confidence=args.min_confidence,
                 timeout_seconds=args.timeout_seconds,
+                wait_for_response=args.wait_for_response,
             )
             emit(result)
             return 0 if result.get("ok") else 1

--- a/src/agent_memory_orchestrator/runtime/mcp/server.py
+++ b/src/agent_memory_orchestrator/runtime/mcp/server.py
@@ -176,6 +176,7 @@ def create_server(settings: Settings) -> FastMCP:
         session_id: str = "",
         min_confidence: float = 0.72,
         timeout_seconds: float = 45,
+        wait_for_response: bool = False,
     ) -> dict:
         """Send a schema-valid follow-up request inside an existing peer-agent room."""
         return memory_tools.peer_room_ask(
@@ -185,6 +186,7 @@ def create_server(settings: Settings) -> FastMCP:
             session_id=session_id,
             min_confidence=min_confidence,
             timeout_seconds=timeout_seconds,
+            wait_for_response=wait_for_response,
         )
 
     @mcp.tool()

--- a/src/agent_memory_orchestrator/runtime/mcp/tools/contracts.py
+++ b/src/agent_memory_orchestrator/runtime/mcp/tools/contracts.py
@@ -77,9 +77,9 @@ MCP_MEMORY_TOOL_CONTRACTS: dict[str, dict[str, Any]] = {
         "returns": ["room", "agent_state"],
     },
     "peer_room_ask": {
-        "description": "Send a schema-valid follow-up request inside an existing peer-agent room.",
+        "description": "Send a schema-valid follow-up request inside an existing peer-agent room, optionally waiting for targeted responses.",
         "required": ["room_id", "query"],
-        "returns": ["room_id", "mode", "logical_request_id", "peer_requests", "deliveries", "timing"],
+        "returns": ["room_id", "mode", "logical_request_id", "peer_requests", "deliveries", "peer_responses", "timing"],
     },
     "peer_room_continue": {
         "description": "Let the initiator planner choose one next action for a peer-agent room.",

--- a/src/agent_memory_orchestrator/runtime/mcp/tools/peer_service.py
+++ b/src/agent_memory_orchestrator/runtime/mcp/tools/peer_service.py
@@ -34,6 +34,7 @@ class PeerToolMixin:
         session_id: str = "",
         min_confidence: float = 0.72,
         timeout_seconds: float = 45,
+        wait_for_response: bool = False,
     ) -> dict[str, Any]:
         return self._peer_agent_service().ask_room(
             room_id=_require_text(room_id, "room_id"),
@@ -42,6 +43,7 @@ class PeerToolMixin:
             session_id=session_id,
             min_confidence=min_confidence,
             timeout_seconds=timeout_seconds,
+            wait_for_response=wait_for_response,
         )
 
     def peer_room_continue(

--- a/tests/test_peer_agent.py
+++ b/tests/test_peer_agent.py
@@ -108,6 +108,29 @@ def test_peer_agent_ask_room_sends_schema_valid_followup(tmp_path: Path) -> None
     assert metadata["query"] == "Can you answer a valid room follow-up?"
 
 
+def test_peer_agent_ask_room_can_wait_for_target_response(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    store = PeerStore(settings)
+    store.init_config(node_id="zenbook-amo")
+    store.add_peer(PeerNode(node_id="poco-amo", peer_id="12D3KooWPeer", capabilities=("graph_retrieval",)))
+    room = store.create_room(topic="debug peer room", participants=["poco-amo"])
+    netd = FakeNetdClient()
+    svc = PeerAgentService(settings, peer_service=PeerService(settings, store=store, netd_client=netd))
+
+    result = svc.ask_room(
+        room_id=room["room_id"],
+        peer_ids=["poco-amo"],
+        query="Can you answer a valid room follow-up?",
+        timeout_seconds=0.1,
+        wait_for_response=True,
+    )
+
+    assert result["ok"] is True
+    assert result["response_count"] == 0
+    assert result["peer_responses"] == []
+    assert result["timing"]["wait_ms"] >= 0
+
+
 def test_peer_agent_watch_returns_llm_answer_when_peer_ollama_available(tmp_path: Path) -> None:
     settings = make_settings(tmp_path, peer_agent_allow_retrieval_only_responses=False)
     store = peer_room_with_request(tmp_path, local_node="poco-amo")
@@ -220,6 +243,32 @@ def test_peer_agent_retries_failed_response_delivery(tmp_path: Path) -> None:
     state = json.loads((settings.home / ".peer" / "rooms" / room_id / "agent_state.json").read_text(encoding="utf-8"))
     assert state["response_attempts"]["req_1"]["attempt_count"] == 2
     assert "req_1" in state["sent_response_for_request_ids"]
+
+
+def test_peer_agent_response_records_stage_timing(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path)
+    store = peer_room_with_request(tmp_path, local_node="poco-amo")
+    netd = FakeNetdClient()
+    svc = PeerAgentService(
+        settings,
+        peer_service=PeerService(settings, store=store, netd_client=netd),
+        graph=FakeGraph(good_retrieval()),
+        llm=FakeLlm(local_ready=False),
+    )
+
+    result = svc.watch_once()
+
+    assert result["processed"][0]["ok"] is True
+    response = [item for item in netd.sent if item["message"]["type"] == CONTEXT_RESPONSE][0]["message"]
+    timing = response["payload"]["metadata"]["timing"]
+    assert timing["retrieval_ms"] >= 0
+    assert timing["quality_support_ms"] >= 0
+    assert timing["llm_ready"] is False
+    assert timing["llm_ready_ms"] >= 0
+    assert timing["total_ms"] >= timing["retrieval_ms"]
+    room_id = store.list_rooms()[0]["room_id"]
+    state = json.loads((settings.home / ".peer" / "rooms" / room_id / "agent_state.json").read_text(encoding="utf-8"))
+    assert state["response_attempts"]["req_1"]["last_timing"]["retrieval_ms"] >= 0
 
 
 def test_peer_agent_skips_stale_manual_context_requests(tmp_path: Path) -> None:

--- a/tests/test_peer_rooms.py
+++ b/tests/test_peer_rooms.py
@@ -634,6 +634,48 @@ def test_context_pack_uses_deduped_orchestration_view_for_initiator(tmp_path: Pa
     assert pack["layers"]["pairwise_recent_messages"] == recent
 
 
+def test_context_pack_excludes_answered_context_requests_from_open_questions(tmp_path: Path) -> None:
+    settings = make_settings(tmp_path / "initiator")
+    store = PeerStore(settings)
+    store.init_config(node_id="zenbook-amo")
+    room = PeerService(settings, store=store).open_room(
+        topic="collect peer answers",
+        peer_ids=["poco-amo"],
+        send_invites=False,
+    )["room"]
+    svc = PeerService(settings, store=store)
+    svc.append_message(
+        room_id=room["room_id"],
+        from_node_id="zenbook-amo",
+        to_node_ids=["poco-amo"],
+        message_type="context_request",
+        content="Answered question?",
+        metadata={"request_id": "req_answered", "query": "Answered question?"},
+    )
+    svc.append_message(
+        room_id=room["room_id"],
+        from_node_id="poco-amo",
+        to_node_ids=["zenbook-amo"],
+        message_type="context_response",
+        content="Answered.",
+        metadata={"request_id": "req_answered"},
+    )
+    svc.append_message(
+        room_id=room["room_id"],
+        from_node_id="zenbook-amo",
+        to_node_ids=["poco-amo"],
+        message_type="context_request",
+        content="Still pending?",
+        metadata={"request_id": "req_pending", "query": "Still pending?"},
+    )
+
+    initiator_pack = svc.context_pack(room["room_id"], viewer_node_id="zenbook-amo")["context"]
+    peer_pack = svc.context_pack(room["room_id"], viewer_node_id="poco-amo")["context"]
+
+    assert [item["request_id"] for item in initiator_pack["layers"]["open_questions"]] == ["req_pending"]
+    assert [item["request_id"] for item in peer_pack["layers"]["open_questions"]] == ["req_pending"]
+
+
 def make_settings(tmp_path: Path) -> Settings:
     return Settings(
         home=tmp_path,


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to wait for peer responses when querying rooms
  * Response timing now tracked across processing stages

* **Documentation**
  * Added peer-agent LLM contracts documentation

* **Bug Fixes**
  * Fixed reappearance of previously answered questions in open questions

* **Tests**
  * Added tests for response waiting and timing tracking functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->