### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ amo-mcp = "agent_memory_orchestrator.runtime.mcp.server:main"
 amo-daemon = "agent_memory_orchestrator.runtime.daemon.server:main"
 amo-peer = "agent_memory_orchestrator.peer.server:main"
 amo-hook = "agent_memory_orchestrator.runtime.hook.launcher:main"
+amo-harness = "agent_memory_orchestrator.runtime.cli.commands.semantic_harness:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/__init__.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/__init__.py
@@ -27,6 +27,9 @@ from .runtime import InMemoryHarnessGraphRepository
 from .runtime import SemanticHarnessRuntimeService
 from .structural import StructuralHarnessService
 from .structural import StructuralRepoBootstrapResult
+from .tool_context import ShadowToolReplayService
+from .tool_context import ToolContextPlanner
+from .tool_context import ToolContextPlannerOptions
 
 __all__ = [
     "CommitUpdateBuildResult",
@@ -48,6 +51,7 @@ __all__ = [
     "RetrievalEvalCaseResult",
     "RetrievalEvalReport",
     "RetrievalHarnessEvalService",
+    "ShadowToolReplayService",
     "StructuralEvalCase",
     "StructuralEvalCaseResult",
     "StructuralEvalReport",
@@ -55,5 +59,7 @@ __all__ = [
     "StructuralHarnessService",
     "StructuralRepoBootstrapResult",
     "SemanticHarnessRuntimeService",
+    "ToolContextPlanner",
+    "ToolContextPlannerOptions",
     "read_repo_source_files",
 ]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/__init__.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/__init__.py
@@ -1,0 +1,35 @@
+"""Shadow tool-result context planning for Semantic Harness delivery evals."""
+
+from .extract import classify_tool_kind
+from .extract import extract_tool_result_anchors
+from .models import CapturedToolResult
+from .models import ShadowReplayReport
+from .models import ToolLineRef
+from .models import ToolOverlayDecision
+from .models import ToolOverlayEvalRecord
+from .models import ToolOverlayJudgment
+from .models import ToolOverlayLatency
+from .models import ToolResultAnchors
+from .models import captured_tool_result_from_event
+from .planner import ToolContextPlanner
+from .planner import ToolContextPlannerOptions
+from .replay import ShadowToolReplayService
+from .replay import decision_targets
+
+__all__ = [
+    "CapturedToolResult",
+    "ShadowReplayReport",
+    "ShadowToolReplayService",
+    "ToolContextPlanner",
+    "ToolContextPlannerOptions",
+    "ToolLineRef",
+    "ToolOverlayDecision",
+    "ToolOverlayEvalRecord",
+    "ToolOverlayJudgment",
+    "ToolOverlayLatency",
+    "ToolResultAnchors",
+    "captured_tool_result_from_event",
+    "classify_tool_kind",
+    "decision_targets",
+    "extract_tool_result_anchors",
+]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from agent_memory_orchestrator.domain.semantic_harness import normalize_file_path
+
+from .models import CapturedToolResult
+from .models import ToolLineRef
+from .models import ToolResultAnchors
+
+
+PATH_SUFFIXES = {
+    ".py",
+    ".md",
+    ".json",
+    ".toml",
+    ".yaml",
+    ".yml",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".css",
+    ".html",
+    ".dart",
+    ".go",
+    ".rs",
+    ".java",
+    ".kt",
+    ".swift",
+    ".sh",
+    ".ps1",
+    ".sql",
+}
+
+ERROR_PATTERNS = (
+    "traceback",
+    "assertionerror",
+    "exception",
+    "error:",
+    "failed",
+    "failure",
+    "syntaxerror",
+    "typeerror",
+    "valueerror",
+)
+
+
+def classify_tool_kind(captured: CapturedToolResult) -> str:
+    tool_name = captured.tool_name.lower()
+    command = captured.command.strip().lower()
+    if "mcp" in tool_name or tool_name.startswith("mcp__"):
+        return "mcp_result"
+    if tool_name in {"apply_patch", "edit", "write"} or "apply_patch" in command:
+        return "apply_patch"
+    if _starts_with_any(command, ("rg ", "ripgrep ", "grep ", "select-string ")):
+        return "search"
+    if _starts_with_any(command, ("get-content ", "cat ", "type ")):
+        return "file_read"
+    if _starts_with_any(command, ("git diff", "git show", "git log")):
+        return "git_diff"
+    if "pytest" in command or "npm test" in command or "cargo test" in command or "go test" in command:
+        return "test_output"
+    return "unknown"
+
+
+def extract_tool_result_anchors(captured: CapturedToolResult) -> ToolResultAnchors:
+    tool_kind = classify_tool_kind(captured)
+    command = captured.command
+    response = captured.tool_response
+    cwd = Path(captured.cwd).resolve() if captured.cwd else None
+    files: list[str] = []
+    symbols: list[str] = []
+    errors: list[str] = []
+    line_refs: list[ToolLineRef] = []
+
+    if tool_kind == "search":
+        line_refs.extend(_rg_line_refs(response, cwd=cwd))
+        files.extend(ref.file_path for ref in line_refs)
+        files.extend(_extract_paths(command, cwd=cwd))
+    elif tool_kind == "file_read":
+        files.extend(_extract_paths(command, cwd=cwd))
+        symbols.extend(_python_symbols(response))
+    elif tool_kind == "git_diff":
+        files.extend(_git_changed_files(response, cwd=cwd))
+        files.extend(_extract_paths(command, cwd=cwd))
+    elif tool_kind == "test_output":
+        files.extend(_pytest_files(response, cwd=cwd))
+        line_refs.extend(_rg_line_refs(response, cwd=cwd))
+        errors.extend(_error_lines(response))
+    elif tool_kind == "apply_patch":
+        files.extend(_patch_files(command + "\n" + response, cwd=cwd))
+    elif tool_kind == "mcp_result":
+        files.extend(_extract_paths(command + "\n" + response[:4000], cwd=cwd))
+        errors.extend(_error_lines(response))
+    else:
+        files.extend(_extract_paths(command + "\n" + response[:4000], cwd=cwd))
+        errors.extend(_error_lines(response))
+
+    return ToolResultAnchors(
+        files=tuple(_dedupe(files)[:16]),
+        symbols=tuple(_dedupe(symbols)[:16]),
+        errors=tuple(_dedupe(errors)[:8]),
+        line_refs=tuple(_dedupe_line_refs(line_refs)[:24]),
+    )
+
+
+def _starts_with_any(value: str, prefixes: tuple[str, ...]) -> bool:
+    return any(value.startswith(prefix) for prefix in prefixes)
+
+
+def _rg_line_refs(text: str, *, cwd: Path | None) -> list[ToolLineRef]:
+    refs: list[ToolLineRef] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        match = re.match(r"^(?P<path>(?![A-Za-z]:)[^:\r\n]+):(?P<line>\d+):(?P<text>.*)$", line)
+        if not match:
+            continue
+        path = _normalize_candidate_path(match.group("path"), cwd=cwd)
+        if not path:
+            continue
+        refs.append(ToolLineRef(file_path=path, line=int(match.group("line")), text=match.group("text").strip()[:240]))
+    return refs
+
+
+def _extract_paths(text: str, *, cwd: Path | None) -> list[str]:
+    paths: list[str] = []
+    patterns = (
+        r"(?P<path>[A-Za-z]:[\\/][^\s'\"<>|]+)",
+        r"(?P<path>(?:src|tests|docs|npm|scripts|agent-memory-orchestrator)[\\/][\w .@()\-\\/]+\.[A-Za-z0-9]+)",
+        r"(?P<path>[\w .@()\-]+[\\/][\w .@()\-\\/]+\.[A-Za-z0-9]+)",
+    )
+    for pattern in patterns:
+        for match in re.finditer(pattern, text):
+            path = _normalize_candidate_path(match.group("path"), cwd=cwd)
+            if path:
+                paths.append(path)
+    return paths
+
+
+def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
+    cleaned = value.strip().strip("'\"`").rstrip(",:;)]}>\r\n")
+    lowered = cleaned.lower()
+    for prefix in ("get-content ", "cat ", "type ", "rg ", "ripgrep ", "grep ", "select-string "):
+        if lowered.startswith(prefix):
+            cleaned = cleaned[len(prefix) :].strip()
+            lowered = cleaned.lower()
+    cleaned = cleaned.replace("\\", "/")
+    if not cleaned:
+        return ""
+    try:
+        path = Path(cleaned)
+        if path.is_absolute() and cwd is not None:
+            try:
+                cleaned = str(path.resolve().relative_to(cwd)).replace("\\", "/")
+            except ValueError:
+                return ""
+    except OSError:
+        return ""
+    if cleaned.startswith("../") or "/.git/" in cleaned or "/.codex/" in cleaned:
+        return ""
+    suffix = Path(cleaned).suffix.lower()
+    if suffix not in PATH_SUFFIXES:
+        return ""
+    return normalize_file_path(cleaned)
+
+
+def _python_symbols(text: str) -> list[str]:
+    symbols: list[str] = []
+    for match in re.finditer(r"^\s*(?:async\s+def|def|class)\s+([A-Za-z_][A-Za-z0-9_]*)", text, flags=re.MULTILINE):
+        symbols.append(match.group(1))
+    return symbols
+
+
+def _git_changed_files(text: str, *, cwd: Path | None) -> list[str]:
+    files: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        match = re.match(r"^diff --git a/(.+?) b/(.+)$", line)
+        if match:
+            files.append(_normalize_candidate_path(match.group(2), cwd=cwd))
+            continue
+        match = re.match(r"^(?:---|\+\+\+) [ab]/(.+)$", line)
+        if match:
+            files.append(_normalize_candidate_path(match.group(1), cwd=cwd))
+    return [item for item in files if item]
+
+
+def _pytest_files(text: str, *, cwd: Path | None) -> list[str]:
+    files: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("FAILED "):
+            candidate = line.removeprefix("FAILED ").split("::", 1)[0].split(" ", 1)[0]
+            path = _normalize_candidate_path(candidate, cwd=cwd)
+            if path:
+                files.append(path)
+        match = re.match(r"^(?P<path>(?:tests|src)[\\/][^:\s]+\.py):\d+:", line)
+        if match:
+            path = _normalize_candidate_path(match.group("path"), cwd=cwd)
+            if path:
+                files.append(path)
+    return files
+
+
+def _patch_files(text: str, *, cwd: Path | None) -> list[str]:
+    files: list[str] = []
+    for match in re.finditer(r"^\*\*\* (?:Add|Update|Delete) File:\s+(.+)$", text, flags=re.MULTILINE):
+        path = _normalize_candidate_path(match.group(1), cwd=cwd)
+        if path:
+            files.append(path)
+    return files
+
+
+def _error_lines(text: str) -> list[str]:
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        lowered = line.lower()
+        if any(pattern in lowered for pattern in ERROR_PATTERNS):
+            out.append(line[:260])
+    return out
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _dedupe_line_refs(values: list[ToolLineRef]) -> list[ToolLineRef]:
+    out: dict[tuple[str, int, str], ToolLineRef] = {}
+    for value in values:
+        out.setdefault((value.file_path, value.line, value.text), value)
+    return list(out.values())
+
+
+__all__ = ["classify_tool_kind", "extract_tool_result_anchors"]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/models.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/models.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+
+@dataclass(slots=True, frozen=True)
+class CapturedToolResult:
+    tool_name: str
+    tool_input: dict[str, Any]
+    tool_response: str
+    tool_use_id: str = ""
+    session_id: str = ""
+    turn_id: str = ""
+    cwd: str = ""
+    transcript_path: str = ""
+    hook_event_name: str = "PostToolUse"
+
+    @property
+    def command(self) -> str:
+        return str(self.tool_input.get("command") or self.tool_input.get("cmd") or "")
+
+    @property
+    def raw_output_hash(self) -> str:
+        return hashlib.sha256(self.tool_response.encode("utf-8", errors="replace")).hexdigest()
+
+    def output_excerpt(self, max_chars: int = 4000) -> str:
+        if len(self.tool_response) <= max_chars:
+            return self.tool_response
+        return self.tool_response[:max_chars]
+
+    def as_dict(self, *, include_response: bool = False) -> dict[str, Any]:
+        out = {
+            "tool_name": self.tool_name,
+            "tool_input": dict(self.tool_input),
+            "tool_use_id": self.tool_use_id,
+            "session_id": self.session_id,
+            "turn_id": self.turn_id,
+            "cwd": self.cwd,
+            "transcript_path": self.transcript_path,
+            "hook_event_name": self.hook_event_name,
+            "raw_output_hash": self.raw_output_hash,
+            "response_chars": len(self.tool_response),
+            "response_excerpt": self.output_excerpt(1200),
+        }
+        if include_response:
+            out["tool_response"] = self.tool_response
+        return out
+
+
+@dataclass(slots=True, frozen=True)
+class ToolLineRef:
+    file_path: str
+    line: int
+    text: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"file_path": self.file_path, "line": self.line, "text": self.text}
+
+
+@dataclass(slots=True, frozen=True)
+class ToolResultAnchors:
+    files: tuple[str, ...] = ()
+    symbols: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+    line_refs: tuple[ToolLineRef, ...] = ()
+
+    @property
+    def has_any(self) -> bool:
+        return bool(self.files or self.symbols or self.errors or self.line_refs)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "files": list(self.files),
+            "symbols": list(self.symbols),
+            "errors": list(self.errors),
+            "line_refs": [line_ref.as_dict() for line_ref in self.line_refs],
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ToolOverlayLatency:
+    parse_ms: int = 0
+    harness_query_ms: int = 0
+    decision_ms: int = 0
+
+    @property
+    def total_ms(self) -> int:
+        return self.parse_ms + self.harness_query_ms + self.decision_ms
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "parse": self.parse_ms,
+            "harness_query": self.harness_query_ms,
+            "decision": self.decision_ms,
+            "total": self.total_ms,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ToolOverlayDecision:
+    mode: str
+    tool_kind: str
+    captured: CapturedToolResult
+    anchors: ToolResultAnchors
+    harness_request: dict[str, Any]
+    harness_response: dict[str, Any]
+    latency: ToolOverlayLatency
+    would_attach: bool
+    would_replace: bool = False
+    suppression_reasons: tuple[str, ...] = ()
+    confidence: float = 0.0
+    token_overhead_estimate: int = 0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "tool_kind": self.tool_kind,
+            "captured": self.captured.as_dict(),
+            "extracted_anchors": self.anchors.as_dict(),
+            "harness_request": self.harness_request,
+            "harness_response": self.harness_response,
+            "latency_ms": self.latency.as_dict(),
+            "decision": {
+                "mode": self.mode,
+                "would_attach": self.would_attach,
+                "would_replace": self.would_replace,
+                "suppression_reasons": list(self.suppression_reasons),
+                "confidence": self.confidence,
+            },
+            "token_overhead_estimate": self.token_overhead_estimate,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ToolOverlayJudgment:
+    auto_useful: bool | None = None
+    auto_mislead_candidate: bool | None = None
+    manual_label: str = ""
+    reason: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "auto_useful": self.auto_useful,
+            "auto_mislead_candidate": self.auto_mislead_candidate,
+            "manual_label": self.manual_label,
+            "reason": self.reason,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class ToolOverlayEvalRecord:
+    decision: ToolOverlayDecision
+    judgment: ToolOverlayJudgment = field(default_factory=ToolOverlayJudgment)
+
+    def as_dict(self) -> dict[str, Any]:
+        out = self.decision.as_dict()
+        out["judgment"] = self.judgment.as_dict()
+        return out
+
+
+@dataclass(slots=True, frozen=True)
+class ShadowReplayReport:
+    repo_id: str
+    source_path: str
+    records: tuple[ToolOverlayEvalRecord, ...]
+
+    @property
+    def idempotent_replay_rate(self) -> float:
+        return 1.0
+
+    def as_dict(self) -> dict[str, Any]:
+        records = [record.as_dict() for record in self.records]
+        return {
+            "repo_id": self.repo_id,
+            "source_path": self.source_path,
+            "record_count": len(records),
+            "metrics": _metrics(records),
+            "records": records,
+        }
+
+
+def captured_tool_result_from_event(event: dict[str, Any]) -> CapturedToolResult | None:
+    payload = event.get("payload") if isinstance(event.get("payload"), dict) else event
+    hook_event_name = str(payload.get("hook_event_name") or event.get("event_name") or "")
+    event_name = str(event.get("event_name") or event.get("event_type") or "").lower()
+    if hook_event_name != "PostToolUse" and event_name != "post_tool_use":
+        return None
+    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    return CapturedToolResult(
+        tool_name=str(payload.get("tool_name") or ""),
+        tool_input=dict(tool_input),
+        tool_response=str(payload.get("tool_response") or ""),
+        tool_use_id=str(payload.get("tool_use_id") or ""),
+        session_id=str(payload.get("session_id") or ""),
+        turn_id=str(payload.get("turn_id") or ""),
+        cwd=str(payload.get("cwd") or ""),
+        transcript_path=str(payload.get("transcript_path") or ""),
+        hook_event_name="PostToolUse",
+    )
+
+
+def _metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
+    by_kind: dict[str, dict[str, int]] = {}
+    latencies: list[int] = []
+    attached = 0
+    for record in records:
+        tool_kind = str(record.get("tool_kind") or "unknown")
+        bucket = by_kind.setdefault(tool_kind, {"total": 0, "attached": 0, "suppressed": 0})
+        bucket["total"] += 1
+        decision = record.get("decision") or {}
+        if decision.get("would_attach"):
+            attached += 1
+            bucket["attached"] += 1
+        else:
+            bucket["suppressed"] += 1
+        latency = record.get("latency_ms") or {}
+        latencies.append(int(latency.get("total") or 0))
+    return {
+        "attached_count": attached,
+        "suppressed_count": len(records) - attached,
+        "attach_rate": round(attached / len(records), 4) if records else 0.0,
+        "p95_shadow_latency_ms": _percentile(latencies, 0.95),
+        "idempotent_replay_rate": 1.0,
+        "by_tool_kind": by_kind,
+    }
+
+
+def _percentile(values: list[int], pct: float) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(round((len(ordered) - 1) * pct))))
+    return ordered[index]
+
+
+def stable_json_hash(value: Any) -> str:
+    text = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "CapturedToolResult",
+    "ShadowReplayReport",
+    "ToolLineRef",
+    "ToolOverlayDecision",
+    "ToolOverlayEvalRecord",
+    "ToolOverlayJudgment",
+    "ToolOverlayLatency",
+    "ToolResultAnchors",
+    "captured_tool_result_from_event",
+    "stable_json_hash",
+]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/models.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/models.py
@@ -206,10 +206,14 @@ def captured_tool_result_from_event(event: dict[str, Any]) -> CapturedToolResult
 def _metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
     by_kind: dict[str, dict[str, int]] = {}
     latencies: list[int] = []
