### PR TITLE
fix(antelligent): address release lifecycle review hardening

### DIFF
--- a/.github/workflows/antelligent-release.yml
+++ b/.github/workflows/antelligent-release.yml
@@ -21,7 +21,7 @@ on:
       - "antelligent-v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   prepare:
@@ -35,7 +35,9 @@ jobs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Resolve release metadata
         id: meta
@@ -100,10 +102,12 @@ jobs:
             build_args: --bundles app --no-sign
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
           cache: npm
@@ -134,7 +138,7 @@ jobs:
             --output-dir dist/antelligent
 
       - name: Upload release artifact candidate
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: antelligent-${{ matrix.label }}
           path: dist/antelligent/*
@@ -144,12 +148,16 @@ jobs:
     name: Publish Antelligent release
     needs: [prepare, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Download artifact candidates
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: antelligent-*
           path: release-assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,12 @@ jobs:
         os: [windows-latest, macos-14]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
           cache: npm

--- a/apps/antelligent/src-tauri/src/config.rs
+++ b/apps/antelligent/src-tauri/src/config.rs
@@ -42,8 +42,8 @@ pub fn daemon_base_url() -> String {
     launch_config()
         .and_then(|config| config.daemon_url)
         .filter(|value| !value.trim().is_empty())
-        .or_else(|| env::var("ANTELLIGENT_DAEMON_URL").ok())
-        .or_else(|| env::var("AMO_DAEMON_URL").ok())
+        .or_else(|| non_empty_env("ANTELLIGENT_DAEMON_URL"))
+        .or_else(|| non_empty_env("AMO_DAEMON_URL"))
         .unwrap_or_else(|| "http://127.0.0.1:8765".to_string())
 }
 
@@ -57,17 +57,17 @@ pub fn amo_home() -> PathBuf {
             return PathBuf::from(value);
         }
     }
-    if let Ok(value) = env::var("AMO_HOME") {
+    if let Some(value) = non_empty_env("AMO_HOME") {
         return PathBuf::from(value);
     }
     home_dir().join(".agent-memory-orchestrator")
 }
 
 pub fn launch_config_path() -> PathBuf {
-    if let Ok(value) = env::var("ANTELLIGENT_CONFIG") {
+    if let Some(value) = non_empty_env("ANTELLIGENT_CONFIG") {
         return PathBuf::from(value);
     }
-    if let Ok(value) = env::var("AMO_HOME") {
+    if let Some(value) = non_empty_env("AMO_HOME") {
         return PathBuf::from(value)
             .join(".ui")
             .join("antelligent.launch.json");
@@ -120,4 +120,8 @@ fn home_dir() -> PathBuf {
         .or_else(|_| env::var("HOME"))
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.trim().is_empty())
 }

--- a/apps/antelligent/src-tauri/src/lib.rs
+++ b/apps/antelligent/src-tauri/src/lib.rs
@@ -32,8 +32,10 @@ pub fn run() {
             hide_panel
         ])
         .setup(|app| {
-            let _ = pid::write_pid();
-            supervisor::ensure_daemon_started();
+            pid::write_pid().map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            if let Err(err) = supervisor::ensure_daemon_started() {
+                eprintln!("Antelligent daemon supervisor failed: {err}");
+            }
             tray::install(app.handle())?;
             window::place_bubble(app.handle());
             Ok(())

--- a/apps/antelligent/src-tauri/src/pid.rs
+++ b/apps/antelligent/src-tauri/src/pid.rs
@@ -1,4 +1,4 @@
-use std::{fs, process};
+use std::{fs, io::ErrorKind, process};
 
 use crate::config;
 
@@ -10,7 +10,11 @@ pub fn write_pid() -> Result<(), String> {
     fs::write(path, format!("{{\"pid\":{}}}\n", process::id())).map_err(|err| err.to_string())
 }
 
-pub fn clear_pid() {
+pub fn clear_pid() -> Result<(), String> {
     let path = config::pid_path();
-    let _ = fs::remove_file(path);
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.to_string()),
+    }
 }

--- a/apps/antelligent/src-tauri/src/supervisor.rs
+++ b/apps/antelligent/src-tauri/src/supervisor.rs
@@ -9,18 +9,19 @@ use crate::config;
 
 const SPAWN_COOLDOWN: Duration = Duration::from_secs(8);
 
-pub fn ensure_daemon_started() {
+pub fn ensure_daemon_started() -> Result<(), String> {
     if daemon_reachable() || !spawn_allowed() {
-        return;
+        return Ok(());
     }
     let Some(daemon) = config::daemon_command() else {
-        return;
+        return Ok(());
     };
     let mut command = Command::new(daemon.program);
     command.args(daemon.args);
     command.env("AMO_HOME", config::amo_home());
     hide_console(&mut command);
-    let _ = command.spawn();
+    command.spawn().map_err(|err| err.to_string())?;
+    Ok(())
 }
 
 fn spawn_allowed() -> bool {

--- a/apps/antelligent/src-tauri/src/tray.rs
+++ b/apps/antelligent/src-tauri/src/tray.rs
@@ -22,7 +22,9 @@ pub fn install(app: &AppHandle) -> tauri::Result<()> {
                 let _ = window::hide_panel(app);
             }
             "quit" => {
-                pid::clear_pid();
+                if let Err(err) = pid::clear_pid() {
+                    eprintln!("Antelligent failed to clear PID file: {err}");
+                }
                 app.exit(0);
             }
             _ => {}

--- a/scripts/package_antelligent_artifact.py
+++ b/scripts/package_antelligent_artifact.py
@@ -7,6 +7,7 @@ import tarfile
 import zipfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 APP_BUNDLE_NAME = "Antelligent.app"
 CRATE_BINARY = "antelligent"
@@ -49,6 +50,7 @@ def package_artifact(
     output_dir: Path,
     base_url: str,
 ) -> dict[str, Any]:
+    _require_https_base_url(base_url)
     output_dir.mkdir(parents=True, exist_ok=True)
     if platform_name == "windows":
         source = _windows_executable(target_root, target)
@@ -139,6 +141,12 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _require_https_base_url(value: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("Antelligent release base_url must use HTTPS")
 
 
 if __name__ == "__main__":

--- a/src/agent_memory_orchestrator/runtime/antelligent/artifacts.py
+++ b/src/agent_memory_orchestrator/runtime/antelligent/artifacts.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from tarfile import TarFile
 from tarfile import open as tar_open
 from typing import Any
+from urllib.parse import urlparse
 
 from .paths import arch_key, platform_key
 
@@ -48,12 +49,16 @@ def select_artifact(manifest: dict[str, Any], *, platform_name: str | None = Non
         item_version = str(item.get("version") or manifest_version)
         if version and version != "latest" and item_version != version:
             continue
+        url = str(item.get("url") or "")
+        sha256 = str(item.get("sha256") or "")
+        if _is_remote_url(url) and not sha256:
+            raise ValueError("remote Antelligent artifacts must include sha256")
         return Artifact(
             version=item_version,
             platform=wanted_platform,
             arch=wanted_arch,
-            url=str(item.get("url") or ""),
-            sha256=str(item.get("sha256") or ""),
+            url=url,
+            sha256=sha256,
             executable_relpath=str(item.get("executable_relpath") or ""),
             minimum_amo_version=str(item.get("minimum_amo_version") or manifest.get("minimum_amo_version") or ""),
         )
@@ -67,6 +72,8 @@ def download_artifact(artifact: Artifact, dest: Path) -> Path:
     if artifact.url.startswith("http://"):
         raise ValueError("Antelligent artifact URL must use HTTPS")
     if artifact.url.startswith("https://"):
+        if not artifact.sha256:
+            raise ValueError("remote Antelligent artifacts must include sha256")
         with urllib.request.urlopen(artifact.url, timeout=120) as response:  # noqa: S310 - release artifact URL from manifest.
             dest.write_bytes(response.read())
         return dest
@@ -85,8 +92,10 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def verify_sha256(path: Path, expected: str) -> str:
+def verify_sha256(path: Path, expected: str, *, required: bool = False) -> str:
     actual = sha256_file(path)
+    if required and not expected:
+        raise ValueError("Antelligent artifact SHA256 is required")
     if expected and actual.lower() != expected.lower():
         raise ValueError(f"Antelligent artifact SHA256 mismatch: expected {expected}, got {actual}")
     return actual
@@ -117,14 +126,21 @@ def _safe_extract_zip(archive: zipfile.ZipFile, dest: Path) -> None:
 
 def _safe_extract_tar(archive: TarFile, dest: Path) -> None:
     root = dest.resolve()
-    members = archive.getmembers()
-    for member in members:
+    members = []
+    for member in archive.getmembers():
         target = (dest / member.name).resolve()
         if root != target and root not in target.parents:
             raise ValueError(f"unsafe tar member path: {member.name}")
         if member.islnk() or member.issym():
             raise ValueError(f"refusing symlink in Antelligent artifact: {member.name}")
+        if not (member.isdir() or member.isreg()):
+            raise ValueError(f"refusing unsupported tar member in Antelligent artifact: {member.name}")
+        members.append(member)
     archive.extractall(dest, members=members)
+
+
+def _is_remote_url(value: str) -> bool:
+    return urlparse(value).scheme in {"http", "https"}
 
 
 def temp_dir(prefix: str = "antelligent-") -> Path:

--- a/src/agent_memory_orchestrator/runtime/antelligent/install.py
+++ b/src/agent_memory_orchestrator/runtime/antelligent/install.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -40,9 +41,10 @@ def install_antelligent(
             sha256="",
             executable_relpath="",
         )
-    actual_sha = verify_sha256(archive_path, artifact.sha256)
+    actual_sha = verify_sha256(archive_path, artifact.sha256, required=artifact_path is None)
 
-    extract_dir = temp_dir("antelligent-extract-")
+    paths.app_dir.parent.mkdir(parents=True, exist_ok=True)
+    extract_dir = Path(tempfile.mkdtemp(prefix="antelligent-extract-", dir=str(paths.app_dir.parent)))
     extract_artifact(archive_path, extract_dir)
     executable_relpath = artifact.executable_relpath or _find_executable_relpath(extract_dir)
     executable = extract_dir / executable_relpath
@@ -50,21 +52,26 @@ def install_antelligent(
         raise FileNotFoundError(f"Antelligent executable not found in artifact: {executable_relpath}")
 
     previous_dir = paths.app_dir.with_name(paths.app_dir.name + ".previous")
-    if paths.app_dir.exists():
-        if not force and not _looks_like_antelligent_install(paths.app_dir):
-            raise FileExistsError(f"refusing to replace non-Antelligent directory: {paths.app_dir}")
+    if paths.app_dir.exists() and not force and not _looks_like_antelligent_install(paths.app_dir):
+        _remove_path(extract_dir)
+        raise FileExistsError(f"refusing to replace non-Antelligent directory: {paths.app_dir}")
+    try:
+        if paths.app_dir.exists():
+            if previous_dir.exists():
+                shutil.rmtree(previous_dir)
+            paths.app_dir.replace(previous_dir)
+        shutil.move(str(extract_dir), str(paths.app_dir))
+        installed_executable = paths.app_dir / executable_relpath
+        if not installed_executable.exists():
+            raise FileNotFoundError(f"installed Antelligent executable missing: {installed_executable}")
         if previous_dir.exists():
             shutil.rmtree(previous_dir)
-        paths.app_dir.replace(previous_dir)
-    paths.app_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(extract_dir), str(paths.app_dir))
-    installed_executable = paths.app_dir / executable_relpath
-    if not installed_executable.exists():
-        if previous_dir.exists() and not paths.app_dir.exists():
+    except Exception:
+        _remove_path(paths.app_dir)
+        if previous_dir.exists():
             previous_dir.replace(paths.app_dir)
-        raise FileNotFoundError(f"installed Antelligent executable missing: {installed_executable}")
-    if previous_dir.exists():
-        shutil.rmtree(previous_dir)
+        _remove_path(extract_dir)
+        raise
 
     metadata = {
         "ok": True,
@@ -145,6 +152,13 @@ def _looks_like_antelligent_install(path: Path) -> bool:
 def _cleanup_temp(path: Path, should_remove: bool) -> None:
     if should_remove and path.exists():
         shutil.rmtree(path, ignore_errors=True)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+    elif path.exists():
+        path.unlink()
 
 
 __all__ = ["install_antelligent", "install_metadata", "installed_executable", "uninstall_antelligent"]

--- a/src/agent_memory_orchestrator/runtime/antelligent/launch_config.py
+++ b/src/agent_memory_orchestrator/runtime/antelligent/launch_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -13,7 +14,8 @@ SCHEMA_VERSION = 1
 
 
 def build_launch_config(settings: Settings, *, python_executable: str | None = None) -> dict[str, Any]:
-    program = str(Path(python_executable or sys.executable).resolve())
+    """Build launch config. python_executable must resolve to an existing executable."""
+    program = _resolve_python_executable(python_executable or sys.executable)
     settings.home.mkdir(parents=True, exist_ok=True)
     token = ensure_antelligent_token(settings)
     paths = paths_for(settings)
@@ -33,6 +35,19 @@ def build_launch_config(settings: Settings, *, python_executable: str | None = N
         "ui_token_path": str(paths.token_path),
         "token_ready": bool(token),
     }
+
+
+def _resolve_python_executable(value: str) -> str:
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        resolved = shutil.which(value)
+        if not resolved:
+            raise ValueError(f"Python executable not found on PATH: {value}")
+        candidate = Path(resolved)
+    candidate = candidate.resolve()
+    if not candidate.exists():
+        raise ValueError(f"Python executable does not exist: {candidate}")
+    return str(candidate)
 
 
 def write_launch_config(settings: Settings, *, python_executable: str | None = None) -> dict[str, Any]:

--- a/src/agent_memory_orchestrator/runtime/antelligent/process.py
+++ b/src/agent_memory_orchestrator/runtime/antelligent/process.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import signal
 import subprocess
 from pathlib import Path
@@ -126,8 +127,8 @@ def _pid_exists(pid: int) -> bool:
 
 def _process_matches_antelligent(settings: Settings, pid: int) -> bool:
     exe = installed_executable(settings)
-    expected = str(exe.resolve()).lower() if exe and exe.exists() else ""
     if is_windows():
+        expected = str(exe.resolve()).lower() if exe and exe.exists() else ""
         command = [
             "powershell",
             "-NoProfile",
@@ -139,9 +140,22 @@ def _process_matches_antelligent(settings: Settings, pid: int) -> bool:
         return bool(expected and actual and actual == expected)
     result = subprocess.run(["ps", "-p", str(pid), "-o", "command="], text=True, capture_output=True, check=False)
     command_line = result.stdout.strip()
-    if expected and expected in command_line.lower():
-        return True
-    return "antelligent" in command_line.lower()
+    if not exe or not exe.exists() or not command_line:
+        return False
+    try:
+        argv = shlex.split(command_line)
+    except ValueError:
+        return False
+    if not argv:
+        return False
+    expected_path = exe.resolve()
+    argv0 = Path(argv[0])
+    if argv0.is_absolute():
+        try:
+            return argv0.resolve() == expected_path
+        except OSError:
+            return False
+    return argv0.name.lower() == expected_path.name.lower()
 
 
 def _safe_unlink(path: Path) -> None:

--- a/src/agent_memory_orchestrator/runtime/antelligent/startup.py
+++ b/src/agent_memory_orchestrator/runtime/antelligent/startup.py
@@ -12,6 +12,7 @@ from .paths import APP_NAME, is_macos, is_windows, paths_for
 
 RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
 LAUNCH_AGENT_LABEL = "com.agent-memory-orchestrator.antelligent"
+LAUNCHCTL_TIMEOUT_SECONDS = 10
 
 
 def install_startup(settings: Settings) -> dict[str, Any]:
@@ -87,8 +88,12 @@ def _install_macos_launch_agent(settings: Settings, exe: Path) -> dict[str, Any]
     plist = macos_launch_agent_plist(settings, exe)
     with path.open("wb") as handle:
         plistlib.dump(plist, handle)
-    subprocess.run(["launchctl", "bootout", _launchd_domain(), str(path)], text=True, capture_output=True, check=False)
-    result = subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(path)], text=True, capture_output=True, check=False)
+    bootout = _run_launchctl(["launchctl", "bootout", _launchd_domain(), str(path)], path)
+    if isinstance(bootout, dict):
+        return bootout
+    result = _run_launchctl(["launchctl", "bootstrap", _launchd_domain(), str(path)], path)
+    if isinstance(result, dict):
+        return result
     return {
         "ok": result.returncode == 0,
         "platform": "darwin",
@@ -104,7 +109,9 @@ def _install_macos_launch_agent(settings: Settings, exe: Path) -> dict[str, Any]
 
 def _uninstall_macos_launch_agent() -> dict[str, Any]:
     path = _launch_agent_path()
-    result = subprocess.run(["launchctl", "bootout", _launchd_domain(), str(path)], text=True, capture_output=True, check=False)
+    result = _run_launchctl(["launchctl", "bootout", _launchd_domain(), str(path)], path)
+    if isinstance(result, dict):
+        return result
     removed = False
     if path.exists():
         path.unlink()
@@ -121,6 +128,26 @@ def _uninstall_macos_launch_agent() -> dict[str, Any]:
 
 def _launch_agent_path() -> Path:
     return Path.home() / "Library" / "LaunchAgents" / f"{LAUNCH_AGENT_LABEL}.plist"
+
+
+def _run_launchctl(command: list[str], path: Path) -> subprocess.CompletedProcess[str] | dict[str, Any]:
+    try:
+        return subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=LAUNCHCTL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "platform": "darwin",
+            "method": "launch-agent",
+            "plist_path": str(path),
+            "error": "launchctl_timeout",
+            "timeout_seconds": LAUNCHCTL_TIMEOUT_SECONDS,
+        }
 
 
 def windows_run_command(exe: Path) -> str:

--- a/src/agent_memory_orchestrator/runtime/cli/commands/antelligent.py
+++ b/src/agent_memory_orchestrator/runtime/cli/commands/antelligent.py
@@ -58,8 +58,12 @@ def handle_antelligent_command(args: Any, *, emit: Callable[[object], None]) -> 
         )
         if args.install_startup:
             result["startup"] = install_startup(settings)
+            if not result["startup"].get("ok"):
+                result["ok"] = False
         if args.start:
             result["start"] = start_antelligent(settings)
+            if not result["start"].get("ok"):
+                result["ok"] = False
         emit(result)
         return 0 if result.get("ok") else 1
     if command == "start":

--- a/tests/test_antelligent_lifecycle.py
+++ b/tests/test_antelligent_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tarfile
 import zipfile
 from argparse import Namespace
 from pathlib import Path
@@ -10,12 +11,13 @@ from pathlib import Path
 import pytest
 
 from agent_memory_orchestrator.core.config import Settings
-from agent_memory_orchestrator.runtime.antelligent.artifacts import Artifact, download_artifact, load_manifest, select_artifact, verify_sha256
+from agent_memory_orchestrator.runtime.antelligent.artifacts import Artifact, download_artifact, extract_artifact, load_manifest, select_artifact, verify_sha256
 from agent_memory_orchestrator.runtime.antelligent.install import install_antelligent, installed_executable
 from agent_memory_orchestrator.runtime.antelligent.launch_config import write_launch_config
 from agent_memory_orchestrator.runtime.antelligent.paths import executable_name, paths_for
 from agent_memory_orchestrator.runtime.antelligent.process import status_antelligent, stop_antelligent
 from agent_memory_orchestrator.runtime.antelligent.startup import macos_launch_agent_plist, windows_run_command
+from agent_memory_orchestrator.runtime.cli.commands import antelligent as antelligent_command
 from agent_memory_orchestrator.runtime.cli.commands import install as install_command
 
 
@@ -66,6 +68,39 @@ def test_verify_sha256_rejects_mismatch(tmp_path: Path) -> None:
         verify_sha256(artifact, "0" * 64)
 
 
+def test_remote_artifacts_require_sha256(tmp_path: Path) -> None:
+    artifact = tmp_path / "app.zip"
+    artifact.write_text("payload", encoding="utf-8")
+    manifest = {
+        "version": "0.1.0",
+        "artifacts": [
+            {
+                "platform": "windows",
+                "arch": "amd64",
+                "url": "https://example.invalid/antelligent.zip",
+                "executable_relpath": "antelligent.exe",
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="sha256"):
+        select_artifact(manifest, platform_name="windows", arch="amd64")
+    with pytest.raises(ValueError, match="SHA256 is required"):
+        verify_sha256(artifact, "", required=True)
+    with pytest.raises(ValueError, match="sha256"):
+        download_artifact(
+            Artifact(
+                version="0.1.0",
+                platform="windows",
+                arch="amd64",
+                url="https://example.invalid/antelligent.zip",
+                sha256="",
+                executable_relpath="antelligent.exe",
+            ),
+            tmp_path / "antelligent.zip",
+        )
+
+
 def test_remote_artifact_sources_must_use_https(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="manifest URL must use HTTPS"):
         load_manifest("http://example.invalid/manifest.json")
@@ -81,6 +116,17 @@ def test_remote_artifact_sources_must_use_https(tmp_path: Path) -> None:
             ),
             tmp_path / "antelligent.zip",
         )
+
+
+def test_tar_extraction_rejects_unsupported_members(tmp_path: Path) -> None:
+    archive_path = tmp_path / "bad.tar.gz"
+    with tarfile.open(archive_path, "w:gz") as archive:
+        member = tarfile.TarInfo("bad-fifo")
+        member.type = tarfile.FIFOTYPE
+        archive.addfile(member)
+
+    with pytest.raises(ValueError, match="unsupported tar member"):
+        extract_artifact(archive_path, tmp_path / "out")
 
 
 def test_install_from_local_artifact_writes_metadata_and_launch_config(
@@ -201,3 +247,26 @@ def test_amo_install_rejects_antelligent_startup_without_install(tmp_path: Path)
 
     assert status == 2
     assert emitted == [{"ok": False, "error": "--antelligent-startup requires --with-antelligent"}]
+
+
+def test_antelligent_install_command_fails_when_nested_startup_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(antelligent_command, "install_antelligent", lambda *_args, **_kwargs: {"ok": True})
+    monkeypatch.setattr(antelligent_command, "install_startup", lambda *_args, **_kwargs: {"ok": False, "error": "startup_failed"})
+    emitted: list[object] = []
+    args = Namespace(
+        command="antelligent",
+        antelligent_command="install",
+        amo_home=tmp_path / "amo",
+        version="latest",
+        artifact=None,
+        manifest=None,
+        force=False,
+        install_startup=True,
+        start=False,
+    )
+
+    status = antelligent_command.handle_antelligent_command(args, emit=emitted.append)
+
+    assert status == 1
+    assert emitted[-1]["ok"] is False
+    assert emitted[-1]["startup"]["error"] == "startup_failed"

--- a/tests/test_antelligent_release_packaging.py
+++ b/tests/test_antelligent_release_packaging.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import tarfile
 import zipfile
 from pathlib import Path
+
+import pytest
 
 from scripts.package_antelligent_artifact import package_artifact
 
@@ -35,3 +38,52 @@ def test_package_antelligent_windows_artifact_manifest(tmp_path: Path) -> None:
     assert item["url"].endswith("/antelligent-windows-amd64.zip")
     assert item["sha256"] == result["sha256"]
     assert item["executable_relpath"] == "antelligent.exe"
+
+
+def test_package_antelligent_darwin_artifact_manifest(tmp_path: Path) -> None:
+    target_root = tmp_path / "target"
+    exe = target_root / "release" / "bundle" / "macos" / "Antelligent.app" / "Contents" / "MacOS" / "antelligent"
+    exe.parent.mkdir(parents=True)
+    exe.write_bytes(b"fake antelligent binary")
+    output = tmp_path / "out"
+
+    result = package_artifact(
+        platform_name="darwin",
+        arch="amd64",
+        version="0.1.0",
+        minimum_amo_version="0.1.4",
+        target=None,
+        target_root=target_root,
+        output_dir=output,
+        base_url="https://github.com/spurbey/agent-memory-orchestrator/releases/download/antelligent-v0.1.0",
+    )
+
+    artifact = Path(result["artifact"])
+    fragment = json.loads(Path(result["manifest_fragment"]).read_text(encoding="utf-8"))
+    with tarfile.open(artifact, "r:gz") as archive:
+        assert "Antelligent.app/Contents/MacOS/antelligent" in archive.getnames()
+    item = fragment["artifacts"][0]
+    assert item["platform"] == "darwin"
+    assert item["arch"] == "amd64"
+    assert item["url"].endswith("/antelligent-darwin-amd64.tar.gz")
+    assert item["sha256"] == result["sha256"]
+    assert item["executable_relpath"] == "Antelligent.app/Contents/MacOS/antelligent"
+
+
+def test_package_antelligent_requires_https_base_url(tmp_path: Path) -> None:
+    target_root = tmp_path / "target"
+    exe = target_root / "release" / "antelligent.exe"
+    exe.parent.mkdir(parents=True)
+    exe.write_bytes(b"fake antelligent exe")
+
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        package_artifact(
+            platform_name="windows",
+            arch="amd64",
+            version="0.1.0",
+            minimum_amo_version="0.1.4",
+            target=None,
+            target_root=target_root,
+            output_dir=tmp_path / "out",
+            base_url="http://example.invalid/release",
+        )


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.
