### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/service.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/runtime/service.py
@@ -31,6 +31,7 @@ class SemanticHarnessRuntimeService:
         self._graph_repository = graph_repository or InMemoryHarnessGraphRepository()
         self._projection_cache = projection_cache or InMemoryProjectionCache()
         self._structural = structural or StructuralHarnessService(projection_cache=self._projection_cache)
+        self._graph_cache: dict[str, StructuralHarnessGraph] = {}
 
     def bootstrap_repo(
         self,
@@ -41,6 +42,7 @@ class SemanticHarnessRuntimeService:
     ) -> HarnessRuntimeBootstrapResult:
         bootstrap = self._structural.bootstrap_repo(repo_root, repo_id=repo_id, options=options)
         self._graph_repository.replace_from_graph(bootstrap.graph)
+        self._graph_cache[bootstrap.graph.repo_id] = bootstrap.graph
         projection = self._projection_cache.get_or_build(bootstrap.graph)
         snapshot = graph_snapshot_identity(bootstrap.graph)
         return HarnessRuntimeBootstrapResult(
@@ -55,8 +57,15 @@ class SemanticHarnessRuntimeService:
         )
 
     def load_graph(self, repo_id: str) -> StructuralHarnessGraph | None:
+        cached = self._graph_cache.get(repo_id)
+        if cached is not None:
+            return cached
         store = self._graph_repository.load(repo_id)
-        return store.to_graph() if store is not None else None
+        if store is None:
+            return None
+        graph = store.to_graph()
+        self._graph_cache[repo_id] = graph
+        return graph
 
     def query(self, repo_id: str, request: HarnessQueryRequest) -> HarnessQueryResponse:
         graph = self.load_graph(repo_id)
@@ -79,6 +88,7 @@ class SemanticHarnessRuntimeService:
             raise ValueError(f"repo_not_bootstrapped:{delta.repo_id}")
         apply_result = apply_graph_update_delta(store, delta)
         graph = store.to_graph()