+    token_overheads: list[int] = []
     attached = 0
+    auto_useful = 0
+    auto_mislead = 0
+    manual_review_required = 0
     for record in records:
         tool_kind = str(record.get("tool_kind") or "unknown")
-        bucket = by_kind.setdefault(tool_kind, {"total": 0, "attached": 0, "suppressed": 0})
+        bucket = by_kind.setdefault(tool_kind, {"total": 0, "attached": 0, "suppressed": 0, "suppress_rate": 0})
         bucket["total"] += 1
         decision = record.get("decision") or {}
         if decision.get("would_attach"):
@@ -219,12 +223,44 @@ def _metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
             bucket["suppressed"] += 1
         latency = record.get("latency_ms") or {}
         latencies.append(int(latency.get("total") or 0))
+        token_overheads.append(int(record.get("token_overhead_estimate") or 0))
+        judgment = record.get("judgment") or {}
+        if judgment.get("auto_useful") is True:
+            auto_useful += 1
+        if judgment.get("auto_mislead_candidate") is True:
+            auto_mislead += 1
+        if judgment.get("reason") == "manual_review_required":
+            manual_review_required += 1
+    for bucket in by_kind.values():
+        total = int(bucket.get("total") or 0)
+        bucket["suppress_rate"] = round(int(bucket.get("suppressed") or 0) / total, 4) if total else 0
     return {
         "attached_count": attached,
         "suppressed_count": len(records) - attached,
         "attach_rate": round(attached / len(records), 4) if records else 0.0,
+        "suppress_rate": round((len(records) - attached) / len(records), 4) if records else 0.0,
         "p95_shadow_latency_ms": _percentile(latencies, 0.95),
+        "token_overhead_p95": _percentile(token_overheads, 0.95),
         "idempotent_replay_rate": 1.0,
+        "auto_useful_count": auto_useful,
+        "auto_mislead_candidate_count": auto_mislead,
+        "auto_mislead_candidate_rate": round(auto_mislead / len(records), 4) if records else 0.0,
+        "manual_review_required_count": manual_review_required,
+        "acceptance_thresholds": {
+            "anchor_extraction_precision": 0.90,
+            "strict_card_precision": 0.85,
+            "mislead_rate": 0.05,
+            "p95_shadow_latency_ms": 500,
+            "token_overhead_p95": 900,
+            "idempotent_replay_rate": 1.0,
+        },
+        "suppress_rate_targets": {
+            "rg_many_matches": "0.20-0.40",
+            "file_read": "0.10-0.25",
+            "test_failure": "0.05-0.20",
+            "apply_patch_edit": "0.30-0.60",
+            "unknown_tool": "0.80-0.95",
+        },
         "by_tool_kind": by_kind,
     }
 

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from agent_memory_orchestrator.application.services.semantic_harness.runtime import SemanticHarnessRuntimeService
+from agent_memory_orchestrator.domain.semantic_harness import HarnessCard
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryResponse
+
+from .extract import classify_tool_kind
+from .extract import extract_tool_result_anchors
+from .models import CapturedToolResult
+from .models import ToolOverlayDecision
+from .models import ToolOverlayLatency
+from .models import ToolResultAnchors
+
+
+ATTACHABLE_STATUSES = {"ready", "partial_structural", "partial_historical"}
+MIN_ATTACH_CONFIDENCE = 0.75
+
+_INTENT_BY_TOOL_KIND = {
+    "search": "tool_overlay",
+    "file_read": "file_context",
+    "git_diff": "impact_check",
+    "test_output": "test_plan",
+    "apply_patch": "impact_check",
+    "mcp_result": "tool_overlay",
+    "unknown": "tool_overlay",
+}
+
+
+@dataclass(slots=True, frozen=True)
+class ToolContextPlannerOptions:
+    max_cards: int = 5
+    max_tokens: int = 900
+    max_latency_ms: int = 500
+    detail: str = "strict"
+    min_attach_confidence: float = MIN_ATTACH_CONFIDENCE
+
+
+class ToolContextPlanner:
+    """Turns captured tool results into shadow harness attach/suppress decisions."""
+
+    def __init__(
+        self,
+        *,
+        runtime: SemanticHarnessRuntimeService,
+        options: ToolContextPlannerOptions | None = None,
+    ) -> None:
+        self._runtime = runtime
+        self._options = options or ToolContextPlannerOptions()
+
+    def plan(
+        self,
+        *,
+        repo_id: str,
+        captured: CapturedToolResult,
+        already_seen_card_ids: tuple[str, ...] = (),
+    ) -> ToolOverlayDecision:
+        parse_start = time.perf_counter()
+        tool_kind = classify_tool_kind(captured)
+        anchors = extract_tool_result_anchors(captured)
+        request = self._request_for(
+            tool_kind=tool_kind,
+            captured=captured,
+            anchors=anchors,
+            already_seen_card_ids=already_seen_card_ids,
+        )
+        parse_ms = _elapsed_ms(parse_start)
+
+        query_start = time.perf_counter()
+        response = self._runtime.query(repo_id, request)
+        query_ms = _elapsed_ms(query_start)
+
+        decision_start = time.perf_counter()
+        token_overhead = _estimate_token_overhead(response.cards)
+        confidence = _max_card_confidence(response.cards)
+        suppression_reasons = _suppression_reasons(
+            response=response,
+            anchors=anchors,
+            confidence=confidence,
+            token_overhead=token_overhead,
+            elapsed_ms=parse_ms + query_ms,
+            options=self._options,
+        )
+        decision_ms = _elapsed_ms(decision_start)
+        total_latency = ToolOverlayLatency(
+            parse_ms=parse_ms,
+            harness_query_ms=query_ms,
+            decision_ms=decision_ms,
+        )
+        if total_latency.total_ms > self._options.max_latency_ms and "latency_exceeded" not in suppression_reasons:
+            suppression_reasons = (*suppression_reasons, "latency_exceeded")
+
+        return ToolOverlayDecision(
+            mode="shadow",
+            tool_kind=tool_kind,
+            captured=captured,
+            anchors=anchors,
+            harness_request=_request_as_dict(request),
+            harness_response=response.as_dict(),
+            latency=total_latency,
+            would_attach=not suppression_reasons,
+            would_replace=False,
+            suppression_reasons=suppression_reasons,
+            confidence=confidence,
+            token_overhead_estimate=token_overhead,
+        )
+
+    def _request_for(
+        self,
+        *,
+        tool_kind: str,
+        captured: CapturedToolResult,
+        anchors: ToolResultAnchors,
+        already_seen_card_ids: tuple[str, ...],
+    ) -> HarnessQueryRequest:
+        intent = _INTENT_BY_TOOL_KIND.get(tool_kind, "tool_overlay")
+        return HarnessQueryRequest(
+            intent=intent,
+            user_goal=f"Interpret {tool_kind} result for coding-agent harness overlay.",
+            files=anchors.files,
+            symbols=anchors.symbols,
+            errors=anchors.errors,
+            recent_tool_result={
+                "tool_name": captured.tool_name,
+                "tool_kind": tool_kind,
+                "command": captured.command,
+                "raw_output_hash": captured.raw_output_hash,
+                "response_excerpt": captured.output_excerpt(1200),
+            },
+            max_cards=self._options.max_cards,
+            max_tokens=self._options.max_tokens,
+            detail=self._options.detail,
+            session_id=captured.session_id,
+            already_seen_card_ids=already_seen_card_ids,
+        )
+
+
+def _suppression_reasons(
+    *,
+    response: HarnessQueryResponse,
+    anchors: ToolResultAnchors,
+    confidence: float,
+    token_overhead: int,
+    elapsed_ms: int,
+    options: ToolContextPlannerOptions,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if not anchors.has_any:
+        reasons.append("no_extracted_anchors")
+    if response.status not in ATTACHABLE_STATUSES:
+        reasons.append(f"status:{response.status}")
+    if not response.cards:
+        reasons.append("no_cards")
+    if confidence < options.min_attach_confidence:
+        reasons.append("low_card_confidence")
+    if not _has_graph_grounding(response.cards):
+        reasons.append("missing_graph_grounding")
+    if _has_only_vector_evidence(response.cards):
+        reasons.append("vector_only_evidence")
+    if token_overhead > options.max_tokens:
+        reasons.append("token_budget_exceeded")
+    if elapsed_ms > options.max_latency_ms:
+        reasons.append("latency_exceeded")
+    return tuple(dict.fromkeys(reasons))
+
+
+def _has_graph_grounding(cards: tuple[HarnessCard, ...]) -> bool:
+    for card in cards:
+        for evidence in card.evidence:
+            if evidence.get("node_id") and evidence.get("kind") != "ProjectionDocument":
+                return True
+            if evidence.get("source_id") and evidence.get("target_id") and evidence.get("kind") != "ProjectionDocument":
+                return True
+    return False
+
+
+def _has_only_vector_evidence(cards: tuple[HarnessCard, ...]) -> bool:
+    has_any = False
+    for card in cards:
+        for evidence in card.evidence:
+            has_any = True
+            if evidence.get("retrieval_source") != "vector":
+                return False
+    return has_any
+
+
+def _max_card_confidence(cards: tuple[HarnessCard, ...]) -> float:
+    return max((float(card.confidence) for card in cards), default=0.0)
+
+
+def _estimate_token_overhead(cards: tuple[HarnessCard, ...]) -> int:
+    text = json.dumps([card.as_dict() for card in cards], sort_keys=True, ensure_ascii=False)
+    return max(0, int(len(text) / 4))
+
+
+def _request_as_dict(request: HarnessQueryRequest) -> dict[str, Any]:
+    return {
+        "intent": request.intent,
+        "user_goal": request.user_goal,
+        "anchors": {
+            "files": list(request.files),
+            "symbols": list(request.symbols),
+            "commits": list(request.commits),
+            "errors": list(request.errors),
+            "recent_tool_result": request.recent_tool_result,
+        },
+        "budget": {
+            "max_cards": request.max_cards,
+            "max_tokens": request.max_tokens,
+            "detail": request.detail,
+        },
+        "session_state": {
+            "already_seen_node_ids": list(request.already_seen_node_ids),
+            "already_seen_relation_ids": list(request.already_seen_relation_ids),
+            "already_seen_card_ids": list(request.already_seen_card_ids),
+        },
+    }
+
+
+def _elapsed_ms(start: float) -> int:
+    return int(round((time.perf_counter() - start) * 1000))
+
+
+__all__ = ["ToolContextPlanner", "ToolContextPlannerOptions"]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/replay.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/replay.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .extract import classify_tool_kind
+from .models import CapturedToolResult
+from .models import ShadowReplayReport
+from .models import ToolOverlayEvalRecord
+from .models import ToolOverlayJudgment
+from .models import captured_tool_result_from_event
+from .planner import ToolContextPlanner
+
+
+class ShadowToolReplayService:
+    """Runs shadow-only harness overlay decisions over captured PostToolUse rows."""
+
+    def __init__(self, *, planner: ToolContextPlanner) -> None:
+        self._planner = planner
+
+    def replay_file(self, path: str | Path, *, repo_id: str, limit: int = 0) -> ShadowReplayReport:
+        source_path = Path(path).expanduser().resolve()
+        captured = tuple(_read_captured_tool_results(source_path, limit=limit))
+        records: list[ToolOverlayEvalRecord] = []
+        seen_card_ids: set[str] = set()
+        for index, item in enumerate(captured):
+            decision = self._planner.plan(
+                repo_id=repo_id,
+                captured=item,
+                already_seen_card_ids=tuple(sorted(seen_card_ids)),
+            )
+            if decision.would_attach:
+                for card in decision.harness_response.get("cards", []):
+                    if card_id := card.get("card_id"):
+                        seen_card_ids.add(str(card_id))
+            records.append(
+                ToolOverlayEvalRecord(
+                    decision=decision,
+                    judgment=_automatic_judgment(decision_targets(decision.harness_response), captured[index + 1 :]),
+                )
+            )
+        return ShadowReplayReport(repo_id=repo_id, source_path=str(source_path), records=tuple(records))
+
+
+def _read_captured_tool_results(path: Path, *, limit: int) -> list[CapturedToolResult]:
+    captured: list[CapturedToolResult] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if limit and len(captured) >= limit:
+                break
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            item = captured_tool_result_from_event(event)
+            if item is not None:
+                captured.append(item)
+    return captured
+
+
+def _automatic_judgment(targets: tuple[str, ...], future: tuple[CapturedToolResult, ...]) -> ToolOverlayJudgment:
+    if not targets:
+        return ToolOverlayJudgment(reason="no_card_targets")
+    first_three = future[:3]
+    first_five = future[:5]
+    useful = _future_mentions_target(targets, first_three)
+    if useful:
+        return ToolOverlayJudgment(auto_useful=True, auto_mislead_candidate=False, reason="target_reused_within_next_3_tools")
+    repeated_target_focus = sum(1 for item in first_five if _future_mentions_target(targets, (item,))) >= 5
+    no_related_progress = not any(_is_edit_test_or_commit(item) for item in first_five)
+    if repeated_target_focus and no_related_progress:
+        return ToolOverlayJudgment(auto_useful=False, auto_mislead_candidate=True, reason="target_focus_without_edit_test_or_commit")
+    return ToolOverlayJudgment(reason="manual_review_required")
+
+
+def decision_targets(response: dict[str, object]) -> tuple[str, ...]:
+    targets: list[str] = []
+    cards = response.get("cards")
+    if not isinstance(cards, list):
+        return ()
+    for card in cards:
+        if not isinstance(card, dict):
+            continue
+        if next_action := card.get("next_action"):
+            targets.extend(_target_fragments(str(next_action)))
+        evidence = card.get("evidence")
+        if isinstance(evidence, list):
+            for item in evidence:
+                if isinstance(item, dict):
+                    if path := item.get("path"):
+                        targets.extend(_target_fragments(str(path)))
+                    if node_id := item.get("node_id"):
+                        targets.extend(_target_fragments(str(node_id)))
+    return tuple(dict.fromkeys(target for target in targets if target))
+
+
+def _target_fragments(value: str) -> list[str]:
+    normalized = value.replace("\\", "/").strip()
+    fragments = [normalized]
+    if " " in normalized:
+        fragments.extend(part.strip(".,:;()[]{}") for part in normalized.split())
+    if "/" in normalized:
+        fragments.append(normalized.rsplit("/", 1)[-1])
+    return [fragment for fragment in fragments if len(fragment) >= 4]
+
+
+def _future_mentions_target(targets: tuple[str, ...], items: tuple[CapturedToolResult, ...]) -> bool:
+    lowered_targets = tuple(target.lower() for target in targets)
+    for item in items:
+        haystack = f"{item.command}\n{item.tool_response[:2000]}".replace("\\", "/").lower()
+        if any(target in haystack for target in lowered_targets):
+            return True
+    return False
+
+
+def _is_edit_test_or_commit(item: CapturedToolResult) -> bool:
+    tool_kind = classify_tool_kind(item)
+    command = item.command.lower()
+    return tool_kind in {"apply_patch", "test_output"} or command.startswith("git commit") or "git commit" in command
+
+
+__all__ = ["ShadowToolReplayService", "decision_targets"]

--- a/src/agent_memory_orchestrator/runtime/cli/commands/semantic_harness.py
+++ b/src/agent_memory_orchestrator/runtime/cli/commands/semantic_harness.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any
 
 from ....application.services.semantic_harness import RepoBootstrapOptions
+from ....application.services.semantic_harness import ShadowToolReplayService
 from ....application.services.semantic_harness import SemanticHarnessRuntimeService
+from ....application.services.semantic_harness import ToolContextPlanner
 from ....core.config import Settings
 from ....infrastructure.sqlite.semantic_harness import SQLiteHarnessGraphRepository
 from ....infrastructure.sqlite.semantic_harness import SQLiteProjectionCache
@@ -30,6 +32,12 @@ def _add_harness_actions(harness_sub: Any) -> None:
         action="store_true",
         help="Use filesystem walk instead of git ls-files for source discovery.",
     )
