### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/src/agent_memory_orchestrator/application/services/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/__init__.py
@@ -20,6 +20,11 @@ from .retrieval_eval import RetrievalEvalCase
 from .retrieval_eval import RetrievalEvalCaseResult
 from .retrieval_eval import RetrievalEvalReport
 from .retrieval_eval import RetrievalHarnessEvalService
+from .runtime import HarnessGraphRepository
+from .runtime import HarnessRuntimeBootstrapResult
+from .runtime import HarnessRuntimeDeltaApplyResult
+from .runtime import InMemoryHarnessGraphRepository
+from .runtime import SemanticHarnessRuntimeService
 from .structural import StructuralHarnessService
 from .structural import StructuralRepoBootstrapResult
 
@@ -30,6 +35,10 @@ __all__ = [
     "CommitUpdateEvalReport",
     "CommitUpdateEvalService",
     "CommitUpdateService",
+    "HarnessGraphRepository",
+    "HarnessRuntimeBootstrapResult",
+    "HarnessRuntimeDeltaApplyResult",
+    "InMemoryHarnessGraphRepository",
     "InMemoryProjectionCache",
     "ProjectionCache",
     "ProjectionCacheStats",
@@ -45,5 +54,6 @@ __all__ = [
     "StructuralHarnessEvalService",
     "StructuralHarnessService",
     "StructuralRepoBootstrapResult",
+    "SemanticHarnessRuntimeService",
     "read_repo_source_files",
 ]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/__init__.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from .memory import InMemoryHarnessGraphRepository
+from .models import HarnessRuntimeBootstrapResult
+from .models import HarnessRuntimeDeltaApplyResult
+from .ports import HarnessGraphRepository
+from .service import SemanticHarnessRuntimeService
+
+__all__ = [
+    "HarnessGraphRepository",
+    "HarnessRuntimeBootstrapResult",
+    "HarnessRuntimeDeltaApplyResult",
+    "InMemoryHarnessGraphRepository",
+    "SemanticHarnessRuntimeService",
+]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/memory.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/memory.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+
+from agent_memory_orchestrator.domain.semantic_harness import HarnessGraphStore
+from agent_memory_orchestrator.domain.semantic_harness import InMemoryHarnessGraphStore
+from agent_memory_orchestrator.domain.semantic_harness import StructuralHarnessGraph
+
+
+@dataclass(slots=True)
+class InMemoryHarnessGraphRepository:
+    """Process-local graph repository for runtime service tests and smoke use."""
+
+    _stores: dict[str, InMemoryHarnessGraphStore] = field(default_factory=dict)
+
+    def load(self, repo_id: str) -> HarnessGraphStore | None:
+        return self._stores.get(repo_id)
+
+    def replace_from_graph(self, graph: StructuralHarnessGraph) -> HarnessGraphStore:
+        store = InMemoryHarnessGraphStore.from_graph(graph)
+        self._stores[graph.repo_id] = store
+        return store
+
+
+__all__ = ["InMemoryHarnessGraphRepository"]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/models.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/models.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_memory_orchestrator.domain.semantic_harness import GraphDeltaApplyResult
+from agent_memory_orchestrator.domain.semantic_harness import HarnessProjectionSet
+from agent_memory_orchestrator.domain.semantic_harness import GraphSnapshotIdentity
+
+
+@dataclass(slots=True, frozen=True)
+class HarnessRuntimeBootstrapResult:
+    repo_root: Path
+    repo_id: str
+    file_count: int
+    skipped_count: int
+    skipped: tuple[dict[str, str], ...]
+    graph_snapshot: GraphSnapshotIdentity
+    projection_id: str
+    projection_document_count: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "repo_root": str(self.repo_root),
+            "repo_id": self.repo_id,
+            "file_count": self.file_count,
+            "skipped_count": self.skipped_count,
+            "skipped": list(self.skipped),
+            "graph_snapshot": self.graph_snapshot.as_dict(),
+            "projection_id": self.projection_id,
+            "projection_document_count": self.projection_document_count,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class HarnessRuntimeDeltaApplyResult:
+    repo_id: str
+    graph_snapshot: GraphSnapshotIdentity
+    projection: HarnessProjectionSet
+    apply_result: GraphDeltaApplyResult
+
+    @property
+    def applied(self) -> bool:
+        return self.apply_result.applied
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "repo_id": self.repo_id,
+            "graph_snapshot": self.graph_snapshot.as_dict(),
+            "projection": self.projection.as_dict(),
+            "apply_result": self.apply_result.as_dict(),
+            "applied": self.applied,
+        }
+
+
+__all__ = ["HarnessRuntimeBootstrapResult", "HarnessRuntimeDeltaApplyResult"]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/ports.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/ports.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from agent_memory_orchestrator.domain.semantic_harness import HarnessGraphStore
+from agent_memory_orchestrator.domain.semantic_harness import StructuralHarnessGraph
+
+
+class HarnessGraphRepository(Protocol):
+    """Application boundary for loading and replacing persisted harness graphs."""
+
+    def load(self, repo_id: str) -> HarnessGraphStore | None: ...
+
+    def replace_from_graph(self, graph: StructuralHarnessGraph) -> HarnessGraphStore: ...
+
+
+__all__ = ["HarnessGraphRepository"]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/service.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/service.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_memory_orchestrator.application.services.semantic_harness.projection_cache import InMemoryProjectionCache
+from agent_memory_orchestrator.application.services.semantic_harness.projection_cache import ProjectionCache
+from agent_memory_orchestrator.application.services.semantic_harness.repository import RepoBootstrapOptions
+from agent_memory_orchestrator.application.services.semantic_harness.runtime.memory import InMemoryHarnessGraphRepository
+from agent_memory_orchestrator.application.services.semantic_harness.runtime.models import HarnessRuntimeBootstrapResult
+from agent_memory_orchestrator.application.services.semantic_harness.runtime.models import HarnessRuntimeDeltaApplyResult
+from agent_memory_orchestrator.application.services.semantic_harness.runtime.ports import HarnessGraphRepository
+from agent_memory_orchestrator.application.services.semantic_harness.structural import StructuralHarnessService
+from agent_memory_orchestrator.domain.semantic_harness import GraphUpdateDelta
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryResponse
+from agent_memory_orchestrator.domain.semantic_harness import StructuralHarnessGraph
+from agent_memory_orchestrator.domain.semantic_harness import apply_graph_update_delta
+from agent_memory_orchestrator.domain.semantic_harness import graph_snapshot_identity
+
+
+class SemanticHarnessRuntimeService:
+    """Coordinates persisted graph lifecycle, projection refresh, and queries."""
+
+    def __init__(
+        self,
+        *,
+        graph_repository: HarnessGraphRepository | None = None,
+        projection_cache: ProjectionCache | None = None,
+        structural: StructuralHarnessService | None = None,
+    ) -> None:
+        self._graph_repository = graph_repository or InMemoryHarnessGraphRepository()
+        self._projection_cache = projection_cache or InMemoryProjectionCache()
+        self._structural = structural or StructuralHarnessService(projection_cache=self._projection_cache)
+
+    def bootstrap_repo(
+        self,
+        repo_root: str | Path,
+        *,
+        repo_id: str = "",
+        options: RepoBootstrapOptions | None = None,
+    ) -> HarnessRuntimeBootstrapResult:
+        bootstrap = self._structural.bootstrap_repo(repo_root, repo_id=repo_id, options=options)
+        self._graph_repository.replace_from_graph(bootstrap.graph)
+        projection = self._projection_cache.get_or_build(bootstrap.graph)
+        snapshot = graph_snapshot_identity(bootstrap.graph)
+        return HarnessRuntimeBootstrapResult(
+            repo_root=bootstrap.repo_root,
+            repo_id=bootstrap.graph.repo_id,
+            file_count=bootstrap.file_count,
+            skipped_count=bootstrap.skipped_count,
+            skipped=bootstrap.skipped,
+            graph_snapshot=snapshot,
+            projection_id=projection.projection_id,
+            projection_document_count=projection.document_count,
+        )
+
+    def load_graph(self, repo_id: str) -> StructuralHarnessGraph | None:
+        store = self._graph_repository.load(repo_id)
+        return store.to_graph() if store is not None else None
+
+    def query(self, repo_id: str, request: HarnessQueryRequest) -> HarnessQueryResponse:
+        graph = self.load_graph(repo_id)
+        if graph is None:
+            return HarnessQueryResponse(
+                status="unavailable",
+                intent_requested=request.intent,
+                intent_used=request.intent,
+                intent_correction=None,
+                cards=(),
+                next_actions=(),
+                trace={"nodes": [], "edges": [], "versions": [], "occurrences": []},
+                warnings=(f"repo_not_bootstrapped:{repo_id}",),
+            )
+        return self._structural.query(graph, request)
+
+    def apply_delta(self, delta: GraphUpdateDelta) -> HarnessRuntimeDeltaApplyResult:
+        store = self._graph_repository.load(delta.repo_id)
+        if store is None:
+            raise ValueError(f"repo_not_bootstrapped:{delta.repo_id}")
+        apply_result = apply_graph_update_delta(store, delta)
+        graph = store.to_graph()
+        projection = self._projection_cache.get_or_build(graph)
+        return HarnessRuntimeDeltaApplyResult(
+            repo_id=delta.repo_id,
+            graph_snapshot=graph_snapshot_identity(graph),
+            projection=projection,
+            apply_result=apply_result,
+        )
+
+
+__all__ = ["SemanticHarnessRuntimeService"]

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/__init__.py
@@ -2,5 +2,6 @@ from __future__ import annotations
 
 from .graph_store import SQLiteHarnessGraphStore
 from .projection_store import SQLiteProjectionCache
