### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/docs/semantic_harness/03-runtime-and-storage.md
+++ b/docs/semantic_harness/03-runtime-and-storage.md
@@ -35,6 +35,40 @@ AMO IDs are stored in `ExternalAmoRef` nodes or `IMPORTED_FROM_AMO` edge metadat
 
 Every bootstrap and update stage must be replayable. Re-running the same input should produce the same primary IDs and either reuse or supersede projections deterministically.
 
+## Graph And Projection Identity
+
+The structural graph snapshot ID tracks structural identity, not operational state:
+
+```text
+graph_snapshot_id =
+  hash(
+    graph_schema_version
+    repo_id
+    sorted node IDs
+    sorted edge keys: source_id + kind + target_id
+  )
+```
+
+Do not include mutable metadata, summaries, relation weights, counters, or feedback status in `graph_snapshot_id`. Those fields can change during enrichment or eval feedback without changing the structural graph shape.
+
+Projection identity is derived from graph identity plus projection policy:
+
+```text
+projection_id =
+  hash(
+    projection_version
+    graph_snapshot_id
+  )
+```
+
+This gives later SQLite/vector caches a stable invalidation boundary:
+
+```text
+same graph_snapshot_id + same projection_version -> reusable projection
+same graph_snapshot_id + new projection_version -> rebuild projection
+new graph_snapshot_id -> rebuild projection and derived vector cache
+```
+
 ## Qwen Degraded Mode
 
 If Qwen is unavailable, the daemon still updates deterministic structural graph state and marks semantic enrichment as missing or pending. Structural harness queries remain available.

--- a/docs/semantic_harness/13-retrieval-embeddings-and-projections.md
+++ b/docs/semantic_harness/13-retrieval-embeddings-and-projections.md
@@ -78,6 +78,21 @@ The first projection layer is deterministic and storage-neutral. It emits high-s
 }
 ```
 
+Projection sets wrap these documents with cache identity:
+
+```json
+{
+  "projection_id": "hproj:<hash>",
+  "projection_version": "semantic_harness_projection_v1",
+  "graph_snapshot_id": "gsnap:<repo_id>:<hash>",
+  "graph_schema_version": "semantic_harness_graph_v1",
+  "document_count": 42,
+  "document_ids_hash": "sha256"
+}
+```
+
+`projection_id` is derived from `projection_version + graph_snapshot_id`. It is the invalidation key for future BM25/vector caches. Document content hashes remain per-document integrity checks, not the structural graph identity.
+
 Default projected node kinds:
 
 ```text

--- a/docs/semantic_harness/13-retrieval-embeddings-and-projections.md
+++ b/docs/semantic_harness/13-retrieval-embeddings-and-projections.md
@@ -284,3 +284,30 @@ Suppressed reasons are retained for eval/debug. The normal response only returns
 ## Projection Health
 
 Projection metadata must record source graph version, embedding model, document content hash, vector count, and readiness status.
+
+## Service-Level Projection Cache
+
+The first cache is application-local and rebuildable:
+
+```text
+StructuralHarnessService
+-> InMemoryProjectionCache
+-> HarnessProjectionSet
+```
+
+Cache key:
+
+```text
+projection_id = hash(projection_version + graph_snapshot_id)
+```
+
+Rules:
+
+```text
+exact-anchor queries do not build projection docs when the card budget is already filled
+lexical/vector routes request projection docs lazily
+same graph_snapshot_id + projection_version reuses the in-memory projection set
+new structural graph shape creates a new graph_snapshot_id and projection_id
+```
+
+This cache is not durable truth. The future SQLite projection store should persist the same `projection_id`, `graph_snapshot_id`, `projection_version`, `document_ids_hash`, and document rows.

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/__init__.py
@@ -13,6 +13,9 @@ from .evaluation import StructuralHarnessEvalService
 from .repository import RepoBootstrapOptions
 from .repository import RepoSourceSnapshot
 from .repository import read_repo_source_files
+from .projection_cache import InMemoryProjectionCache
+from .projection_cache import ProjectionCache
+from .projection_cache import ProjectionCacheStats
 from .retrieval_eval import RetrievalEvalCase
 from .retrieval_eval import RetrievalEvalCaseResult
 from .retrieval_eval import RetrievalEvalReport
@@ -27,6 +30,9 @@ __all__ = [
     "CommitUpdateEvalReport",
     "CommitUpdateEvalService",
     "CommitUpdateService",
+    "InMemoryProjectionCache",
+    "ProjectionCache",
+    "ProjectionCacheStats",
     "RepoBootstrapOptions",
     "RepoSourceSnapshot",
     "RetrievalEvalCase",

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/projection_cache.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/projection_cache.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from ....domain.semantic_harness import DEFAULT_PROJECTION_VERSION
+from ....domain.semantic_harness import HarnessProjectionSet
+from ....domain.semantic_harness import StructuralHarnessGraph
+from ....domain.semantic_harness import build_projection_set
+from ....domain.semantic_harness import graph_snapshot_identity
+from ....domain.semantic_harness import projection_set_id
+
+
+class ProjectionCache(Protocol):
+    def get_or_build(
+        self,
+        graph: StructuralHarnessGraph,
+        *,
+        projection_version: str = DEFAULT_PROJECTION_VERSION,
+    ) -> HarnessProjectionSet: ...
+
+
+@dataclass(slots=True, frozen=True)
+class ProjectionCacheStats:
+    size: int
+    hits: int
+    misses: int
+
+
+class InMemoryProjectionCache:
+    """Application-layer projection cache keyed by graph snapshot and projection version."""
+
+    def __init__(self) -> None:
+        self._sets: dict[str, HarnessProjectionSet] = {}
+        self._hits = 0
+        self._misses = 0
+
+    def get_or_build(
+        self,
+        graph: StructuralHarnessGraph,
+        *,
+        projection_version: str = DEFAULT_PROJECTION_VERSION,
+    ) -> HarnessProjectionSet:
+        snapshot = graph_snapshot_identity(graph)
+        cache_key = projection_set_id(snapshot.graph_snapshot_id, projection_version=projection_version)
+        if cached := self._sets.get(cache_key):
+            self._hits += 1
+            return cached
+        projection = build_projection_set(graph, projection_version=projection_version)
+        self._sets[projection.projection_id] = projection
+        self._misses += 1
+        return projection
+
+    def stats(self) -> ProjectionCacheStats:
+        return ProjectionCacheStats(size=len(self._sets), hits=self._hits, misses=self._misses)
+
+
+__all__ = ["InMemoryProjectionCache", "ProjectionCache", "ProjectionCacheStats"]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/structural.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/structural.py
@@ -5,13 +5,15 @@ from pathlib import Path
 
 from ....domain.semantic_harness import HarnessQueryRequest
 from ....domain.semantic_harness import HarnessQueryResponse
+from ....domain.semantic_harness import HarnessProjectionSet
 from ....domain.semantic_harness import HarnessProjectionDocument
 from ....domain.semantic_harness import SourceFile
 from ....domain.semantic_harness import StructuralHarnessGraph
 from ....domain.semantic_harness import answer_structural_query
 from ....domain.semantic_harness import build_structural_graph
-from ....domain.semantic_harness import build_projection_documents
 from ....domain.semantic_harness import repo_id_for_root
+from .projection_cache import InMemoryProjectionCache
+from .projection_cache import ProjectionCache
 from .repository import RepoBootstrapOptions
 from .repository import read_repo_source_files
 
@@ -28,9 +30,12 @@ class StructuralRepoBootstrapResult:
 class StructuralHarnessService:
     """Structural-only harness service for Phase 1.
 
-    This service is intentionally stateless. Storage-backed graph persistence,
-    AMO imports, vectors, and semantic enrichment are later phases.
+    Graph persistence, AMO imports, vectors, and semantic enrichment are later
+    phases. Projection cache is intentionally in-memory and rebuildable.
     """
+
+    def __init__(self, *, projection_cache: ProjectionCache | None = None) -> None:
+        self._projection_cache = projection_cache or InMemoryProjectionCache()
 
     def bootstrap(self, *, repo_id: str, files: tuple[SourceFile, ...]) -> StructuralHarnessGraph:
         return build_structural_graph(repo_id, files)
@@ -54,10 +59,17 @@ class StructuralHarnessService:
         )
 
     def query(self, graph: StructuralHarnessGraph, request: HarnessQueryRequest) -> HarnessQueryResponse:
-        return answer_structural_query(graph, request)
+        return answer_structural_query(
+            graph,
+            request,
+            projection_document_provider=lambda: self.projection_documents(graph),
+        )
+
+    def projection_set(self, graph: StructuralHarnessGraph) -> HarnessProjectionSet:
+        return self._projection_cache.get_or_build(graph)
 
     def projection_documents(self, graph: StructuralHarnessGraph) -> tuple[HarnessProjectionDocument, ...]:
-        return build_projection_documents(graph)
+        return self.projection_set(graph).documents
 
 
 __all__ = ["StructuralHarnessService", "StructuralRepoBootstrapResult"]

--- a/src/agent_memory_orchestrator/domain/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/__init__.py
@@ -39,7 +39,11 @@ from .models import HarnessQueryResponse
 from .models import SourceFile
 from .models import StructuralHarnessGraph
 from .projection import HarnessProjectionDocument
+from .projection import HarnessProjectionSet
+from .projection import DEFAULT_PROJECTION_VERSION
 from .projection import build_projection_documents
+from .projection import build_projection_set
+from .projection import projection_set_id
 from .query import answer_structural_query
 from .relations import CoChangeSeed
 from .relations import HistoricalRelationCandidate
@@ -74,6 +78,7 @@ from .store import apply_graph_update_delta
 
 __all__ = [
     "EdgeKey",
+    "DEFAULT_PROJECTION_VERSION",
     "GraphDeltaApplyResult",
     "HASH_COSINE_METHOD",
     "HarnessCard",
@@ -82,6 +87,7 @@ __all__ = [
     "HarnessNextAction",
     "HarnessNode",
     "HarnessProjectionDocument",
+    "HarnessProjectionSet",
     "HarnessQueryRequest",
     "HarnessQueryResponse",
     "InMemoryHarnessGraphStore",
@@ -114,6 +120,7 @@ __all__ = [
     "build_commit_update_delta",
     "build_cochange_seed",
     "build_projection_documents",
+    "build_projection_set",
     "historical_relation_candidates",
     "code_region_id",
     "commit_id",
@@ -129,6 +136,7 @@ __all__ = [
     "map_hunk_to_entities",
     "normalize_file_path",
     "parse_unified_diff_hunks",
+    "projection_set_id",
     "repo_id_for_root",
     "resolve_anchors",
     "search_projection_documents",

--- a/src/agent_memory_orchestrator/domain/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/__init__.py
@@ -62,6 +62,10 @@ from .selection import CardSelectionResult
 from .selection import SuppressedCard
 from .selection import card_selection_score
 from .selection import select_harness_cards
+from .snapshots import GRAPH_SCHEMA_VERSION
+from .snapshots import GraphSnapshotIdentity
+from .snapshots import graph_snapshot_id
+from .snapshots import graph_snapshot_identity
 from .store import EdgeKey
 from .store import GraphDeltaApplyResult
 from .store import HarnessGraphStore
@@ -93,6 +97,8 @@ __all__ = [
     "CardSelectionResult",
     "DocSemanticArtifact",
     "GraphUpdateDelta",
+    "GRAPH_SCHEMA_VERSION",
+    "GraphSnapshotIdentity",
     "HunkEntityMapping",
     "HunkRange",
     "HistoricalRelationCandidate",
@@ -118,6 +124,8 @@ __all__ = [
     "hunk_id",
     "hash_embed_text",
     "card_selection_score",
+    "graph_snapshot_id",
+    "graph_snapshot_identity",
     "map_hunk_to_entities",
     "normalize_file_path",
     "parse_unified_diff_hunks",

--- a/src/agent_memory_orchestrator/domain/semantic_harness/projection/__init__.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/projection/__init__.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 
 from .builder import DEFAULT_PROJECTED_KINDS
 from .builder import build_projection_documents
+from .builder import build_projection_set
+from .identity import DEFAULT_PROJECTION_VERSION
+from .identity import projection_set_id
 from .models import HarnessProjectionDocument
+from .models import HarnessProjectionSet
 
 __all__ = [
+    "DEFAULT_PROJECTION_VERSION",
     "DEFAULT_PROJECTED_KINDS",
     "HarnessProjectionDocument",
+    "HarnessProjectionSet",
     "build_projection_documents",
+    "build_projection_set",
+    "projection_set_id",
 ]

--- a/src/agent_memory_orchestrator/domain/semantic_harness/projection/builder.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/projection/builder.py
@@ -7,7 +7,11 @@ from ..identity import projection_doc_id
 from ..models import HarnessEdge
 from ..models import HarnessNode
 from ..models import StructuralHarnessGraph
+from ..snapshots import graph_snapshot_identity
+from .identity import DEFAULT_PROJECTION_VERSION
+from .identity import projection_set_id
 from .models import HarnessProjectionDocument
+from .models import HarnessProjectionSet
 
 
 DEFAULT_PROJECTED_KINDS = frozenset({"File", "Symbol", "DocSection", "DocString"})
@@ -34,6 +38,24 @@ def build_projection_documents(
         if (doc := _document_for_node(graph, node, node_by_id)) is not None
     ]
     return tuple(docs)
+
+
+def build_projection_set(
+    graph: StructuralHarnessGraph,
+    *,
+    include_kinds: Iterable[str] = DEFAULT_PROJECTED_KINDS,
+    projection_version: str = DEFAULT_PROJECTION_VERSION,
+) -> HarnessProjectionSet:
+    snapshot = graph_snapshot_identity(graph)
+    documents = build_projection_documents(graph, include_kinds=include_kinds)
+    return HarnessProjectionSet(
+        repo_id=graph.repo_id,
+        projection_id=projection_set_id(snapshot.graph_snapshot_id, projection_version=projection_version),
+        projection_version=projection_version,
+        graph_snapshot_id=snapshot.graph_snapshot_id,
+        graph_schema_version=snapshot.graph_schema_version,
+        documents=documents,
+    )
 
 
 def _document_for_node(
@@ -191,4 +213,4 @@ def _doc_summaries(
     return tuple(dict.fromkeys(summaries))[:limit]
 
 
-__all__ = ["DEFAULT_PROJECTED_KINDS", "build_projection_documents"]
+__all__ = ["DEFAULT_PROJECTED_KINDS", "build_projection_documents", "build_projection_set"]

--- a/src/agent_memory_orchestrator/domain/semantic_harness/projection/identity.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/projection/identity.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import hashlib
+
+DEFAULT_PROJECTION_VERSION = "semantic_harness_projection_v1"
+
+
+def projection_set_id(
+    graph_snapshot_id: str,
+    *,
+    projection_version: str = DEFAULT_PROJECTION_VERSION,
+) -> str:
+    stable = "\n".join((projection_version, str(graph_snapshot_id or "")))
+    return f"hproj:{_short_hash(stable, size=24)}"
+
+
+def _short_hash(value: str, *, size: int) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:size]
+
+
+__all__ = ["DEFAULT_PROJECTION_VERSION", "projection_set_id"]

--- a/src/agent_memory_orchestrator/domain/semantic_harness/projection/models.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/projection/models.py
@@ -35,4 +35,37 @@ class HarnessProjectionDocument:
         }
 
 
-__all__ = ["HarnessProjectionDocument"]
+@dataclass(slots=True, frozen=True)
+class HarnessProjectionSet:
+    repo_id: str
+    projection_id: str
+    projection_version: str
+    graph_snapshot_id: str
+    graph_schema_version: str
+    documents: tuple[HarnessProjectionDocument, ...]
+
+    @property
+    def document_count(self) -> int:
+        return len(self.documents)
+
+    @property
+    def document_ids_hash(self) -> str:
+        stable = "\n".join(sorted(document.doc_id for document in self.documents))
+        return hashlib.sha256(stable.encode("utf-8")).hexdigest()
+
+    def as_dict(self, *, include_documents: bool = False) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "repo_id": self.repo_id,
+            "projection_id": self.projection_id,
+            "projection_version": self.projection_version,
+            "graph_snapshot_id": self.graph_snapshot_id,
+            "graph_schema_version": self.graph_schema_version,
+            "document_count": self.document_count,
+            "document_ids_hash": self.document_ids_hash,
+        }
+        if include_documents:
+            out["documents"] = [document.as_dict() for document in self.documents]
+        return out
+
+
+__all__ = ["HarnessProjectionDocument", "HarnessProjectionSet"]

--- a/src/agent_memory_orchestrator/domain/semantic_harness/query.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/query.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from .anchor_resolution import resolve_anchors
 from .identity import harness_card_id
 from .models import HarnessCard
@@ -31,6 +33,7 @@ def answer_structural_query(
     request: HarnessQueryRequest,
     *,
     historical_relation_policy: HistoricalRelationPolicy = HistoricalRelationPolicy(),
+    projection_document_provider: Callable[[], tuple[HarnessProjectionDocument, ...]] | None = None,
 ) -> HarnessQueryResponse:
     intent_requested = str(request.intent or "").strip() or "file_context"
     intent_used = intent_requested if intent_requested in SUPPORTED_INTENTS else "file_context"
@@ -124,7 +127,7 @@ def answer_structural_query(
 
     lexical_used = False
     if len(cards) < max_cards:
-        projection_documents = build_projection_documents(graph)
+        projection_documents = _projection_documents_for_query(graph, projection_document_provider)
         lexical_cards = _lexical_candidate_cards(
             graph=graph,
             request=request,
@@ -143,7 +146,7 @@ def answer_structural_query(
     vector_used = False
     if len(cards) < max_cards and _should_use_vector_candidates(anchors.resolved, anchors.unresolved, lexical_used):
         if projection_documents is None:
-            projection_documents = build_projection_documents(graph)
+            projection_documents = _projection_documents_for_query(graph, projection_document_provider)
         vector_cards = _vector_candidate_cards(
             graph=graph,
             request=request,
@@ -181,6 +184,15 @@ def answer_structural_query(
         trace=trace,
         warnings=tuple(warnings),
     )
+
+
+def _projection_documents_for_query(
+    graph: StructuralHarnessGraph,
+    provider: Callable[[], tuple[HarnessProjectionDocument, ...]] | None,
+) -> tuple[HarnessProjectionDocument, ...]:
+    if provider is not None:
+        return provider()
+    return build_projection_documents(graph)
 
 
 def _select_cards(candidates: list[HarnessCard], *, request: HarnessQueryRequest, max_cards: int) -> tuple[HarnessCard, ...]:

--- a/src/agent_memory_orchestrator/domain/semantic_harness/snapshots.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/snapshots.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from .models import StructuralHarnessGraph
+
+GRAPH_SCHEMA_VERSION = "semantic_harness_graph_v1"
+
+
+@dataclass(slots=True, frozen=True)
+class GraphSnapshotIdentity:
+    repo_id: str
+    graph_schema_version: str
+    graph_snapshot_id: str
+    node_count: int
+    edge_count: int
+
+    def as_dict(self) -> dict[str, str | int]:
+        return {
+            "repo_id": self.repo_id,
+            "graph_schema_version": self.graph_schema_version,
+            "graph_snapshot_id": self.graph_snapshot_id,
+            "node_count": self.node_count,
+            "edge_count": self.edge_count,
+        }
+
+
+def graph_snapshot_identity(
+    graph: StructuralHarnessGraph,
+    *,
+    graph_schema_version: str = GRAPH_SCHEMA_VERSION,
+) -> GraphSnapshotIdentity:
+    """Return structural graph identity for caches, projections, and eval replay.
+
+    The snapshot intentionally hashes node IDs and edge keys only. Mutable
+    operational metadata, summaries, weights, and counters must not invalidate
+    structural snapshot identity.
+    """
+
+    return GraphSnapshotIdentity(
+        repo_id=graph.repo_id,
+        graph_schema_version=graph_schema_version,
+        graph_snapshot_id=graph_snapshot_id(graph, graph_schema_version=graph_schema_version),
+        node_count=len(graph.nodes),
+        edge_count=len(graph.edges),
+    )
+
+
+def graph_snapshot_id(
+    graph: StructuralHarnessGraph,
+    *,
+    graph_schema_version: str = GRAPH_SCHEMA_VERSION,
+) -> str:
+    node_ids = sorted(node.id for node in graph.nodes)
+    edge_keys = sorted(_edge_key(edge.source_id, edge.kind, edge.target_id) for edge in graph.edges)
+    stable = "\n".join((graph_schema_version, graph.repo_id, "nodes", *node_ids, "edges", *edge_keys))
+    return f"gsnap:{_safe_repo(graph.repo_id)}:{_short_hash(stable, size=24)}"
+
+
+def _edge_key(source_id: str, kind: str, target_id: str) -> str:
+    return "|".join((source_id, kind, target_id))
+
+
+def _safe_repo(repo_id: str) -> str:
+    return str(repo_id or "").strip() or "repo:unknown"
+
+
+def _short_hash(value: str, *, size: int) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:size]
+
+
+__all__ = ["GRAPH_SCHEMA_VERSION", "GraphSnapshotIdentity", "graph_snapshot_id", "graph_snapshot_identity"]

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from .graph_store import SQLiteHarnessGraphStore
+from .projection_store import SQLiteProjectionCache
 
-__all__ = ["SQLiteHarnessGraphStore"]
+__all__ = ["SQLiteHarnessGraphStore", "SQLiteProjectionCache"]

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .graph_store import SQLiteHarnessGraphStore
+
+__all__ = ["SQLiteHarnessGraphStore"]

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/graph_store.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/graph_store.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from agent_memory_orchestrator.domain.semantic_harness.models import HarnessEdge
+from agent_memory_orchestrator.domain.semantic_harness.models import HarnessNode
+from agent_memory_orchestrator.domain.semantic_harness.models import StructuralHarnessGraph
+from agent_memory_orchestrator.domain.semantic_harness.store.interfaces import EdgeKey
+
+from .schema import ensure_semantic_harness_schema
+
+
+class SQLiteHarnessGraphStore:
+    """SQLite-backed implementation of the semantic harness graph store protocol."""
+
+    def __init__(self, db_path: str | Path, repo_id: str) -> None:
+        self._db_path = Path(db_path)
+        self._repo_id = repo_id
+        if str(self._db_path) != ":memory:":
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn.row_factory = sqlite3.Row
+        ensure_semantic_harness_schema(self._conn)
+
+    @classmethod
+    def from_graph(cls, db_path: str | Path, graph: StructuralHarnessGraph) -> SQLiteHarnessGraphStore:
+        store = cls(db_path, graph.repo_id)
+        with store._conn:
+            for node in graph.nodes:
+                store._write_node(node)
+            for edge in graph.edges:
+                store._write_edge(edge)
+        return store
+
+    @property
+    def repo_id(self) -> str:
+        return self._repo_id
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> SQLiteHarnessGraphStore:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def get_node(self, node_id: str) -> HarnessNode | None:
+        row = self._conn.execute(
+            """
+            SELECT node_id, kind, label, repo_id, status, summary, metadata_json
+            FROM semantic_harness_nodes
+            WHERE repo_id = ? AND node_id = ?
+            """,
+            (self.repo_id, node_id),
+        ).fetchone()
+        return _node_from_row(row) if row is not None else None
+
+    def get_edge(self, source_id: str, target_id: str, kind: str) -> HarnessEdge | None:
+        row = self._conn.execute(
+            """
+            SELECT source_id, target_id, kind, weight, confidence, metadata_json
+            FROM semantic_harness_edges
+            WHERE repo_id = ? AND source_id = ? AND target_id = ? AND kind = ?
+            """,
+            (self.repo_id, source_id, target_id, kind),
+        ).fetchone()
+        return _edge_from_row(row) if row is not None else None
+
+    def node_exists(self, node_id: str) -> bool:
+        return (
+            self._conn.execute(
+                "SELECT 1 FROM semantic_harness_nodes WHERE repo_id = ? AND node_id = ? LIMIT 1",
+                (self.repo_id, node_id),
+            ).fetchone()
+            is not None
+        )
+
+    def edge_exists(self, source_id: str, target_id: str, kind: str) -> bool:
+        return (
+            self._conn.execute(
+                """
+                SELECT 1
+                FROM semantic_harness_edges
+                WHERE repo_id = ? AND source_id = ? AND target_id = ? AND kind = ?
+                LIMIT 1
+                """,
+                (self.repo_id, source_id, target_id, kind),
+            ).fetchone()
+            is not None
+        )
+
+    def upsert_node(self, node: HarnessNode) -> bool:
+        if self.node_exists(node.id):
+            return False
+        self.replace_node(node)
+        return True
+
+    def replace_node(self, node: HarnessNode) -> None:
+        self._write_node(node)
+        self._conn.commit()
+
+    def _write_node(self, node: HarnessNode) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO semantic_harness_nodes (
+                repo_id, node_id, kind, label, status, summary, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                self.repo_id,
+                node.id,
+                node.kind,
+                node.label,
+                node.status,
+                node.summary,
+                _json_dumps(node.metadata),
+            ),
+        )
+
+    def upsert_edge(self, edge: HarnessEdge) -> bool:
+        if self.edge_exists(edge.source_id, edge.target_id, edge.kind):
+            return False
+        self.replace_edge(edge)
+        return True
+
+    def replace_edge(self, edge: HarnessEdge) -> None:
+        self._write_edge(edge)
+        self._conn.commit()
+
+    def _write_edge(self, edge: HarnessEdge) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO semantic_harness_edges (
+                repo_id, source_id, target_id, kind, weight, confidence, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                self.repo_id,
+                edge.source_id,
+                edge.target_id,
+                edge.kind,
+                edge.weight,
+                edge.confidence,
+                _json_dumps(edge.metadata),
+            ),
+        )
+
+    def outgoing(self, node_id: str, *, kind: str = "") -> tuple[HarnessEdge, ...]:
+        if kind:
+            rows = self._conn.execute(
+                """
+                SELECT source_id, target_id, kind, weight, confidence, metadata_json
+                FROM semantic_harness_edges
+                WHERE repo_id = ? AND source_id = ? AND kind = ?
+                ORDER BY kind, target_id
+                """,
+                (self.repo_id, node_id, kind),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT source_id, target_id, kind, weight, confidence, metadata_json
+                FROM semantic_harness_edges
+                WHERE repo_id = ? AND source_id = ?
+                ORDER BY kind, target_id
+                """,
+                (self.repo_id, node_id),
+            ).fetchall()
+        return tuple(_edge_from_row(row) for row in rows)
+
+    def edge_keys(self) -> tuple[EdgeKey, ...]:
+        rows = self._conn.execute(
+            """
+            SELECT source_id, target_id, kind
+            FROM semantic_harness_edges
+            WHERE repo_id = ?
+            ORDER BY source_id, target_id, kind
+            """,
+            (self.repo_id,),
+        ).fetchall()
+        return tuple((str(row["source_id"]), str(row["target_id"]), str(row["kind"])) for row in rows)
+
+    def node_ids(self) -> tuple[str, ...]:
+        rows = self._conn.execute(
+            """
+            SELECT node_id
+            FROM semantic_harness_nodes
+            WHERE repo_id = ?
+            ORDER BY node_id
+            """,
+            (self.repo_id,),
+        ).fetchall()
+        return tuple(str(row["node_id"]) for row in rows)
+
+    def to_graph(self) -> StructuralHarnessGraph:
+        nodes = tuple(_node_from_row(row) for row in self._node_rows())
+        edges = tuple(_edge_from_row(row) for row in self._edge_rows())
+        return StructuralHarnessGraph(repo_id=self.repo_id, nodes=nodes, edges=edges)
+
+    def _node_rows(self) -> Iterator[sqlite3.Row]:
+        yield from self._conn.execute(
+            """
+            SELECT node_id, kind, label, repo_id, status, summary, metadata_json
+            FROM semantic_harness_nodes
+            WHERE repo_id = ?
+            ORDER BY node_id
+            """,
+            (self.repo_id,),
+        )
+
+    def _edge_rows(self) -> Iterator[sqlite3.Row]:
+        yield from self._conn.execute(
+            """
+            SELECT source_id, target_id, kind, weight, confidence, metadata_json
+            FROM semantic_harness_edges
+            WHERE repo_id = ?
+            ORDER BY source_id, target_id, kind
+            """,
+            (self.repo_id,),
+        )
+
+
+def _node_from_row(row: sqlite3.Row) -> HarnessNode:
+    return HarnessNode(
+        id=str(row["node_id"]),
+        kind=str(row["kind"]),
+        label=str(row["label"]),
+        repo_id=str(row["repo_id"]),
+        status=str(row["status"]),
+        summary=str(row["summary"]),
+        metadata=_json_loads(str(row["metadata_json"])),
+    )
+
+
+def _edge_from_row(row: sqlite3.Row) -> HarnessEdge:
+    return HarnessEdge(
+        source_id=str(row["source_id"]),
+        target_id=str(row["target_id"]),
+        kind=str(row["kind"]),
+        weight=float(row["weight"]),
+        confidence=float(row["confidence"]),
+        metadata=_json_loads(str(row["metadata_json"])),
+    )
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_loads(value: str) -> dict[str, Any]:
+    loaded = json.loads(value) if value else {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+__all__ = ["SQLiteHarnessGraphStore"]

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/projection_store.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/projection_store.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from agent_memory_orchestrator.domain.semantic_harness.projection import DEFAULT_PROJECTION_VERSION
+from agent_memory_orchestrator.domain.semantic_harness.projection import HarnessProjectionDocument
+from agent_memory_orchestrator.domain.semantic_harness.projection import HarnessProjectionSet
+from agent_memory_orchestrator.domain.semantic_harness.projection import build_projection_set
+from agent_memory_orchestrator.domain.semantic_harness.projection import projection_set_id
+from agent_memory_orchestrator.domain.semantic_harness.snapshots import graph_snapshot_identity
+from agent_memory_orchestrator.domain.semantic_harness.models import StructuralHarnessGraph
+
+from .schema import ensure_semantic_harness_schema
+
+
+class SQLiteProjectionCache:
+    """Persistent projection cache keyed by graph snapshot and projection version."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path)
+        if str(self._db_path) != ":memory:":
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn.row_factory = sqlite3.Row
+        ensure_semantic_harness_schema(self._conn)
+        self._hits = 0
+        self._misses = 0
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> SQLiteProjectionCache:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def get_or_build(
+        self,
+        graph: StructuralHarnessGraph,
+        *,
+        projection_version: str = DEFAULT_PROJECTION_VERSION,
+    ) -> HarnessProjectionSet:
+        snapshot = graph_snapshot_identity(graph)
+        projection_id = projection_set_id(snapshot.graph_snapshot_id, projection_version=projection_version)
+        if cached := self.get(projection_id):
+            self._hits += 1
+            return cached
+        projection = build_projection_set(graph, projection_version=projection_version)
+        self.save(projection)
+        self._misses += 1
+        return projection
+
+    def get(self, projection_id: str) -> HarnessProjectionSet | None:
+        row = self._conn.execute(
+            """
+            SELECT projection_id, repo_id, projection_version, graph_snapshot_id, graph_schema_version
+            FROM semantic_harness_projection_sets
+            WHERE projection_id = ?
+            """,
+            (projection_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        documents = self._documents_for_projection(projection_id)
+        return HarnessProjectionSet(
+            repo_id=str(row["repo_id"]),
+            projection_id=str(row["projection_id"]),
+            projection_version=str(row["projection_version"]),
+            graph_snapshot_id=str(row["graph_snapshot_id"]),
+            graph_schema_version=str(row["graph_schema_version"]),
+            documents=documents,
+        )
+
+    def get_for_graph(
+        self,
+        graph_snapshot_id: str,
+        *,
+        projection_version: str = DEFAULT_PROJECTION_VERSION,
+    ) -> HarnessProjectionSet | None:
+        return self.get(projection_set_id(graph_snapshot_id, projection_version=projection_version))
+
+    def save(self, projection: HarnessProjectionSet) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO semantic_harness_projection_sets (
+                    projection_id,
+                    repo_id,
+                    projection_version,
+                    graph_snapshot_id,
+                    graph_schema_version,
+                    document_ids_hash,
+                    document_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    projection.projection_id,
+                    projection.repo_id,
+                    projection.projection_version,
+                    projection.graph_snapshot_id,
+                    projection.graph_schema_version,
+                    projection.document_ids_hash,
+                    projection.document_count,
+                ),
+            )
+            self._conn.execute(
+                "DELETE FROM semantic_harness_projection_documents WHERE projection_id = ?",
+                (projection.projection_id,),
+            )
+            self._conn.executemany(
+                """
+                INSERT INTO semantic_harness_projection_documents (
+                    projection_id,
+                    doc_id,
+                    repo_id,
+                    source_node_id,
+                    source_kind,
+                    doc_type,
+                    title,
+                    text,
+                    metadata_json,
+                    content_hash
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                tuple(_document_row(projection.projection_id, document) for document in projection.documents),
+            )
+
+    def stats(self) -> dict[str, int]:
+        return {"hits": self._hits, "misses": self._misses}
+
+    def _documents_for_projection(self, projection_id: str) -> tuple[HarnessProjectionDocument, ...]:
+        rows = self._conn.execute(
+            """
+            SELECT doc_id, repo_id, source_node_id, source_kind, doc_type, title, text, metadata_json
+            FROM semantic_harness_projection_documents
+            WHERE projection_id = ?
+            ORDER BY doc_id
+            """,
+            (projection_id,),
+        ).fetchall()
+        return tuple(_document_from_row(row) for row in rows)
+
+
+def _document_row(projection_id: str, document: HarnessProjectionDocument) -> tuple[str, ...]:
+    return (
+        projection_id,
+        document.doc_id,
+        document.repo_id,
+        document.source_node_id,
+        document.source_kind,
+        document.doc_type,
+        document.title,
+        document.text,
+        _json_dumps(document.metadata),
+        document.content_hash,
+    )
+
+
+def _document_from_row(row: sqlite3.Row) -> HarnessProjectionDocument:
+    return HarnessProjectionDocument(
+        doc_id=str(row["doc_id"]),
+        repo_id=str(row["repo_id"]),
+        source_node_id=str(row["source_node_id"]),
+        source_kind=str(row["source_kind"]),
+        doc_type=str(row["doc_type"]),
+        title=str(row["title"]),
+        text=str(row["text"]),
+        metadata=_json_loads(str(row["metadata_json"])),
+    )
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_loads(value: str) -> dict[str, Any]:
+    loaded = json.loads(value) if value else {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+__all__ = ["SQLiteProjectionCache"]

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/schema.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/schema.py
@@ -41,6 +41,42 @@ def ensure_semantic_harness_schema(conn: sqlite3.Connection) -> None:
 
         CREATE INDEX IF NOT EXISTS idx_semantic_harness_edges_repo_target_kind
             ON semantic_harness_edges (repo_id, target_id, kind);
+
+        CREATE TABLE IF NOT EXISTS semantic_harness_projection_sets (
+            projection_id TEXT PRIMARY KEY,
+            repo_id TEXT NOT NULL,
+            projection_version TEXT NOT NULL,
+            graph_snapshot_id TEXT NOT NULL,
+            graph_schema_version TEXT NOT NULL,
+            document_ids_hash TEXT NOT NULL,
+            document_count INTEGER NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_semantic_harness_projection_sets_graph
+            ON semantic_harness_projection_sets (graph_snapshot_id, projection_version);
+
+        CREATE INDEX IF NOT EXISTS idx_semantic_harness_projection_sets_repo
+            ON semantic_harness_projection_sets (repo_id, projection_version);
+
+        CREATE TABLE IF NOT EXISTS semantic_harness_projection_documents (
+            projection_id TEXT NOT NULL,
+            doc_id TEXT NOT NULL,
+            repo_id TEXT NOT NULL,
+            source_node_id TEXT NOT NULL,
+            source_kind TEXT NOT NULL,
+            doc_type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            text TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            PRIMARY KEY (projection_id, doc_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_semantic_harness_projection_docs_repo_type
+            ON semantic_harness_projection_documents (repo_id, doc_type);
+
+        CREATE INDEX IF NOT EXISTS idx_semantic_harness_projection_docs_source
+            ON semantic_harness_projection_documents (projection_id, source_node_id);
         """
     )
     conn.commit()

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/schema.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/schema.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlite3
+
+
+SCHEMA_VERSION = 1
+
+
+def ensure_semantic_harness_schema(conn: sqlite3.Connection) -> None:
+    """Create the SQLite tables used by semantic harness infrastructure adapters."""
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS semantic_harness_nodes (
+            repo_id TEXT NOT NULL,
+            node_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            label TEXT NOT NULL,
+            status TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            metadata_json TEXT NOT NULL,
+            PRIMARY KEY (repo_id, node_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_semantic_harness_nodes_repo_kind
+            ON semantic_harness_nodes (repo_id, kind);
+
+        CREATE TABLE IF NOT EXISTS semantic_harness_edges (
+            repo_id TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            target_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            weight REAL NOT NULL,
+            confidence REAL NOT NULL,
+            metadata_json TEXT NOT NULL,
+            PRIMARY KEY (repo_id, source_id, target_id, kind)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_semantic_harness_edges_repo_source_kind
+            ON semantic_harness_edges (repo_id, source_id, kind);
+
+        CREATE INDEX IF NOT EXISTS idx_semantic_harness_edges_repo_target_kind
+            ON semantic_harness_edges (repo_id, target_id, kind);
+        """
+    )
+    conn.commit()
+
+
+__all__ = ["SCHEMA_VERSION", "ensure_semantic_harness_schema"]

--- a/tests/application/semantic_harness/test_projection_cache.py
+++ b/tests/application/semantic_harness/test_projection_cache.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.application.services.semantic_harness import InMemoryProjectionCache
+from agent_memory_orchestrator.application.services.semantic_harness import StructuralHarnessService
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.domain.semantic_harness import SourceFile
+
+
+def test_projection_cache_reuses_projection_for_same_structural_graph() -> None:
+    cache = InMemoryProjectionCache()
+    service = StructuralHarnessService(projection_cache=cache)
+    graph = service.bootstrap(
+        repo_id="repo:test",
+        files=(SourceFile(path="src/main.py", text="def run():\n    return True\n"),),
+    )
+
+    first = service.projection_set(graph)
+    second = service.projection_set(graph)
+
+    assert first is second
+    assert cache.stats().size == 1
+    assert cache.stats().misses == 1
+    assert cache.stats().hits == 1
+
+
+def test_projection_cache_invalidates_when_structural_graph_changes() -> None:
+    cache = InMemoryProjectionCache()
+    service = StructuralHarnessService(projection_cache=cache)
+    first_graph = service.bootstrap(
+        repo_id="repo:test",
+        files=(SourceFile(path="src/main.py", text="def run():\n    return True\n"),),
+    )
+    second_graph = service.bootstrap(
+        repo_id="repo:test",
+        files=(
+            SourceFile(path="src/main.py", text="def run():\n    return True\n"),
+            SourceFile(path="src/extra.py", text="def extra():\n    return True\n"),
+        ),
+    )
+
+    first = service.projection_set(first_graph)
+    second = service.projection_set(second_graph)
+
+    assert first.projection_id != second.projection_id
+    assert first.graph_snapshot_id != second.graph_snapshot_id
+    assert cache.stats().size == 2
+    assert cache.stats().misses == 2
+
+
+def test_service_query_uses_projection_cache_lazily() -> None:
+    cache = InMemoryProjectionCache()
+    service = StructuralHarnessService(projection_cache=cache)
+    graph = service.bootstrap(
+        repo_id="repo:test",
+        files=(SourceFile(path="src/auth.py", text='def refresh_token():\n    """Refresh token."""\n    return True\n'),),
+    )
+
+    exact = service.query(
+        graph,
+        HarnessQueryRequest(
+            intent="file_context",
+            user_goal="inspect auth",
+            files=("src/auth.py",),
+            max_cards=1,
+        ),
+    )
+    first_vague = service.query(
+        graph,
+        HarnessQueryRequest(intent="edit_plan", user_goal="refresh token", max_cards=1),
+    )
+    second_vague = service.query(
+        graph,
+        HarnessQueryRequest(intent="edit_plan", user_goal="refresh token", max_cards=1),
+    )
+
+    assert exact.cards[0].type == "next_file"
+    assert first_vague.cards[0].title == "Inspect refresh_token"
+    assert second_vague.cards[0].title == "Inspect refresh_token"
+    assert cache.stats().size == 1
+    assert cache.stats().misses == 1
+    assert cache.stats().hits == 1

--- a/tests/domain/semantic_harness/test_projection.py
+++ b/tests/domain/semantic_harness/test_projection.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from agent_memory_orchestrator.domain.semantic_harness import SourceFile
+from agent_memory_orchestrator.domain.semantic_harness import build_projection_set
 from agent_memory_orchestrator.domain.semantic_harness import build_projection_documents
 from agent_memory_orchestrator.domain.semantic_harness import build_structural_graph
+from agent_memory_orchestrator.domain.semantic_harness import graph_snapshot_id
 
 
 def test_projection_documents_include_only_high_signal_bootstrap_nodes() -> None:
@@ -122,3 +124,38 @@ def test_projection_document_ids_and_hashes_are_deterministic() -> None:
     assert [doc.doc_id for doc in first] == [doc.doc_id for doc in second]
     assert [doc.content_hash for doc in first] == [doc.content_hash for doc in second]
     assert all(len(doc.content_hash) == 64 for doc in first)
+
+
+def test_projection_set_identity_references_graph_snapshot_and_version() -> None:
+    graph = build_structural_graph(
+        "repo:test",
+        (SourceFile(path="src/main.py", text="def run():\n    return True\n"),),
+    )
+
+    projection = build_projection_set(graph)
+
+    assert projection.projection_version == "semantic_harness_projection_v1"
+    assert projection.graph_schema_version == "semantic_harness_graph_v1"
+    assert projection.graph_snapshot_id == graph_snapshot_id(graph)
+    assert projection.projection_id.startswith("hproj:")
+    assert projection.document_count == len(projection.documents)
+    assert projection.as_dict()["document_ids_hash"] == projection.document_ids_hash
+
+
+def test_projection_set_id_changes_with_projection_version_not_mutable_metadata() -> None:
+    first = build_structural_graph(
+        "repo:test",
+        (SourceFile(path="src/main.py", text="def run():\n    return True\n"),),
+    )
+    second = build_structural_graph(
+        "repo:test",
+        (SourceFile(path="src/main.py", text="def run():\n    return True\n"),),
+    )
+
+    current = build_projection_set(first)
+    same_structure = build_projection_set(second)
+    new_version = build_projection_set(second, projection_version="semantic_harness_projection_v2")
+
+    assert current.graph_snapshot_id == same_structure.graph_snapshot_id
+    assert current.projection_id == same_structure.projection_id
+    assert current.projection_id != new_version.projection_id

--- a/tests/domain/semantic_harness/test_snapshots.py
+++ b/tests/domain/semantic_harness/test_snapshots.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.domain.semantic_harness import HarnessEdge
+from agent_memory_orchestrator.domain.semantic_harness import HarnessNode
+from agent_memory_orchestrator.domain.semantic_harness import StructuralHarnessGraph
+from agent_memory_orchestrator.domain.semantic_harness import graph_snapshot_id
+from agent_memory_orchestrator.domain.semantic_harness import graph_snapshot_identity
+
+
+def test_graph_snapshot_id_ignores_mutable_node_and_edge_metadata() -> None:
+    first = _graph(
+        node_summary="old summary",
+        node_metadata={"change_stats": 1},
+        edge_weight=0.4,
+        edge_metadata={"cochange_count": 1},
+    )
+    second = _graph(
+        node_summary="new summary",
+        node_metadata={"change_stats": 99},
+        edge_weight=0.9,
+        edge_metadata={"cochange_count": 10},
+    )
+
+    assert graph_snapshot_id(first) == graph_snapshot_id(second)
+
+
+def test_graph_snapshot_id_changes_when_structural_edge_key_changes() -> None:
+    first = _graph(edge_kind="DEFINES")
+    second = _graph(edge_kind="CONTAINS")
+
+    assert graph_snapshot_id(first) != graph_snapshot_id(second)
+
+
+def test_graph_snapshot_identity_reports_counts_and_schema() -> None:
+    graph = _graph()
+    identity = graph_snapshot_identity(graph)
+
+    assert identity.repo_id == "repo:test"
+    assert identity.graph_schema_version == "semantic_harness_graph_v1"
+    assert identity.graph_snapshot_id == graph_snapshot_id(graph)
+    assert identity.node_count == 2
+    assert identity.edge_count == 1
+    assert identity.as_dict()["graph_snapshot_id"] == identity.graph_snapshot_id
+
+
+def _graph(
+    *,
+    node_summary: str = "",
+    node_metadata: dict[str, object] | None = None,
+    edge_kind: str = "DEFINES",
+    edge_weight: float = 1.0,
+    edge_metadata: dict[str, object] | None = None,
+) -> StructuralHarnessGraph:
+    file_node = HarnessNode(id="file:repo:test:src/a.py", kind="File", label="src/a.py", repo_id="repo:test")
+    symbol_node = HarnessNode(
+        id="symbol:repo:test:src/a.py:run:function",
+        kind="Symbol",
+        label="run",
+        repo_id="repo:test",
+        summary=node_summary,
+        metadata=dict(node_metadata or {}),
+    )
+    edge = HarnessEdge(
+        source_id=file_node.id,
+        target_id=symbol_node.id,
+        kind=edge_kind,
+        weight=edge_weight,
+        metadata=dict(edge_metadata or {}),
+    )
+    return StructuralHarnessGraph(repo_id="repo:test", nodes=(file_node, symbol_node), edges=(edge,))

--- a/tests/infrastructure/sqlite/semantic_harness/test_graph_store.py
+++ b/tests/infrastructure/sqlite/semantic_harness/test_graph_store.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from agent_memory_orchestrator.domain.semantic_harness import CommitHunk
+from agent_memory_orchestrator.domain.semantic_harness import CommitWorkWindow
+from agent_memory_orchestrator.domain.semantic_harness import HunkRange
+from agent_memory_orchestrator.domain.semantic_harness import SourceFile
+from agent_memory_orchestrator.domain.semantic_harness import apply_graph_update_delta
+from agent_memory_orchestrator.domain.semantic_harness import build_commit_update_delta
+from agent_memory_orchestrator.domain.semantic_harness import build_structural_graph
+from agent_memory_orchestrator.infrastructure.sqlite.semantic_harness import SQLiteHarnessGraphStore
+
+
+def test_sqlite_graph_store_round_trips_bootstrap_graph(tmp_path) -> None:
+    db_path = tmp_path / "harness.sqlite"
+    graph = build_structural_graph(
+        "repo:test",
+        (
+            SourceFile(
+                path="src/auth.py",
+                text="def login(user):\n    return user.is_active\n",
+            ),
+            SourceFile(path="README.md", text="# Auth\n\nLogin behavior.\n"),
+        ),
+    )
+
+    with SQLiteHarnessGraphStore.from_graph(db_path, graph) as store:
+        assert store.node_ids() == tuple(sorted(node.id for node in graph.nodes))
+        assert store.edge_keys() == tuple(sorted((edge.source_id, edge.target_id, edge.kind) for edge in graph.edges))
+
+    with SQLiteHarnessGraphStore(db_path, "repo:test") as reopened:
+        persisted = reopened.to_graph()
+        repo_edges = reopened.outgoing("repo:test", kind="CONTAINS")
+
+        assert persisted.repo_id == graph.repo_id
+        assert {node.id for node in persisted.nodes} == {node.id for node in graph.nodes}
+        assert {(edge.source_id, edge.target_id, edge.kind) for edge in persisted.edges} == {
+            (edge.source_id, edge.target_id, edge.kind) for edge in graph.edges
+        }
+        assert repo_edges
+        assert {edge.kind for edge in repo_edges} == {"CONTAINS"}
+
+
+def test_sqlite_graph_store_preserves_replace_semantics(tmp_path) -> None:
+    db_path = tmp_path / "harness.sqlite"
+    graph = build_structural_graph("repo:test", (SourceFile(path="src/main.py", text="value = 1\n"),))
+    node = next(item for item in graph.nodes if item.kind == "File")
+
+    with SQLiteHarnessGraphStore.from_graph(db_path, graph) as store:
+        assert store.upsert_node(node) is False
+        store.replace_node(replace(node, summary="updated summary", metadata={**node.metadata, "reviewed": True}))
+
+    with SQLiteHarnessGraphStore(db_path, "repo:test") as reopened:
+        persisted = reopened.get_node(node.id)
+
+        assert persisted is not None
+        assert persisted.summary == "updated summary"
+        assert persisted.metadata["reviewed"] is True
+
+
+def test_sqlite_graph_store_applies_commit_delta_and_reopens(tmp_path) -> None:
+    db_path = tmp_path / "harness.sqlite"
+    repo_id = "repo:test"
+    graph = build_structural_graph(
+        repo_id,
+        (SourceFile(path="src/auth.py", text="def login():\n    return True\n"),),
+    )
+    delta = build_commit_update_delta(
+        graph,
+        CommitWorkWindow(
+            repo_id=repo_id,
+            session_id="session-1",
+            commit_sha="abc123456789",
+            commit_message="fix login",
+            hunks=(
+                CommitHunk(
+                    file_path="src/auth.py",
+                    old_range=HunkRange(start=2, count=1),
+                    new_range=HunkRange(start=2, count=1),
+                ),
+            ),
+        ),
+    )
+
+    with SQLiteHarnessGraphStore.from_graph(db_path, graph) as store:
+        first = apply_graph_update_delta(store, delta)
+        second = apply_graph_update_delta(store, delta)
+
+        assert first.status == "applied"
+        assert second.status == "noop"
+
+    with SQLiteHarnessGraphStore(db_path, repo_id) as reopened:
+        persisted = reopened.to_graph()
+
+        assert delta.commit_id in reopened.node_ids()
+        assert {node.id for node in delta.created_nodes}.issubset({node.id for node in persisted.nodes})
+        assert {(edge.source_id, edge.target_id, edge.kind) for edge in delta.created_edges}.issubset(
+            {(edge.source_id, edge.target_id, edge.kind) for edge in persisted.edges}
+        )

--- a/tests/infrastructure/sqlite/semantic_harness/test_projection_store.py
+++ b/tests/infrastructure/sqlite/semantic_harness/test_projection_store.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.application.services.semantic_harness import StructuralHarnessService
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.domain.semantic_harness import SourceFile
+from agent_memory_orchestrator.domain.semantic_harness import build_projection_set
+from agent_memory_orchestrator.domain.semantic_harness import build_structural_graph
+from agent_memory_orchestrator.infrastructure.sqlite.semantic_harness import SQLiteProjectionCache
+
+
+def test_sqlite_projection_cache_round_trips_projection_set(tmp_path) -> None:
+    db_path = tmp_path / "harness.sqlite"
+    graph = build_structural_graph(
+        "repo:test",
+        (SourceFile(path="src/auth.py", text='"""Auth module."""\n\ndef login(user):\n    return user.is_active\n'),),
+    )
+    projection = build_projection_set(graph)
+
+    with SQLiteProjectionCache(db_path) as cache:
+        cache.save(projection)
+
+    with SQLiteProjectionCache(db_path) as reopened:
+        persisted = reopened.get(projection.projection_id)
+
+        assert persisted is not None
+        assert persisted.projection_id == projection.projection_id
+        assert persisted.graph_snapshot_id == projection.graph_snapshot_id
+        assert persisted.document_ids_hash == projection.document_ids_hash
+        assert {document.doc_id for document in persisted.documents} == {document.doc_id for document in projection.documents}
+        assert {document.content_hash for document in persisted.documents} == {document.content_hash for document in projection.documents}
+
+
+def test_sqlite_projection_cache_get_or_build_reuses_persisted_set(tmp_path) -> None:
+    db_path = tmp_path / "harness.sqlite"
+    graph = build_structural_graph(
+        "repo:test",
+        (SourceFile(path="src/auth.py", text="def login(user):\n    return user.is_active\n"),),
+    )
+
+    with SQLiteProjectionCache(db_path) as first_cache:
+        first = first_cache.get_or_build(graph)
+        assert first_cache.stats() == {"hits": 0, "misses": 1}
+
+    with SQLiteProjectionCache(db_path) as second_cache:
+        second = second_cache.get_or_build(graph)
+
+        assert second.projection_id == first.projection_id
+        assert second_cache.stats() == {"hits": 1, "misses": 0}
+
+
+def test_sqlite_projection_cache_integrates_with_structural_service(tmp_path) -> None:
+    db_path = tmp_path / "harness.sqlite"
+    graph = build_structural_graph(
+        "repo:test",
+        (SourceFile(path="src/auth.py", text="def login(user):\n    return user.is_active\n"),),
+    )
+
+    with SQLiteProjectionCache(db_path) as cache:
+        service = StructuralHarnessService(projection_cache=cache)
+        response = service.query(
+            graph,
+            HarnessQueryRequest(
+                intent="edit_plan",
+                user_goal="fix login behavior",
+                symbols=("login",),
+            ),
+        )
+
+        assert response.cards
+        assert cache.get(service.projection_set(graph).projection_id) is not None


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projection caching: in-memory and SQLite-backed storage for semantic projections with automatic reuse and invalidation.
  * Graph snapshot identity system providing deterministic versioning and change detection for structural graphs.
  * Automatic projection rebuild triggered by structural graph modifications.

* **Documentation**
  * Added cache identity contract and service-level caching specifications.
  * Documented snapshot identity computation and projection version management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->