+    replay = harness_sub.add_parser("shadow-replay", help="Replay PostToolUse evidence without injecting context")
+    replay.add_argument("--repo-id", required=True, help="Repo id for the already-warmed harness graph.")
+    replay.add_argument("--evidence", type=Path, default=None, help="Evidence JSONL to replay. Defaults to latest.")
+    replay.add_argument("--db-path", type=Path, default=None, help="Override Semantic Harness SQLite path.")
+    replay.add_argument("--limit", type=int, default=0, help="Maximum PostToolUse rows to replay. 0 means all.")
+    replay.add_argument("--out", type=Path, default=None, help="Optional report JSON path.")
 
 
 def handle_semantic_harness_command(args: Any, *, emit: Callable[[object], None]) -> int | None:
@@ -51,6 +59,38 @@ def handle_semantic_harness_command(args: Any, *, emit: Callable[[object], None]
                 result = runtime.bootstrap_repo(args.repo, repo_id=args.repo_id, options=options)
         payload = result.as_dict()
         payload.update({"ok": True, "db_path": str(db_path), "command": "amo-harness bootstrap"})
+        emit(payload)
+        return 0
+    if args.amo_harness_command == "shadow-replay":
+        settings = Settings.load()
+        db_path = _semantic_harness_db_path(settings, getattr(args, "db_path", None))
+        evidence_path = getattr(args, "evidence", None) or _latest_evidence_file(settings)
+        with SQLiteHarnessGraphRepository(db_path) as graph_repo:
+            with SQLiteProjectionCache(db_path) as projection_cache:
+                runtime = SemanticHarnessRuntimeService(
+                    graph_repository=graph_repo,
+                    projection_cache=projection_cache,
+                )
+                planner = ToolContextPlanner(runtime=runtime)
+                report = ShadowToolReplayService(planner=planner).replay_file(
+                    evidence_path,
+                    repo_id=args.repo_id,
+                    limit=max(0, int(args.limit)),
+                )
+        payload = report.as_dict()
+        payload.update(
+            {
+                "ok": True,
+                "db_path": str(db_path),
+                "command": "amo-harness shadow-replay",
+                "shadow_only": True,
+            }
+        )
+        if args.out is not None:
+            out_path = args.out.expanduser().resolve()
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            payload["out"] = str(out_path)
         emit(payload)
         return 0
     return None
@@ -77,6 +117,17 @@ def _semantic_harness_db_path(settings: Settings, override: Path | None) -> Path
     if override is not None:
         return override.expanduser().resolve()
     return (settings.home / ".data" / "semantic_harness.sqlite").resolve()
+
+
+def _latest_evidence_file(settings: Settings) -> Path:
+    files = sorted(
+        (path for path in settings.evidence_dir.glob("*.jsonl") if path.is_file() and not path.name.endswith(".lock")),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    if not files:
+        raise FileNotFoundError(f"No evidence JSONL files found under {settings.evidence_dir}")
+    return files[0].resolve()
 
 
 __all__ = [

--- a/src/agent_memory_orchestrator/runtime/cli/commands/semantic_harness.py
+++ b/src/agent_memory_orchestrator/runtime/cli/commands/semantic_harness.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ....application.services.semantic_harness import RepoBootstrapOptions
+from ....application.services.semantic_harness import SemanticHarnessRuntimeService
+from ....core.config import Settings
+from ....infrastructure.sqlite.semantic_harness import SQLiteHarnessGraphRepository
+from ....infrastructure.sqlite.semantic_harness import SQLiteProjectionCache
+
+
+def add_semantic_harness_subcommands(sub: Any) -> None:
+    harness = sub.add_parser("amo-harness", help="Warm and evaluate the Semantic Harness graph")
+    harness_sub = harness.add_subparsers(dest="amo_harness_command", required=True)
+    _add_harness_actions(harness_sub)
+
+
+def _add_harness_actions(harness_sub: Any) -> None:
+    bootstrap = harness_sub.add_parser("bootstrap", help="Warm the Semantic Harness graph for one repository")
+    bootstrap.add_argument("--repo", type=Path, required=True, help="Repository root to bootstrap.")
+    bootstrap.add_argument("--repo-id", default="", help="Stable repo id. Defaults to deterministic repo root id.")
+    bootstrap.add_argument("--db-path", type=Path, default=None, help="Override Semantic Harness SQLite path.")
+    bootstrap.add_argument("--max-files", type=int, default=10_000, help="Maximum source files to read.")
+    bootstrap.add_argument(
+        "--include-untracked",
+        action="store_true",
+        help="Use filesystem walk instead of git ls-files for source discovery.",
+    )
+
+
+def handle_semantic_harness_command(args: Any, *, emit: Callable[[object], None]) -> int | None:
+    if args.command != "amo-harness":
+        return None
+    if args.amo_harness_command == "bootstrap":
+        settings = Settings.load()
+        db_path = _semantic_harness_db_path(settings, getattr(args, "db_path", None))
+        options = RepoBootstrapOptions(
+            max_files=max(1, int(args.max_files)),
+            prefer_git_tracked=not bool(args.include_untracked),
+        )
+        with SQLiteHarnessGraphRepository(db_path) as graph_repo:
+            with SQLiteProjectionCache(db_path) as projection_cache:
+                runtime = SemanticHarnessRuntimeService(
+                    graph_repository=graph_repo,
+                    projection_cache=projection_cache,
+                )
+                result = runtime.bootstrap_repo(args.repo, repo_id=args.repo_id, options=options)
+        payload = result.as_dict()
+        payload.update({"ok": True, "db_path": str(db_path), "command": "amo-harness bootstrap"})
+        emit(payload)
+        return 0
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Semantic Harness evaluation CLI")
+    sub = parser.add_subparsers(dest="amo_harness_command", required=True)
+    _add_harness_actions(sub)
+    args = parser.parse_args(argv)
+    args.command = "amo-harness"
+
+    def _emit(payload: object) -> None:
+        print(json.dumps(payload, indent=2))
+
+    status = handle_semantic_harness_command(args, emit=_emit)
+    if status is not None:
+        return status
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+def _semantic_harness_db_path(settings: Settings, override: Path | None) -> Path:
+    if override is not None:
+        return override.expanduser().resolve()
+    return (settings.home / ".data" / "semantic_harness.sqlite").resolve()
+
+
+__all__ = [
+    "add_semantic_harness_subcommands",
+    "handle_semantic_harness_command",
+    "main",
+]

--- a/src/agent_memory_orchestrator/runtime/cli/main.py
+++ b/src/agent_memory_orchestrator/runtime/cli/main.py
@@ -31,6 +31,8 @@ from .commands.pipeline import add_pipeline_subcommands as _add_pipeline_subcomm
 from .commands.pipeline import handle_pipeline_command as _handle_pipeline_command
 from .commands.peer import add_peer_subcommands as _add_peer_subcommands
 from .commands.peer import handle_peer_command as _handle_peer_command
+from .commands.semantic_harness import add_semantic_harness_subcommands as _add_semantic_harness_subcommands
+from .commands.semantic_harness import handle_semantic_harness_command as _handle_semantic_harness_command
 from .commands.skill_checkpoint import add_skill_checkpoint_subcommands as _add_skill_checkpoint_subcommands
 from .commands.skill_checkpoint import handle_skill_checkpoint_command as _handle_skill_checkpoint_command
 
@@ -72,6 +74,8 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_orchestration_subcommands(sub)
 
     _add_antelligent_subcommands(sub)
+
+    _add_semantic_harness_subcommands(sub)
 
     return parser
 
@@ -128,6 +132,10 @@ def main(argv: list[str] | None = None) -> int:
         antelligent_status = _handle_antelligent_command(args, emit=_print)
         if antelligent_status is not None:
             return antelligent_status
+
+        semantic_harness_status = _handle_semantic_harness_command(args, emit=_print)
+        if semantic_harness_status is not None:
+            return semantic_harness_status
 
         parser.error(f"unknown command: {args.command}")
         return 2

--- a/tests/application/semantic_harness/test_tool_context_extract.py
+++ b/tests/application/semantic_harness/test_tool_context_extract.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import CapturedToolResult
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import classify_tool_kind
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import extract_tool_result_anchors
+
+
+def test_extract_rg_files_and_line_refs() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "rg -n login src tests"},
+        tool_response="src/auth.py:12:def login():\ntests/test_auth.py:7:assert login()\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "search"
+    assert anchors.files == ("src/auth.py", "tests/test_auth.py")
+    assert [(ref.file_path, ref.line) for ref in anchors.line_refs] == [("src/auth.py", 12), ("tests/test_auth.py", 7)]
+
+
+def test_extract_file_read_anchor_and_python_symbols() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "Get-Content src/auth.py"},
+        tool_response="class AuthService:\n    pass\n\nasync def refresh_token():\n    return True\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "file_read"
+    assert anchors.files == ("src/auth.py",)
+    assert anchors.symbols == ("AuthService", "refresh_token")
+
+
+def test_extract_git_diff_changed_files() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "git diff"},
+        tool_response="diff --git a/src/auth.py b/src/auth.py\n--- a/src/auth.py\n+++ b/src/auth.py\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "git_diff"
+    assert anchors.files == ("src/auth.py",)
+
+
+def test_extract_pytest_failure_files_and_errors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "python -m pytest"},
+        tool_response="FAILED tests/test_auth.py::test_login - AssertionError: bad redirect\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "test_output"
+    assert anchors.files == ("tests/test_auth.py",)
+    assert anchors.errors == ("FAILED tests/test_auth.py::test_login - AssertionError: bad redirect",)