+from .repository import SQLiteHarnessGraphRepository
 
-__all__ = ["SQLiteHarnessGraphStore", "SQLiteProjectionCache"]
+__all__ = ["SQLiteHarnessGraphRepository", "SQLiteHarnessGraphStore", "SQLiteProjectionCache"]

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/graph_store.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/graph_store.py
@@ -29,12 +29,22 @@ class SQLiteHarnessGraphStore:
     @classmethod
     def from_graph(cls, db_path: str | Path, graph: StructuralHarnessGraph) -> SQLiteHarnessGraphStore:
         store = cls(db_path, graph.repo_id)
-        with store._conn:
-            for node in graph.nodes:
-                store._write_node(node)
-            for edge in graph.edges:
-                store._write_edge(edge)
+        store.replace_graph(graph)
         return store
+
+    def replace_graph(self, graph: StructuralHarnessGraph) -> None:
+        if graph.repo_id != self.repo_id:
+            raise ValueError(f"repo_id_mismatch:{self.repo_id}!={graph.repo_id}")
+        with self._conn:
+            self._delete_repo_graph()
+            for node in graph.nodes:
+                self._write_node(node)
+            for edge in graph.edges:
+                self._write_edge(edge)
+
+    def _delete_repo_graph(self) -> None:
+        self._conn.execute("DELETE FROM semantic_harness_edges WHERE repo_id = ?", (self.repo_id,))
+        self._conn.execute("DELETE FROM semantic_harness_nodes WHERE repo_id = ?", (self.repo_id,))
 
     @property
     def repo_id(self) -> str:

--- a/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/repository.py
+++ b/src/agent_memory_orchestrator/infrastructure/sqlite/semantic_harness/repository.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+
+from agent_memory_orchestrator.domain.semantic_harness import HarnessGraphStore
+from agent_memory_orchestrator.domain.semantic_harness import StructuralHarnessGraph
+
+from .graph_store import SQLiteHarnessGraphStore
+
+
+@dataclass(slots=True)
+class SQLiteHarnessGraphRepository:
+    """SQLite-backed graph repository for the semantic harness runtime."""
+
+    db_path: str | Path
+    _stores: dict[str, SQLiteHarnessGraphStore] = field(default_factory=dict)
+
+    def load(self, repo_id: str) -> HarnessGraphStore | None:
+        if store := self._stores.get(repo_id):
+            return store
+        store = SQLiteHarnessGraphStore(self.db_path, repo_id)
+        if not store.node_exists(repo_id):
+            store.close()
+            return None
+        self._stores[repo_id] = store
+        return store
+
+    def replace_from_graph(self, graph: StructuralHarnessGraph) -> HarnessGraphStore:
+        if existing := self._stores.pop(graph.repo_id, None):
+            existing.close()
+        store = SQLiteHarnessGraphStore.from_graph(self.db_path, graph)
+        self._stores[graph.repo_id] = store
+        return store
+
+    def close(self) -> None:
+        for store in self._stores.values():
+            store.close()
+        self._stores.clear()
+
+    def __enter__(self) -> SQLiteHarnessGraphRepository:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+
+__all__ = ["SQLiteHarnessGraphRepository"]