+        self._graph_cache[delta.repo_id] = graph
         projection = self._projection_cache.get_or_build(graph)
         return HarnessRuntimeDeltaApplyResult(
             repo_id=delta.repo_id,

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
@@ -34,6 +34,8 @@ PATH_SUFFIXES = {
     ".sql",
 }
 
+REPO_ROOT_SEGMENTS = ("src", "tests", "docs", "npm", "scripts", "apps")
+
 ERROR_PATTERNS = (
     "traceback",
     "assertionerror",
@@ -151,6 +153,8 @@ def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
         return ""
     try:
         path = Path(cleaned)
+        if path.is_absolute() and cwd is None:
+            return ""
         if path.is_absolute() and cwd is not None:
             try:
                 cleaned = str(path.resolve().relative_to(cwd)).replace("\\", "/")
@@ -158,12 +162,30 @@ def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
                 return ""
     except OSError:
         return ""
+    cleaned = _strip_workspace_prefix(cleaned)
+    lowered_cleaned = cleaned.lower()
+    if lowered_cleaned.startswith(("users/", "windows/", "program files/", "program files (x86)/")):
+        return ""
+    if "/appdata/" in lowered_cleaned or "/.codex/" in lowered_cleaned:
+        return ""
     if cleaned.startswith("../") or "/.git/" in cleaned or "/.codex/" in cleaned:
         return ""
     suffix = Path(cleaned).suffix.lower()
     if suffix not in PATH_SUFFIXES:
         return ""
     return normalize_file_path(cleaned)
+
+
+def _strip_workspace_prefix(value: str) -> str:
+    lowered = value.lower().lstrip("/")
+    if lowered.startswith(REPO_ROOT_SEGMENTS):
+        return value
+    for segment in REPO_ROOT_SEGMENTS:
+        marker = f"/{segment}/"
+        index = lowered.find(marker)
+        if index >= 0:
+            return value[index + 1 :]
+    return value
 
 
 def _python_symbols(text: str) -> list[str]:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
@@ -130,8 +130,8 @@ def _extract_paths(text: str, *, cwd: Path | None) -> list[str]:
     paths: list[str] = []
     patterns = (
         r"(?P<path>[A-Za-z]:[\\/][^\s'\"<>|]+)",
-        r"(?P<path>(?:src|tests|docs|npm|scripts|agent-memory-orchestrator)[\\/][\w .@()\-\\/]+\.[A-Za-z0-9]+)",
-        r"(?P<path>[\w .@()\-]+[\\/][\w .@()\-\\/]+\.[A-Za-z0-9]+)",
+        r"(?<![A-Za-z0-9_.-])(?P<path>(?:src|tests|docs|npm|scripts|apps)[\\/][^\s'\"<>|:]+\.[A-Za-z0-9]+)",
+        r"(?<![A-Za-z0-9_.-])(?P<path>\.?[\\/][^\s'\"<>|:]+\.[A-Za-z0-9]+)",
     )
     for pattern in patterns:
         for match in re.finditer(pattern, text):
@@ -142,7 +142,7 @@ def _extract_paths(text: str, *, cwd: Path | None) -> list[str]:
 
 
 def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
-    cleaned = value.strip().strip("'\"`").rstrip(",:;)]}>\r\n")
+    cleaned = value.strip().strip("'\"`").lstrip("([{<").rstrip(",:;)]}>\r\n")
     lowered = cleaned.lower()
     for prefix in ("get-content ", "cat ", "type ", "rg ", "ripgrep ", "grep ", "select-string "):
         if lowered.startswith(prefix):
@@ -156,10 +156,10 @@ def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
         if path.is_absolute() and cwd is None:
             return ""
         if path.is_absolute() and cwd is not None:
-            try:
-                cleaned = str(path.resolve().relative_to(cwd)).replace("\\", "/")
-            except ValueError:
+            relative = _absolute_path_relative_to_cwd(cleaned, cwd)
+            if not relative:
                 return ""
+            cleaned = relative
     except OSError:
         return ""
     cleaned = _strip_workspace_prefix(cleaned)
@@ -169,6 +169,8 @@ def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
     if "/appdata/" in lowered_cleaned or "/.codex/" in lowered_cleaned:
         return ""
     if cleaned.startswith("../") or "/.git/" in cleaned or "/.codex/" in cleaned:
+        return ""
+    if not _has_repo_root_segment(cleaned):
         return ""
     suffix = Path(cleaned).suffix.lower()
     if suffix not in PATH_SUFFIXES:
@@ -186,6 +188,31 @@ def _strip_workspace_prefix(value: str) -> str:
         if index >= 0:
             return value[index + 1 :]
     return value
+
+
+def _absolute_path_relative_to_cwd(value: str, cwd: Path) -> str:
+    candidate = _path_text(value)
+    cwd_text = _path_text(str(cwd))
+    candidate_lower = candidate.lower().rstrip("/")
+    cwd_lower = cwd_text.lower().rstrip("/")
+    if candidate_lower == cwd_lower:
+        return ""
+    prefix = cwd_lower + "/"
+    if not candidate_lower.startswith(prefix):
+        return ""
+    return candidate[len(cwd_text.rstrip("/")) + 1 :]
+
+
+def _path_text(value: str) -> str:
+    cleaned = value.replace("\\", "/")
+    if cleaned.startswith("//?/"):
+        cleaned = cleaned[4:]
+    return cleaned
+
+
+def _has_repo_root_segment(value: str) -> bool:
+    lowered = value.lower().lstrip("./")
+    return lowered.startswith(tuple(f"{segment}/" for segment in REPO_ROOT_SEGMENTS))
 
 
 def _python_symbols(text: str) -> list[str]:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
@@ -9,6 +9,7 @@ from agent_memory_orchestrator.application.services.semantic_harness.runtime imp
 from agent_memory_orchestrator.domain.semantic_harness import HarnessCard
 from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
 from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryResponse
+from agent_memory_orchestrator.domain.semantic_harness import resolve_anchors
 
 from .extract import classify_tool_kind
 from .extract import extract_tool_result_anchors
@@ -72,11 +73,7 @@ class ToolContextPlanner:
         parse_ms = _elapsed_ms(parse_start)
 
         query_start = time.perf_counter()
-        response = (
-            _no_anchor_response(request)
-            if not anchors.has_any
-            else self._runtime.query(repo_id, request)
-        )
+        response = self._response_for_overlay(repo_id=repo_id, request=request, anchors=anchors)
         query_ms = _elapsed_ms(query_start)
 
         decision_start = time.perf_counter()
@@ -142,6 +139,23 @@ class ToolContextPlanner:
             session_id=captured.session_id,
             already_seen_card_ids=already_seen_card_ids,
         )
+
+    def _response_for_overlay(
+        self,
+        *,
+        repo_id: str,
+        request: HarnessQueryRequest,
+        anchors: ToolResultAnchors,
+    ) -> HarnessQueryResponse:
+        if not anchors.has_any:
+            return _no_anchor_response(request)
+        graph = self._runtime.load_graph(repo_id)
+        if graph is None:
+            return _missing_graph_response(request, repo_id)
+        resolved = resolve_anchors(graph, files=request.files, symbols=request.symbols)
+        if not resolved.resolved:
+            return _ungrounded_anchor_response(request, unresolved=resolved.unresolved)
+        return self._runtime.query(repo_id, request)
 
 
 def _suppression_reasons(
@@ -236,6 +250,35 @@ def _no_anchor_response(request: HarnessQueryRequest) -> HarnessQueryResponse:
         next_actions=(),
         trace={"nodes": [], "edges": [], "versions": [], "occurrences": []},
         warnings=("no_extracted_anchors",),
+    )
+
+
+def _missing_graph_response(request: HarnessQueryRequest, repo_id: str) -> HarnessQueryResponse:
+    return HarnessQueryResponse(
+        status="unavailable",
+        intent_requested=request.intent,
+        intent_used=request.intent,
+        intent_correction=None,
+        cards=(),
+        next_actions=(),
+        trace={"nodes": [], "edges": [], "versions": [], "occurrences": []},
+        warnings=(f"repo_not_bootstrapped:{repo_id}",),
+    )
+
+
+def _ungrounded_anchor_response(request: HarnessQueryRequest, *, unresolved: tuple[str, ...]) -> HarnessQueryResponse:
+    warning = "ungrounded_tool_anchors"
+    if unresolved:
+        warning += ":" + ",".join(unresolved)
+    return HarnessQueryResponse(
+        status="unavailable",
+        intent_requested=request.intent,
+        intent_used=request.intent,
+        intent_correction=None,
+        cards=(),
+        next_actions=(),
+        trace={"nodes": [], "edges": [], "versions": [], "occurrences": []},
+        warnings=(warning,),
     )
 
 

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
@@ -34,7 +34,7 @@ _INTENT_BY_TOOL_KIND = {
 
 @dataclass(slots=True, frozen=True)
 class ToolContextPlannerOptions:
-    max_cards: int = 5
+    max_cards: int = 3
     max_tokens: int = 900
     max_latency_ms: int = 500
     detail: str = "strict"
@@ -72,7 +72,11 @@ class ToolContextPlanner:
         parse_ms = _elapsed_ms(parse_start)
 
         query_start = time.perf_counter()
-        response = self._runtime.query(repo_id, request)
+        response = (
+            _no_anchor_response(request)
+            if not anchors.has_any
+            else self._runtime.query(repo_id, request)
+        )
         query_ms = _elapsed_ms(query_start)
 
         decision_start = time.perf_counter()
@@ -123,7 +127,7 @@ class ToolContextPlanner:
             intent=intent,
             user_goal=f"Interpret {tool_kind} result for coding-agent harness overlay.",
             files=anchors.files,
-            symbols=anchors.symbols,
+            symbols=() if tool_kind == "file_read" and anchors.files else anchors.symbols,
             errors=anchors.errors,
             recent_tool_result={
                 "tool_name": captured.tool_name,
@@ -220,6 +224,19 @@ def _request_as_dict(request: HarnessQueryRequest) -> dict[str, Any]:
             "already_seen_card_ids": list(request.already_seen_card_ids),
         },
     }
+
+
+def _no_anchor_response(request: HarnessQueryRequest) -> HarnessQueryResponse:
+    return HarnessQueryResponse(
+        status="unavailable",
+        intent_requested=request.intent,
+        intent_used=request.intent,
+        intent_correction=None,
+        cards=(),
+        next_actions=(),
+        trace={"nodes": [], "edges": [], "versions": [], "occurrences": []},
+        warnings=("no_extracted_anchors",),
+    )
 
 
 def _elapsed_ms(start: float) -> int:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/replay.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/replay.py
@@ -36,7 +36,7 @@ class ShadowToolReplayService:
             records.append(
                 ToolOverlayEvalRecord(
                     decision=decision,
-                    judgment=_automatic_judgment(decision_targets(decision.harness_response), captured[index + 1 :]),
+                    judgment=_automatic_judgment(decision, captured[index + 1 :]),
                 )
             )
         return ShadowReplayReport(repo_id=repo_id, source_path=str(source_path), records=tuple(records))
@@ -61,7 +61,10 @@ def _read_captured_tool_results(path: Path, *, limit: int) -> list[CapturedToolR
     return captured
 
 
-def _automatic_judgment(targets: tuple[str, ...], future: tuple[CapturedToolResult, ...]) -> ToolOverlayJudgment:
+def _automatic_judgment(decision: object, future: tuple[CapturedToolResult, ...]) -> ToolOverlayJudgment:
+    if not getattr(decision, "would_attach", False):
+        return ToolOverlayJudgment(reason="suppressed_not_evaluated")
+    targets = decision_targets(getattr(decision, "harness_response", {}))
     if not targets:
         return ToolOverlayJudgment(reason="no_card_targets")
     first_three = future[:3]

--- a/src/agent_memory_orchestrator/domain/semantic_harness/doc_semantics/linking.py
+++ b/src/agent_memory_orchestrator/domain/semantic_harness/doc_semantics/linking.py
@@ -1,39 +1,56 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from functools import lru_cache
 
 from ..models import HarnessEdge
 from ..models import HarnessNode
 from .models import DocSemanticArtifact
 
 
+@dataclass(slots=True, frozen=True)
+class _FileMentionCandidate:
+    node: HarnessNode
+    path: str
+    lowered_paths: tuple[str, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class _SymbolMentionCandidate:
+    node: HarnessNode
+    candidates: tuple[tuple[str, str], ...]
+
+
 def link_doc_mentions(
     artifacts: tuple[DocSemanticArtifact, ...],
     nodes: dict[str, HarnessNode],
 ) -> tuple[HarnessEdge, ...]:
-    file_nodes = tuple(node for node in nodes.values() if node.kind == "File")
-    symbol_nodes = tuple(node for node in nodes.values() if node.kind == "Symbol")
+    file_candidates = _file_candidates(nodes)
+    symbol_candidates = _symbol_candidates(nodes)
     edges: list[HarnessEdge] = []
     seen: set[tuple[str, str, str]] = set()
     for artifact in artifacts:
         text = artifact.text
-        for file_node in file_nodes:
-            if _mentions_file(text, str(file_node.metadata.get("path") or file_node.label)):
+        lowered_text = text.lower()
+        for file_candidate in file_candidates:
+            if _mentions_file(lowered_text, file_candidate):
                 _append_edge(
                     edges,
                     seen,
                     HarnessEdge(
                         source_id=artifact.node.id,
-                        target_id=file_node.id,
+                        target_id=file_candidate.node.id,
                         kind="MENTIONS_FILE",
                         confidence=0.88,
-                        metadata={"match": str(file_node.metadata.get("path") or file_node.label), "match_type": "exact_path"},
+                        metadata={"match": file_candidate.path, "match_type": "exact_path"},
                     ),
                 )
-        for symbol_node in symbol_nodes:
-            if symbol_node.id == artifact.node.metadata.get("target_node_id"):
+        target_node_id = artifact.node.metadata.get("target_node_id")
+        for symbol_candidate in symbol_candidates:
+            if symbol_candidate.node.id == target_node_id:
                 continue
-            match_value = _symbol_match(text, symbol_node)
+            match_value = _symbol_match(text, lowered_text, symbol_candidate)
             if not match_value:
                 continue
             _append_edge(
@@ -41,7 +58,7 @@ def link_doc_mentions(
                 seen,
                 HarnessEdge(
                     source_id=artifact.node.id,
-                    target_id=symbol_node.id,
+                    target_id=symbol_candidate.node.id,
                     kind="MENTIONS_SYMBOL",
                     confidence=0.76,
                     metadata={"match": match_value, "match_type": "exact_symbol_label"},
@@ -50,24 +67,45 @@ def link_doc_mentions(
     return tuple(edges)
 
 
-def _mentions_file(text: str, path: str) -> bool:
-    normalized = path.replace("\\", "/").strip("/")
-    if not normalized:
-        return False
-    candidates = {normalized, normalized.replace("/", "\\")}
-    lowered = text.lower()
-    return any(candidate.lower() in lowered for candidate in candidates)
+def _file_candidates(nodes: dict[str, HarnessNode]) -> tuple[_FileMentionCandidate, ...]:
+    out: list[_FileMentionCandidate] = []
+    for node in nodes.values():
+        if node.kind != "File":
+            continue
+        path = str(node.metadata.get("path") or node.label).replace("\\", "/").strip("/")
+        if not path:
+            continue
+        lowered_paths = tuple(dict.fromkeys((path.lower(), path.replace("/", "\\").lower())))
+        out.append(_FileMentionCandidate(node=node, path=path, lowered_paths=lowered_paths))
+    return tuple(out)
 
 
-def _symbol_match(text: str, node: HarnessNode) -> str:
-    candidates = []
-    qualified_name = str(node.metadata.get("qualified_name") or node.label).strip()
-    if qualified_name:
-        candidates.append(qualified_name)
-    short_name = qualified_name.rsplit(".", 1)[-1] if qualified_name else str(node.label)
-    if len(short_name) >= 4:
-        candidates.append(short_name)
-    for candidate in _dedupe(candidates):
+def _mentions_file(lowered_text: str, candidate: _FileMentionCandidate) -> bool:
+    return any(path in lowered_text for path in candidate.lowered_paths)
+
+
+def _symbol_candidates(nodes: dict[str, HarnessNode]) -> tuple[_SymbolMentionCandidate, ...]:
+    out: list[_SymbolMentionCandidate] = []
+    for node in nodes.values():
+        if node.kind != "Symbol":
+            continue
+        candidates: list[str] = []
+        qualified_name = str(node.metadata.get("qualified_name") or node.label).strip()
+        if qualified_name:
+            candidates.append(qualified_name)
+        short_name = qualified_name.rsplit(".", 1)[-1] if qualified_name else str(node.label)
+        if len(short_name) >= 4:
+            candidates.append(short_name)
+        pairs = tuple((candidate, candidate.lower()) for candidate in _dedupe(candidates))
+        if pairs:
+            out.append(_SymbolMentionCandidate(node=node, candidates=pairs))
+    return tuple(out)
+
+
+def _symbol_match(text: str, lowered_text: str, symbol_candidate: _SymbolMentionCandidate) -> str:
+    for candidate, lowered_candidate in symbol_candidate.candidates:
+        if lowered_candidate not in lowered_text:
+            continue
         if _contains_tokenish(text, candidate):
             return candidate
     return ""
@@ -76,8 +114,13 @@ def _symbol_match(text: str, node: HarnessNode) -> str:
 def _contains_tokenish(text: str, candidate: str) -> bool:
     if not candidate:
         return False
+    return _tokenish_pattern(candidate).search(text) is not None
+
+
+@lru_cache(maxsize=8192)
+def _tokenish_pattern(candidate: str) -> re.Pattern[str]:
     pattern = r"(?<![A-Za-z0-9_])" + re.escape(candidate) + r"(?![A-Za-z0-9_.])"
-    return re.search(pattern, text, flags=re.IGNORECASE) is not None
+    return re.compile(pattern, flags=re.IGNORECASE)
 
 
 def _append_edge(edges: list[HarnessEdge], seen: set[tuple[str, str, str]], edge: HarnessEdge) -> None:

--- a/tests/application/semantic_harness/test_runtime_service.py
+++ b/tests/application/semantic_harness/test_runtime_service.py
@@ -6,8 +6,11 @@ from agent_memory_orchestrator.application.services.semantic_harness import Sema
 from agent_memory_orchestrator.domain.semantic_harness import CommitHunk
 from agent_memory_orchestrator.domain.semantic_harness import CommitWorkWindow
 from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.domain.semantic_harness import HarnessNode
 from agent_memory_orchestrator.domain.semantic_harness import HunkRange
+from agent_memory_orchestrator.domain.semantic_harness import StructuralHarnessGraph
 from agent_memory_orchestrator.domain.semantic_harness import build_commit_update_delta
+from agent_memory_orchestrator.domain.semantic_harness import file_id
 
 
 def test_runtime_bootstrap_persists_graph_and_answers_query(tmp_path) -> None:
@@ -50,6 +53,33 @@ def test_runtime_query_returns_unavailable_for_missing_repo() -> None:
     assert response.warnings == ("repo_not_bootstrapped:repo:missing",)
 
 
+def test_runtime_caches_loaded_graph_for_repeated_queries() -> None:
+    graph = StructuralHarnessGraph(
+        repo_id="repo:test",
+        nodes=(
+            HarnessNode(
+                id=file_id("repo:test", "src/auth.py"),
+                kind="File",
+                label="src/auth.py",
+                repo_id="repo:test",
+                status="active",
+                metadata={"path": "src/auth.py"},
+            ),
+        ),
+        edges=(),
+    )
+    store = _CountingGraphStore(graph)
+    runtime = SemanticHarnessRuntimeService(graph_repository=_SingleGraphRepository(store))
+    request = HarnessQueryRequest(intent="file_context", user_goal="inspect auth", files=("src/auth.py",))
+
+    first = runtime.query("repo:test", request)
+    second = runtime.query("repo:test", request)
+
+    assert first.status == "partial_structural"
+    assert second.status == "partial_structural"
+    assert store.to_graph_calls == 1
+
+
 def test_runtime_apply_delta_updates_persisted_graph_and_projection(tmp_path) -> None:
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "auth.py").write_text("def login():\n    return False\n", encoding="utf-8")
@@ -83,3 +113,31 @@ def test_runtime_apply_delta_updates_persisted_graph_and_projection(tmp_path) ->
     assert applied.projection.graph_snapshot_id == applied.graph_snapshot.graph_snapshot_id
     assert updated_graph is not None
     assert delta.commit_id in {node.id for node in updated_graph.nodes}
+
+
+class _CountingGraphStore:
+    def __init__(self, graph: StructuralHarnessGraph) -> None:
+        self._graph = graph
+        self.to_graph_calls = 0
+
+    @property
+    def repo_id(self) -> str:
+        return self._graph.repo_id
+
+    def to_graph(self) -> StructuralHarnessGraph:
+        self.to_graph_calls += 1
+        return self._graph
+
+
+class _SingleGraphRepository:
+    def __init__(self, store: _CountingGraphStore) -> None:
+        self._store = store
+
+    def load(self, repo_id: str) -> _CountingGraphStore | None:
+        if repo_id == self._store.repo_id:
+            return self._store
+        return None
+
+    def replace_from_graph(self, graph: StructuralHarnessGraph) -> _CountingGraphStore:
+        self._store = _CountingGraphStore(graph)
+        return self._store

--- a/tests/application/semantic_harness/test_tool_context_extract.py
+++ b/tests/application/semantic_harness/test_tool_context_extract.py
@@ -58,3 +58,43 @@ def test_extract_pytest_failure_files_and_errors() -> None:
     assert classify_tool_kind(captured) == "test_output"
     assert anchors.files == ("tests/test_auth.py",)
     assert anchors.errors == ("FAILED tests/test_auth.py::test_login - AssertionError: bad redirect",)
+
+
+def test_external_absolute_paths_are_not_repo_anchors_without_cwd() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": r"Get-Content C:\Users\sumit\.codex\skills\SKILL.md"},
+        tool_response="# Skill\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ()
+
+
+def test_workspace_parent_prefix_is_stripped_to_repo_relative_path() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "Get-ChildItem"},
+        tool_response=(
+            r"C:\Users\sumit\Downloads\Dora\agent-memory-orchestrator"
+            r"\src\agent_memory_orchestrator\runtime\hook\launcher.py"
+        ),
+        cwd=r"C:\Users\sumit\Downloads\Dora",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ("src/agent_memory_orchestrator/runtime/hook/launcher.py",)
+
+
+def test_appdata_cache_paths_are_not_repo_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": r"node C:\Users\sumit\.codex\skills\fetch.mjs"},
+        tool_response=r"C:\Users\sumit\AppData\Local\Temp\openai-docs-cache\codex-manual.md",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ()

--- a/tests/application/semantic_harness/test_tool_context_extract.py
+++ b/tests/application/semantic_harness/test_tool_context_extract.py
@@ -72,6 +72,19 @@ def test_external_absolute_paths_are_not_repo_anchors_without_cwd() -> None:
     assert anchors.files == ()
 
 
+def test_external_skill_path_does_not_become_docs_anchor_with_cwd() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": r"Get-Content C:\Users\sumit\.codex\skills\.system\openai-docs\SKILL.md"},
+        tool_response="# OpenAI docs skill\n",
+        cwd=r"C:\Users\sumit\Downloads\Dora",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ()
+
+
 def test_workspace_parent_prefix_is_stripped_to_repo_relative_path() -> None:
     captured = CapturedToolResult(
         tool_name="shell_command",
@@ -93,6 +106,30 @@ def test_appdata_cache_paths_are_not_repo_anchors() -> None:
         tool_name="shell_command",
         tool_input={"command": r"node C:\Users\sumit\.codex\skills\fetch.mjs"},
         tool_response=r"C:\Users\sumit\AppData\Local\Temp\openai-docs-cache\codex-manual.md",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ()
+
+
+def test_prose_mentions_are_not_file_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "Get-Content evidence.jsonl"},
+        tool_response="Implemented scraper/retry.py and discussed future fixes.",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ()
+
+
+def test_codex_manual_links_are_not_repo_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "Get-Content codex-manual.md"},
+        tool_response="See (/codex/mcp.md), (/codex/hooks.md), and .codex/config.toml.",
     )
 
     anchors = extract_tool_result_anchors(captured)

--- a/tests/application/semantic_harness/test_tool_context_planner.py
+++ b/tests/application/semantic_harness/test_tool_context_planner.py
@@ -68,6 +68,30 @@ def test_missing_graph_returns_unavailable_fast_and_suppresses() -> None:
     assert "status:unavailable" in decision.suppression_reasons
 
 
+def test_unresolved_tool_anchors_do_not_trigger_fallback_cards(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "auth.py").write_text("def login():\n    return True\n", encoding="utf-8")
+    runtime = SemanticHarnessRuntimeService()
+    runtime.bootstrap_repo(repo, repo_id="repo:test")
+
+    decision = ToolContextPlanner(runtime=runtime).plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "Get-Content src/missing.py"},
+            tool_response="No such file or directory: src/missing.py",
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.harness_response["status"] == "unavailable"
+    assert decision.harness_response["cards"] == []
+    assert decision.harness_response["warnings"] == ["ungrounded_tool_anchors:file:src/missing.py"]
+    assert decision.would_attach is False
+
+
 def test_file_read_prefers_file_anchor_over_unresolved_content_symbols(tmp_path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/application/semantic_harness/test_tool_context_planner.py
+++ b/tests/application/semantic_harness/test_tool_context_planner.py
@@ -48,6 +48,7 @@ def test_unknown_tool_without_anchors_suppresses() -> None:
     assert decision.would_attach is False
     assert "no_extracted_anchors" in decision.suppression_reasons
     assert "status:unavailable" in decision.suppression_reasons
+    assert decision.latency.harness_query_ms == 0
 
 
 def test_missing_graph_returns_unavailable_fast_and_suppresses() -> None:
@@ -65,3 +66,26 @@ def test_missing_graph_returns_unavailable_fast_and_suppresses() -> None:
     assert decision.harness_response["status"] == "unavailable"
     assert decision.would_attach is False
     assert "status:unavailable" in decision.suppression_reasons
+
+
+def test_file_read_prefers_file_anchor_over_unresolved_content_symbols(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "hook.py").write_text("def captured_symbol():\n    return True\n", encoding="utf-8")
+    runtime = SemanticHarnessRuntimeService()
+    runtime.bootstrap_repo(repo, repo_id="repo:test")
+
+    decision = ToolContextPlanner(runtime=runtime).plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "Get-Content src/hook.py | Select-Object -First 5"},
+            tool_response="def captured_symbol():\n    pass\n\ndef symbol_not_in_graph():\n    pass\n",
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.harness_response["status"] == "partial_structural"
+    assert decision.would_attach is True
+    assert decision.token_overhead_estimate <= 900


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Semantic harness now caches graph data in memory, improving performance for repeated queries on the same repository.

* **Bug Fixes**
  * Tool anchor extraction is stricter: rejects external paths, system directories, and requires valid repository structure markers.
  * Improved validation of tool-result anchors before semantic queries with early exit handling for unavailable cases.

* **Changes**
  * Reduced default result cards from 5 to 3 for more focused output.

* **Tests**
  * Added coverage for in-memory graph caching and anchor extraction validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->