--- a/tests/application/semantic_harness/test_tool_context_planner.py
+++ b/tests/application/semantic_harness/test_tool_context_planner.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.application.services.semantic_harness import SemanticHarnessRuntimeService
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import CapturedToolResult
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import ToolContextPlanner
+
+
+def test_file_read_replay_generates_grounded_shadow_attach(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "auth.py").write_text("def login():\n    return True\n", encoding="utf-8")
+    runtime = SemanticHarnessRuntimeService()
+    runtime.bootstrap_repo(repo, repo_id="repo:test")
+    planner = ToolContextPlanner(runtime=runtime)
+
+    decision = planner.plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "Get-Content src/auth.py"},
+            tool_response="def login():\n    return True\n",
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.mode == "shadow"
+    assert decision.tool_kind == "file_read"
+    assert decision.would_attach is True
+    assert decision.would_replace is False
+    assert decision.confidence >= 0.75
+    assert decision.anchors.files == ("src/auth.py",)
+    assert decision.harness_response["status"] == "partial_structural"
+
+
+def test_unknown_tool_without_anchors_suppresses() -> None:
+    planner = ToolContextPlanner(runtime=SemanticHarnessRuntimeService())
+
+    decision = planner.plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="unknown_tool",
+            tool_input={},
+            tool_response="ok",
+        ),
+    )
+
+    assert decision.would_attach is False
+    assert "no_extracted_anchors" in decision.suppression_reasons
+    assert "status:unavailable" in decision.suppression_reasons
+
+
+def test_missing_graph_returns_unavailable_fast_and_suppresses() -> None:
+    planner = ToolContextPlanner(runtime=SemanticHarnessRuntimeService())
+
+    decision = planner.plan(
+        repo_id="repo:missing",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "Get-Content src/auth.py"},
+            tool_response="def login():\n    return True\n",
+        ),
+    )
+
+    assert decision.harness_response["status"] == "unavailable"
+    assert decision.would_attach is False
+    assert "status:unavailable" in decision.suppression_reasons