--- a/tests/application/semantic_harness/test_runtime_service.py
+++ b/tests/application/semantic_harness/test_runtime_service.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from agent_memory_orchestrator.application.services.semantic_harness import SemanticHarnessRuntimeService
+from agent_memory_orchestrator.domain.semantic_harness import CommitHunk
+from agent_memory_orchestrator.domain.semantic_harness import CommitWorkWindow
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.domain.semantic_harness import HunkRange
+from agent_memory_orchestrator.domain.semantic_harness import build_commit_update_delta
+
+
+def test_runtime_bootstrap_persists_graph_and_answers_query(tmp_path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "auth.py").write_text(
+        'def refresh_token():\n    """Refresh token before redirect."""\n    return True\n',
+        encoding="utf-8",
+    )
+
+    runtime = SemanticHarnessRuntimeService()
+    bootstrap = runtime.bootstrap_repo(tmp_path, repo_id="repo:test")
+    response = runtime.query(
+        "repo:test",
+        HarnessQueryRequest(
+            intent="file_context",
+            user_goal="inspect refresh token",
+            symbols=("refresh_token",),
+            max_cards=2,
+        ),
+    )
+
+    assert bootstrap.repo_id == "repo:test"
+    assert bootstrap.file_count == 1
+    assert bootstrap.graph_snapshot.node_count > 0
+    assert bootstrap.projection_document_count > 0
+    assert response.status == "partial_structural"
+    assert response.cards
+
+
+def test_runtime_query_returns_unavailable_for_missing_repo() -> None:
+    runtime = SemanticHarnessRuntimeService()
+
+    response = runtime.query(
+        "repo:missing",
+        HarnessQueryRequest(intent="edit_plan", user_goal="fix login"),
+    )
+
+    assert response.status == "unavailable"
+    assert response.cards == ()
+    assert response.warnings == ("repo_not_bootstrapped:repo:missing",)
+
+
+def test_runtime_apply_delta_updates_persisted_graph_and_projection(tmp_path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "auth.py").write_text("def login():\n    return False\n", encoding="utf-8")
+    runtime = SemanticHarnessRuntimeService()
+    bootstrap = runtime.bootstrap_repo(tmp_path, repo_id="repo:test")
+    graph = runtime.load_graph("repo:test")
+    if graph is None:
+        pytest.fail("runtime did not persist bootstrap graph")
+    delta = build_commit_update_delta(
+        graph,
+        CommitWorkWindow(
+            repo_id="repo:test",
+            session_id="session-1",
+            commit_sha="abc123456789",
+            commit_message="fix login",
+            hunks=(
+                CommitHunk(
+                    file_path="src/auth.py",
+                    old_range=HunkRange(start=2, count=1),
+                    new_range=HunkRange(start=2, count=1),
+                ),
+            ),
+        ),
+    )
+
+    applied = runtime.apply_delta(delta)
+    updated_graph = runtime.load_graph("repo:test")
+
+    assert applied.apply_result.status == "applied"
+    assert applied.graph_snapshot.graph_snapshot_id != bootstrap.graph_snapshot.graph_snapshot_id
+    assert applied.projection.graph_snapshot_id == applied.graph_snapshot.graph_snapshot_id
+    assert updated_graph is not None
+    assert delta.commit_id in {node.id for node in updated_graph.nodes}

--- a/tests/infrastructure/sqlite/semantic_harness/test_graph_store.py
+++ b/tests/infrastructure/sqlite/semantic_harness/test_graph_store.py
@@ -59,6 +59,34 @@ def test_sqlite_graph_store_preserves_replace_semantics(tmp_path) -> None:
         assert persisted.metadata["reviewed"] is True
 
 
+def test_sqlite_graph_store_from_graph_replaces_stale_repo_rows(tmp_path) -> None:
+    db_path = tmp_path / "harness.sqlite"
+    first = build_structural_graph(
+        "repo:test",
+        (
+            SourceFile(path="src/main.py", text="def main():\n    return True\n"),
+            SourceFile(path="src/extra.py", text="def extra():\n    return True\n"),
+        ),
+    )
+    second = build_structural_graph(
+        "repo:test",
+        (SourceFile(path="src/main.py", text="def main():\n    return True\n"),),
+    )
+
+    with SQLiteHarnessGraphStore.from_graph(db_path, first):
+        pass
+    with SQLiteHarnessGraphStore.from_graph(db_path, second):
+        pass
+
+    with SQLiteHarnessGraphStore(db_path, "repo:test") as reopened:
+        persisted = reopened.to_graph()
+
+        assert {node.id for node in persisted.nodes} == {node.id for node in second.nodes}
+        assert {(edge.source_id, edge.target_id, edge.kind) for edge in persisted.edges} == {
+            (edge.source_id, edge.target_id, edge.kind) for edge in second.edges
+        }
+
+
 def test_sqlite_graph_store_applies_commit_delta_and_reopens(tmp_path) -> None:
     db_path = tmp_path / "harness.sqlite"
     repo_id = "repo:test"

--- a/tests/infrastructure/sqlite/semantic_harness/test_runtime_repository.py
+++ b/tests/infrastructure/sqlite/semantic_harness/test_runtime_repository.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.application.services.semantic_harness import SemanticHarnessRuntimeService
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.infrastructure.sqlite.semantic_harness import SQLiteHarnessGraphRepository
+from agent_memory_orchestrator.infrastructure.sqlite.semantic_harness import SQLiteProjectionCache
+
+
+def test_sqlite_runtime_repository_reopens_bootstrapped_repo_without_rebuild(tmp_path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "src").mkdir()
+    (repo_root / "src" / "auth.py").write_text(
+        'def refresh_token():\n    """Refresh token before redirect."""\n    return True\n',
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "harness.sqlite"
+
+    with SQLiteHarnessGraphRepository(db_path) as graph_repo:
+        with SQLiteProjectionCache(db_path) as projection_cache:
+            runtime = SemanticHarnessRuntimeService(
+                graph_repository=graph_repo,
+                projection_cache=projection_cache,
+            )
+            bootstrap = runtime.bootstrap_repo(repo_root, repo_id="repo:test")
+
+    with SQLiteHarnessGraphRepository(db_path) as reopened_repo:
+        with SQLiteProjectionCache(db_path) as reopened_projection_cache:
+            runtime = SemanticHarnessRuntimeService(
+                graph_repository=reopened_repo,
+                projection_cache=reopened_projection_cache,
+            )
+            graph = runtime.load_graph("repo:test")
+            response = runtime.query(
+                "repo:test",
+                HarnessQueryRequest(
+                    intent="edit_plan",
+                    user_goal="refresh token redirect",
+                    max_cards=2,
+                ),
+            )
+
+            assert graph is not None
+            assert response.cards
+            assert reopened_projection_cache.stats() == {"hits": 1, "misses": 0}
+            assert runtime.load_graph("repo:missing") is None
+            assert bootstrap.projection_document_count > 0


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.