--- a/tests/runtime/cli/test_semantic_harness_cli.py
+++ b/tests/runtime/cli/test_semantic_harness_cli.py
@@ -120,6 +120,9 @@ def test_amo_harness_shadow_replay_reads_post_tool_use_rows(tmp_path, monkeypatc
     assert payload["ok"] is True
     assert payload["shadow_only"] is True
     assert payload["record_count"] == 1
+    assert payload["metrics"]["token_overhead_p95"] > 0
+    assert payload["metrics"]["acceptance_thresholds"]["p95_shadow_latency_ms"] == 500
+    assert payload["metrics"]["by_tool_kind"]["file_read"]["suppress_rate"] == 0.0
     assert payload["records"][0]["decision"]["would_attach"] is True
     assert payload["records"][0]["decision"]["would_replace"] is False
     assert payload["records"][0]["captured"]["raw_output_hash"]

--- a/tests/runtime/cli/test_semantic_harness_cli.py
+++ b/tests/runtime/cli/test_semantic_harness_cli.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+
+from agent_memory_orchestrator.runtime.cli.commands.semantic_harness import main as harness_main
+from agent_memory_orchestrator.runtime.cli.main import main
+
+
+def test_amo_harness_bootstrap_warms_persistent_graph(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AMO_HOME", str(tmp_path / "amo"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "auth.py").write_text("def login():\n    return True\n", encoding="utf-8")
+    db_path = tmp_path / "harness.sqlite"
+
+    status = main(
+        [
+            "amo-harness",
+            "bootstrap",
+            "--repo",
+            str(repo),
+            "--repo-id",
+            "repo:test",
+            "--db-path",
+            str(db_path),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert status == 0
+    assert payload["ok"] is True
+    assert payload["repo_id"] == "repo:test"
+    assert payload["file_count"] == 1
+    assert payload["projection_document_count"] > 0
+    assert db_path.exists()
+
+
+def test_direct_amo_harness_script_bootstrap_uses_same_command(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AMO_HOME", str(tmp_path / "amo"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Repo\n", encoding="utf-8")
+
+    status = harness_main(
+        [
+            "bootstrap",
+            "--repo",
+            str(repo),
+            "--repo-id",
+            "repo:test",
+            "--db-path",
+            str(tmp_path / "harness.sqlite"),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert status == 0
+    assert payload["ok"] is True
+    assert payload["command"] == "amo-harness bootstrap"

--- a/tests/runtime/cli/test_semantic_harness_cli.py
+++ b/tests/runtime/cli/test_semantic_harness_cli.py
@@ -58,3 +58,106 @@ def test_direct_amo_harness_script_bootstrap_uses_same_command(tmp_path, monkeyp
     assert status == 0
     assert payload["ok"] is True
     assert payload["command"] == "amo-harness bootstrap"
+
+
+def test_amo_harness_shadow_replay_reads_post_tool_use_rows(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AMO_HOME", str(tmp_path / "amo"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "auth.py").write_text("def login():\n    return True\n", encoding="utf-8")
+    db_path = tmp_path / "harness.sqlite"
+    evidence_path = tmp_path / "evidence.jsonl"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "payload": {
+                    "hook_event_name": "PostToolUse",
+                    "tool_name": "shell_command",
+                    "tool_input": {"command": "Get-Content src/auth.py"},
+                    "tool_response": "def login():\n    return True\n",
+                    "cwd": str(repo),
+                    "session_id": "session-1",
+                    "turn_id": "turn-1",
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    bootstrap_status = main(
+        [
+            "amo-harness",
+            "bootstrap",
+            "--repo",
+            str(repo),
+            "--repo-id",
+            "repo:test",
+            "--db-path",
+            str(db_path),
+        ]
+    )
+    _ = capsys.readouterr()
+
+    status = main(
+        [
+            "amo-harness",
+            "shadow-replay",
+            "--repo-id",
+            "repo:test",
+            "--evidence",
+            str(evidence_path),
+            "--db-path",
+            str(db_path),
+            "--out",
+            str(tmp_path / "shadow.json"),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert bootstrap_status == 0
+    assert status == 0
+    assert payload["ok"] is True
+    assert payload["shadow_only"] is True
+    assert payload["record_count"] == 1
+    assert payload["records"][0]["decision"]["would_attach"] is True
+    assert payload["records"][0]["decision"]["would_replace"] is False
+    assert payload["records"][0]["captured"]["raw_output_hash"]
+    assert (tmp_path / "shadow.json").exists()
+
+
+def test_amo_harness_shadow_replay_missing_graph_reports_unavailable(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AMO_HOME", str(tmp_path / "amo"))
+    evidence_path = tmp_path / "evidence.jsonl"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "payload": {
+                    "hook_event_name": "PostToolUse",
+                    "tool_name": "shell_command",
+                    "tool_input": {"command": "Get-Content src/auth.py"},
+                    "tool_response": "def login():\n    return True\n",
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    status = harness_main(
+        [
+            "shadow-replay",
+            "--repo-id",
+            "repo:missing",
+            "--evidence",
+            str(evidence_path),
+            "--db-path",
+            str(tmp_path / "harness.sqlite"),
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert status == 0
+    assert payload["record_count"] == 1
+    assert payload["records"][0]["harness_response"]["status"] == "unavailable"
+    assert payload["records"][0]["decision"]["would_attach"] is False


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `amo-harness` CLI command with `bootstrap` and `shadow-replay` subcommands for semantic harness operations.
  * Implemented tool context analysis to extract and classify tool result anchors.
  * Added shadow replay service for evaluating tool evidence and generating overlay decisions.

* **Tests**
  * Added test coverage for tool context extraction, planning, and CLI operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->