### PR TITLE
Peer frictionless relay ux

### DIFF
--- a/docs/semantic_harness/04-agent-tool-contract.md
+++ b/docs/semantic_harness/04-agent-tool-contract.md
@@ -41,3 +41,23 @@ The harness must:
 ## Output Discipline
 
 Cards must be short by default. Long narrative belongs only to `why_changed` or `detail=deep`.
+
+## Tool Overlay Discipline
+
+`tool_overlay` must add new graph-grounded context, not echo the raw tool result.
+
+Attach only when the card adds one of:
+
+- a graph-grounded file or symbol the agent has not already inspected
+- documented support or constraints
+- dependency, impact, or validation context
+- high-confidence patch, diff, or failing-test guidance
+
+Suppress when the overlay would only repeat the current tool result:
+
+- file read already opened the exact file and the only card is `Inspect <same file>`
+- inventory/status output such as `git status`, `git branch`, `git ls-files`, or `Test-Path` only prints paths
+- successful test output has no failing file, traceback, or assertion anchor
+- card evidence is vector-only or otherwise not graph-grounded
+
+This keeps sidecar context useful under token budget and prevents model-visible noise.

--- a/docs/semantic_harness/04-agent-tool-contract.md
+++ b/docs/semantic_harness/04-agent-tool-contract.md
@@ -56,6 +56,7 @@ Attach only when the card adds one of:
 Suppress when the overlay would only repeat the current tool result:
 
 - file read already opened the exact file and the only card is `Inspect <same file>`
+- broad search output has many matched files and the only cards are exact-anchor `next_file` echoes
 - inventory/status output such as `git status`, `git branch`, `git ls-files`, or `Test-Path` only prints paths
 - successful test output has no failing file, traceback, or assertion anchor
 - card evidence is vector-only or otherwise not graph-grounded

--- a/docs/semantic_harness/08-commit-update-pipeline.md
+++ b/docs/semantic_harness/08-commit-update-pipeline.md
@@ -19,7 +19,7 @@ After an agent completes work, the harness updates versions, relation evidence, 
 ```text
 1. Resolve work window boundaries.
 2. Resolve repo_id and commit_id.
-3. Extract hunks and touched files.
+3. Extract zero-context hunks or changed-line ranges and touched files.
 4. Parse old and new file snapshots where available.
 5. Map hunks to Symbol or CodeRegion with confidence.
 6. Create FileVersion, SymbolVersion, and CodeRegionVersion nodes.
@@ -43,6 +43,17 @@ After an agent completes work, the harness updates versions, relation evidence, 
 ## Qwen Unavailable Mode
 
 If Qwen is unavailable or rejected, deterministic stages still complete. Semantic fields are marked missing or pending. Structural cards remain available.
+
+## Hunk Context Rule
+
+Graph mutation uses changed-line ranges only. The commit-update mapper must not use broad Git context as the hunk span because wide context can overlap unrelated nearby symbols and turn a precise edit into `review_only`.
+
+Broader context is still required, but it belongs in work-window/Qwen packets:
+
+```text
+changed-line hunk -> deterministic version and relation update
+broad work window -> semantic explanation and Qwen proposal input
+```
 
 ## Outputs
 

--- a/docs/semantic_harness/14-sidecar-interception-future.md
+++ b/docs/semantic_harness/14-sidecar-interception-future.md
@@ -40,6 +40,10 @@ test_output:
   attach only when failing files, traceback lines, or assertion anchors are graph-grounded
   suppress successful output with no anchors
 
+search:
+  suppress broad search output when many files match and the only cards are exact-anchor next_file echoes
+  attach only when the harness adds a stronger graph-grounded signal than the raw result list
+
 git_diff / apply_patch:
   attach concise risk cards for graph-grounded changed files
   suppress duplicate cards already seen in the session

--- a/docs/semantic_harness/14-sidecar-interception-future.md
+++ b/docs/semantic_harness/14-sidecar-interception-future.md
@@ -28,3 +28,24 @@ real-session eval passes on rich and partial fixtures
 ## Sidecar Output Rule
 
 Sidecar mode may attach cards but must not block raw tool results. If card confidence is weak, it should attach no card and record an eval event.
+
+Sidecar mode must not attach cards that only restate the visible tool result. The first implemented shadow rules are:
+
+```text
+file_read:
+  suppress same-file-only cards such as "Inspect <file just opened>"
+  attach only if extra graph context remains, such as docs, dependencies, history, or validation guidance
+
+test_output:
+  attach only when failing files, traceback lines, or assertion anchors are graph-grounded
+  suppress successful output with no anchors
+
+git_diff / apply_patch:
+  attach concise risk cards for graph-grounded changed files
+  suppress duplicate cards already seen in the session
+
+unknown / inventory:
+  suppress path-only inventory/status output from git status, git branch, git ls-files, and Test-Path
+```
+
+These rules keep the sidecar append-only path conservative until real-session eval proves higher signal.

--- a/docs/semantic_harness/16-evaluation-real-sessions.md
+++ b/docs/semantic_harness/16-evaluation-real-sessions.md
@@ -110,6 +110,60 @@ expected_agent_action = inspect ranking.py first, then query.py if the behavior 
 - bad Qwen frame is quarantined and does not affect cards
 - card feedback records shown, acted_on, ignored, or invalidated
 
+## Shadow Tool Overlay Eval
+
+Shadow replay must evaluate captured `PostToolUse` records without injecting anything into the agent context.
+
+Required tool-kind checks:
+
+```text
+file_read same-file-only card
+-> suppress
+-> suppression_reasons include redundant_file_read_card
+
+file_read with docs/dependencies/history remaining after same-file filtering
+-> may attach
+-> card evidence must be graph-grounded
+
+successful test output with no failing anchor
+-> suppress
+
+failing test output with graph-grounded file
+-> attach test_target card
+
+git_diff with graph-grounded changed file
+-> attach concise risk card
+
+apply_patch with graph-grounded changed file
+-> attach concise risk card once
+-> repeated same card suppresses with duplicate_card
+
+git status / git branch / git ls-files / Test-Path path inventory
+-> suppress as low-signal inventory
+```
+
+Current shadow replay reports must include:
+
+```text
+record_count
+attached_count
+suppressed_count
+manual_review_required_count
+auto_useful_count
+auto_mislead_candidate_count
+p95_shadow_latency_ms
+token_overhead_p95
+by_tool_kind suppress_rate
+```
+
+Interpretation rule:
+
+```text
+High suppress rate is acceptable for a tool kind when the available graph only produces redundant or low-confidence cards.
+Do not lower attach thresholds to satisfy a suppress-rate target.
+Improve graph/card quality first.
+```
+
 ## Historical Relation Card Gate
 
 `historical_relation` evals must check both strength and evidence count:

--- a/docs/semantic_harness/16-evaluation-real-sessions.md
+++ b/docs/semantic_harness/16-evaluation-real-sessions.md
@@ -134,6 +134,10 @@ failing test output with graph-grounded file
 git_diff with graph-grounded changed file
 -> attach concise risk card
 
+broad search with many matched files and only exact-anchor next_file cards
+-> suppress
+-> suppression_reasons include broad_search_anchor_only_card
+
 apply_patch with graph-grounded changed file
 -> attach concise risk card once
 -> repeated same card suppresses with duplicate_card

--- a/docs/semantic_harness/algorithms/hunk-to-symbol-confidence.md
+++ b/docs/semantic_harness/algorithms/hunk-to-symbol-confidence.md
@@ -21,14 +21,17 @@ Mappings to Symbol, CodeRegion, or review-only unresolved mapping.
 ## Algorithm
 
 ```text
-1. Parse old and new file snapshots.
-2. Build symbol spans and stable names.
-3. Intersect hunk old/new ranges with old/new spans.
-4. Compare structural diff and text diff.
-5. If one symbol contains the hunk in both snapshots, map to Symbol.
-6. If hunk is sub-symbol or non-symbol config/JSX/CSS/docs, create or reuse CodeRegion.
-7. If multiple entities overlap, emit review-only candidates.
+1. Read Git hunks with zero context or derive changed-line ranges from the patch.
+2. Parse old and new file snapshots.
+3. Build symbol spans and stable names.
+4. Intersect changed-line old/new ranges with old/new spans.
+5. Compare structural diff and text diff.
+6. If one symbol contains the changed lines in both snapshots, map to Symbol.
+7. If changed lines are sub-symbol or non-symbol config/JSX/CSS/docs, create or reuse CodeRegion.
+8. If multiple entities overlap the changed lines, emit review-only candidates.
 ```
+
+Mapping must not use wide context hunks. Broad context is useful for Qwen work-causality packets, but it is unsafe as graph mutation input because one small edit can overlap many nearby symbols and suppress version/relation updates.
 
 ## Confidence Scoring
 
@@ -36,7 +39,7 @@ Base `0.50` plus span containment `0.25`, old/new agreement `0.15`, signature st
 
 ## Failure Modes
 
-Parser failure maps file-level only. Multi-symbol hunks create multiple lower-confidence mappings. Formatting-only diffs can create structural-only mapping.
+Parser failure maps file-level only. Multi-symbol changed-line hunks create multiple lower-confidence mappings. Formatting-only diffs can create structural-only mapping. If only a wide-context diff is available, first reduce it to changed-line ranges before mapping.
 
 ## Product Usage
 
@@ -53,3 +56,5 @@ Input: hunk lines `45-67` in `auth.py`; old `login()` span `40-80`; new `login()
 Intermediate: hunk fully inside same symbol, signature unchanged, no competing overlap.
 
 Output: Symbol mapping `auth.py::login`, confidence `0.91`, reason `hunk falls within same symbol span in old and new parse`.
+
+Counterexample: a one-line edit inside `login()` is displayed with 80 lines of Git context and the context also includes `logout()` and `refresh()`. The mapper must score only the changed line, not the full displayed context. Otherwise the hunk becomes a false multi-symbol overlap and version/co-change edges are incorrectly withheld.

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/commit_update.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/commit_update.py
@@ -86,7 +86,10 @@ def _read_commit_diff(repo_root: Path, commit_sha: str) -> str:
         repo_root,
         "show",
         "--format=",
-        "--unified=80",
+        # Hunk-to-entity mapping needs changed-line spans, not broad context.
+        # Wider context belongs in semantic work-window packets, otherwise one
+        # small edit can overlap many symbols and suppress relation updates.
+        "--unified=0",
         "--find-renames",
         "--find-copies",
         commit_sha,

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/cards.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/cards.py
@@ -21,6 +21,8 @@ def enrich_tool_overlay_response(
 ) -> HarnessQueryResponse:
     """Add concise tool-specific cards after generic graph grounding succeeds."""
 
+    if tool_kind == "file_read":
+        return _drop_redundant_file_read_cards(request=request, response=response)
     if tool_kind not in ENRICHABLE_TOOL_KINDS:
         return response
     file_nodes = _grounded_file_nodes(graph, request)
@@ -32,6 +34,43 @@ def enrich_tool_overlay_response(
     if tool_card.card_id in set(request.already_seen_card_ids):
         return _append_warning(response, f"duplicate_tool_card:{tool_kind}")
     return _prepend_tool_card(response=response, request=request, tool_card=tool_card, tool_kind=tool_kind)
+
+
+def _drop_redundant_file_read_cards(
+    *,
+    request: HarnessQueryRequest,
+    response: HarnessQueryResponse,
+) -> HarnessQueryResponse:
+    anchored_files = set(request.files)
+    if not anchored_files:
+        return response
+    kept = tuple(card for card in response.cards if not _is_same_file_read_card(card, anchored_files))
+    if len(kept) == len(response.cards):
+        return response
+    return HarnessQueryResponse(
+        status=response.status,
+        intent_requested=response.intent_requested,
+        intent_used=response.intent_used,
+        intent_correction=response.intent_correction,
+        cards=kept,
+        next_actions=tuple(_next_action_for(card) for card in kept),
+        trace=response.trace,
+        warnings=tuple(dict.fromkeys((*response.warnings, "redundant_file_read_card"))),
+    )
+
+
+def _is_same_file_read_card(card: HarnessCard, anchored_files: set[str]) -> bool:
+    if card.type != "next_file":
+        return False
+    for evidence in card.evidence:
+        if path := evidence.get("path"):
+            return path in anchored_files
+    if card.next_action.startswith("Open "):
+        path = card.next_action.removeprefix("Open ").split(" and inspect", 1)[0]
+        return path in anchored_files
+    if card.title.startswith("Inspect "):
+        return card.title.removeprefix("Inspect ") in anchored_files
+    return False
 
 
 def _grounded_file_nodes(graph: StructuralHarnessGraph, request: HarnessQueryRequest) -> tuple[object, ...]:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/cards.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/cards.py
@@ -10,6 +10,7 @@ from agent_memory_orchestrator.domain.semantic_harness import resolve_anchors
 
 
 ENRICHABLE_TOOL_KINDS = {"apply_patch", "git_diff", "test_output"}
+BROAD_SEARCH_FILE_THRESHOLD = 8
 
 
 def enrich_tool_overlay_response(
@@ -23,6 +24,8 @@ def enrich_tool_overlay_response(
 
     if tool_kind == "file_read":
         return _drop_redundant_file_read_cards(request=request, response=response)
+    if tool_kind == "search":
+        return _drop_broad_search_cards(request=request, response=response)
     if tool_kind not in ENRICHABLE_TOOL_KINDS:
         return response
     file_nodes = _grounded_file_nodes(graph, request)
@@ -59,7 +62,35 @@ def _drop_redundant_file_read_cards(
     )
 
 
+def _drop_broad_search_cards(
+    *,
+    request: HarnessQueryRequest,
+    response: HarnessQueryResponse,
+) -> HarnessQueryResponse:
+    if len(request.files) < BROAD_SEARCH_FILE_THRESHOLD:
+        return response
+    kept = tuple(card for card in response.cards if not _is_exact_anchor_next_file_card(card, set(request.files)))
+    if len(kept) == len(response.cards):
+        return response
+    return HarnessQueryResponse(
+        status=response.status,
+        intent_requested=response.intent_requested,
+        intent_used=response.intent_used,
+        intent_correction=response.intent_correction,
+        cards=kept,
+        next_actions=tuple(_next_action_for(card) for card in kept),
+        trace=response.trace,
+        warnings=tuple(dict.fromkeys((*response.warnings, "broad_search_anchor_only_card"))),
+    )
+
+
 def _is_same_file_read_card(card: HarnessCard, anchored_files: set[str]) -> bool:
+    if card.type != "next_file":
+        return False
+    return _is_exact_anchor_next_file_card(card, anchored_files)
+
+
+def _is_exact_anchor_next_file_card(card: HarnessCard, anchored_files: set[str]) -> bool:
     if card.type != "next_file":
         return False
     for evidence in card.evidence:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/cards.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/cards.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.domain.semantic_harness import HarnessCard
+from agent_memory_orchestrator.domain.semantic_harness import HarnessNextAction
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryRequest
+from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryResponse
+from agent_memory_orchestrator.domain.semantic_harness import StructuralHarnessGraph
+from agent_memory_orchestrator.domain.semantic_harness import harness_card_id
+from agent_memory_orchestrator.domain.semantic_harness import resolve_anchors
+
+
+ENRICHABLE_TOOL_KINDS = {"apply_patch", "git_diff", "test_output"}
+
+
+def enrich_tool_overlay_response(
+    *,
+    graph: StructuralHarnessGraph,
+    request: HarnessQueryRequest,
+    response: HarnessQueryResponse,
+    tool_kind: str,
+) -> HarnessQueryResponse:
+    """Add concise tool-specific cards after generic graph grounding succeeds."""
+
+    if tool_kind not in ENRICHABLE_TOOL_KINDS:
+        return response
+    file_nodes = _grounded_file_nodes(graph, request)
+    if not file_nodes:
+        return response
+    tool_card = _tool_card_for_files(graph=graph, request=request, tool_kind=tool_kind, file_nodes=file_nodes)
+    if tool_card is None:
+        return response
+    if tool_card.card_id in set(request.already_seen_card_ids):
+        return _append_warning(response, f"duplicate_tool_card:{tool_kind}")
+    return _prepend_tool_card(response=response, request=request, tool_card=tool_card, tool_kind=tool_kind)
+
+
+def _grounded_file_nodes(graph: StructuralHarnessGraph, request: HarnessQueryRequest) -> tuple[object, ...]:
+    resolved = resolve_anchors(graph, files=request.files, symbols=())
+    node_by_id = graph.node_by_id()
+    out: list[object] = []
+    for anchor in resolved.resolved:
+        if anchor.kind != "File":
+            continue
+        node = node_by_id.get(anchor.node_id)
+        if node is not None:
+            out.append(node)
+    return tuple(out)
+
+
+def _tool_card_for_files(
+    *,
+    graph: StructuralHarnessGraph,
+    request: HarnessQueryRequest,
+    tool_kind: str,
+    file_nodes: tuple[object, ...],
+) -> HarnessCard | None:
+    visible_files = file_nodes[:3]
+    if not visible_files:
+        return None
+    labels = tuple(str(getattr(node, "label", "")) for node in visible_files)
+    target = labels[0]
+    count_suffix = "" if len(file_nodes) == 1 else f" + {len(file_nodes) - 1} more"
+    card_id = harness_card_id(graph.repo_id, request.session_id, request.intent, ("tool_context", tool_kind, *labels))
+    evidence = tuple(
+        {
+            "node_id": str(getattr(node, "id", "")),
+            "kind": str(getattr(node, "kind", "")),
+            "path": str(getattr(node, "metadata", {}).get("path") or getattr(node, "label", "")),
+        }
+        for node in visible_files
+    )
+    if tool_kind == "test_output":
+        if not request.errors:
+            return None
+        return HarnessCard(
+            card_id=card_id,
+            type="test_target",
+            title=f"Inspect failing test anchor {target}{count_suffix}",
+            why="Test output referenced graph-grounded files; use them as validation anchors before editing.",
+            evidence=evidence,
+            risk="Treat failing test output as the current validation signal; do not patch unrelated files first.",
+            confidence=0.86,
+            next_action=f"Open {target} and inspect the failing assertion or traceback.",
+        )
+    if tool_kind == "git_diff":
+        return HarnessCard(
+            card_id=card_id,
+            type="risk",
+            title=f"Review diff impact for {target}{count_suffix}",
+            why="git diff changed graph-grounded files; verify immediate context before committing or broadening the edit.",
+            evidence=evidence,
+            risk="Diff output can hide dependent tests or imports; inspect touched files before finalizing.",
+            confidence=0.8,
+            next_action=f"Inspect {target} and run the smallest relevant validation.",
+        )
+    return HarnessCard(
+        card_id=card_id,
+        type="risk",
+        title=f"Verify patch impact for {target}{count_suffix}",
+        why="The patch updated graph-grounded files; verify local context and related tests before continuing.",
+        evidence=evidence,
+        risk="A successful patch only proves text changed; it does not prove behavior or dependencies are safe.",
+        confidence=0.82,
+        next_action=f"Inspect {target} after the patch and run targeted validation.",
+    )
+
+
+def _prepend_tool_card(
+    *,
+    response: HarnessQueryResponse,
+    request: HarnessQueryRequest,
+    tool_card: HarnessCard,
+    tool_kind: str,
+) -> HarnessQueryResponse:
+    existing = tuple(card for card in response.cards if card.card_id != tool_card.card_id)
+    cards = (tool_card, *existing)[: max(1, request.max_cards)]
+    actions = (_next_action_for(tool_card), *response.next_actions)[: len(cards)]
+    return HarnessQueryResponse(
+        status=response.status,
+        intent_requested=response.intent_requested,
+        intent_used=response.intent_used,
+        intent_correction=response.intent_correction,
+        cards=cards,
+        next_actions=actions,
+        trace=_trace_with_card(response.trace, tool_card),
+        warnings=tuple(dict.fromkeys((*response.warnings, f"tool_context_enriched:{tool_kind}"))),
+    )
+
+
+def _next_action_for(card: HarnessCard) -> HarnessNextAction:
+    return HarnessNextAction(
+        action_type="inspect_file",
+        target=card.evidence[0].get("path") or card.evidence[0].get("node_id", card.title),
+        reason=card.why,
+        priority="recommended",
+    )
+
+
+def _trace_with_card(trace: dict[str, object], card: HarnessCard) -> dict[str, object]:
+    out = {
+        "nodes": list(trace.get("nodes") or []),
+        "edges": list(trace.get("edges") or []),
+        "versions": list(trace.get("versions") or []),
+        "occurrences": list(trace.get("occurrences") or []),
+    }
+    for evidence in card.evidence:
+        if node_id := evidence.get("node_id"):
+            if node_id not in out["nodes"]:
+                out["nodes"].append(node_id)
+    return out
+
+
+def _append_warning(response: HarnessQueryResponse, warning: str) -> HarnessQueryResponse:
+    return HarnessQueryResponse(
+        status=response.status,
+        intent_requested=response.intent_requested,
+        intent_used=response.intent_used,
+        intent_correction=response.intent_correction,
+        cards=response.cards,
+        next_actions=response.next_actions,
+        trace=response.trace,
+        warnings=tuple(dict.fromkeys((*response.warnings, warning))),
+    )
+
+
+__all__ = ["enrich_tool_overlay_response"]

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
@@ -88,6 +88,8 @@ def extract_tool_result_anchors(captured: CapturedToolResult) -> ToolResultAncho
 
     if _reads_generated_artifact(command):
         return ToolResultAnchors(errors=tuple(_dedupe(_error_lines(response))[:8]))
+    if tool_kind == "unknown" and _is_low_signal_inventory_command(command):
+        return ToolResultAnchors(errors=tuple(_dedupe(_error_lines(response))[:8]))
 
     if tool_kind == "search":
         line_refs.extend(_rg_line_refs(response, cwd=cwd))
@@ -133,6 +135,18 @@ def _reads_generated_artifact(command: str) -> bool:
         "validation-evals",
     )
     return any(marker in normalized for marker in generated_markers)
+
+
+def _is_low_signal_inventory_command(command: str) -> bool:
+    normalized = command.strip().lower()
+    low_signal_starts = (
+        "git status",
+        "git branch",
+        "git ls-files",
+        "git log",
+        "test-path ",
+    )
+    return normalized.startswith(low_signal_starts)
 
 
 def _rg_line_refs(text: str, *, cwd: Path | None) -> list[ToolLineRef]:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
@@ -140,6 +140,8 @@ def _reads_generated_artifact(command: str) -> bool:
 def _is_low_signal_inventory_command(command: str) -> bool:
     normalized = command.strip().lower()
     low_signal_starts = (
+        "get-childitem ",
+        "git add",
         "git status",
         "git branch",
         "git ls-files",

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
@@ -77,6 +77,9 @@ def extract_tool_result_anchors(captured: CapturedToolResult) -> ToolResultAncho
     errors: list[str] = []
     line_refs: list[ToolLineRef] = []
 
+    if _reads_generated_artifact(command):
+        return ToolResultAnchors(errors=tuple(_dedupe(_error_lines(response))[:8]))
+
     if tool_kind == "search":
         line_refs.extend(_rg_line_refs(response, cwd=cwd))
         files.extend(ref.file_path for ref in line_refs)
@@ -112,6 +115,17 @@ def _starts_with_any(value: str, prefixes: tuple[str, ...]) -> bool:
     return any(value.startswith(prefix) for prefix in prefixes)
 
 
+def _reads_generated_artifact(command: str) -> bool:
+    normalized = command.replace("\\", "/").lower()
+    generated_markers = (
+        ".tmp/",
+        "semantic-harness-profile",
+        "semantic-harness-delivery-evals",
+        "validation-evals",
+    )
+    return any(marker in normalized for marker in generated_markers)
+
+
 def _rg_line_refs(text: str, *, cwd: Path | None) -> list[ToolLineRef]:
     refs: list[ToolLineRef] = []
     for raw in text.splitlines():
@@ -143,12 +157,16 @@ def _extract_paths(text: str, *, cwd: Path | None) -> list[str]:
 
 def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
     cleaned = value.strip().strip("'\"`").lstrip("([{<").rstrip(",:;)]}>\r\n")
+    if any(char in cleaned for char in "*?[]"):
+        return ""
     lowered = cleaned.lower()
     for prefix in ("get-content ", "cat ", "type ", "rg ", "ripgrep ", "grep ", "select-string "):
         if lowered.startswith(prefix):
             cleaned = cleaned[len(prefix) :].strip()
             lowered = cleaned.lower()
     cleaned = cleaned.replace("\\", "/")
+    if "//" in cleaned:
+        return ""
     if not cleaned:
         return ""
     try:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/extract.py
@@ -36,6 +36,15 @@ PATH_SUFFIXES = {
 
 REPO_ROOT_SEGMENTS = ("src", "tests", "docs", "npm", "scripts", "apps")
 
+ROOT_FILE_NAMES = {
+    "package.json",
+    "pyproject.toml",
+    "requirements.txt",
+    "setup.py",
+    "tox.ini",
+    "tsconfig.json",
+}
+
 ERROR_PATTERNS = (
     "traceback",
     "assertionerror",
@@ -188,7 +197,7 @@ def _normalize_candidate_path(value: str, *, cwd: Path | None) -> str:
         return ""
     if cleaned.startswith("../") or "/.git/" in cleaned or "/.codex/" in cleaned:
         return ""
-    if not _has_repo_root_segment(cleaned):
+    if not _has_repo_root_segment(cleaned) and not _is_allowed_root_file(cleaned):
         return ""
     suffix = Path(cleaned).suffix.lower()
     if suffix not in PATH_SUFFIXES:
@@ -231,6 +240,11 @@ def _path_text(value: str) -> str:
 def _has_repo_root_segment(value: str) -> bool:
     lowered = value.lower().lstrip("./")
     return lowered.startswith(tuple(f"{segment}/" for segment in REPO_ROOT_SEGMENTS))
+
+
+def _is_allowed_root_file(value: str) -> bool:
+    cleaned = value.strip().replace("\\", "/").lstrip("./").lower()
+    return "/" not in cleaned and cleaned in ROOT_FILE_NAMES
 
 
 def _python_symbols(text: str) -> list[str]:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/models.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/models.py
@@ -207,6 +207,7 @@ def _metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
     by_kind: dict[str, dict[str, int]] = {}
     latencies: list[int] = []
     token_overheads: list[int] = []
+    attached_token_overheads: list[int] = []
     attached = 0
     auto_useful = 0
     auto_mislead = 0
@@ -219,6 +220,7 @@ def _metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
         if decision.get("would_attach"):
             attached += 1
             bucket["attached"] += 1
+            attached_token_overheads.append(int(record.get("token_overhead_estimate") or 0))
         else:
             bucket["suppressed"] += 1
         latency = record.get("latency_ms") or {}
@@ -240,7 +242,8 @@ def _metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
         "attach_rate": round(attached / len(records), 4) if records else 0.0,
         "suppress_rate": round((len(records) - attached) / len(records), 4) if records else 0.0,
         "p95_shadow_latency_ms": _percentile(latencies, 0.95),
-        "token_overhead_p95": _percentile(token_overheads, 0.95),
+        "token_overhead_p95": _percentile(attached_token_overheads, 0.95),
+        "all_token_overhead_p95": _percentile(token_overheads, 0.95),
         "idempotent_replay_rate": 1.0,
         "auto_useful_count": auto_useful,
         "auto_mislead_candidate_count": auto_mislead,

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
@@ -155,7 +155,15 @@ class ToolContextPlanner:
         resolved = resolve_anchors(graph, files=request.files, symbols=request.symbols)
         if not resolved.resolved:
             return _ungrounded_anchor_response(request, unresolved=resolved.unresolved)
-        return self._runtime.query(repo_id, request)
+        grounded_request = _grounded_request(
+            request,
+            resolved_files=_resolved_files(resolved),
+            resolved_symbols=_resolved_symbols(resolved),
+        )
+        response = self._runtime.query(repo_id, grounded_request)
+        if resolved.unresolved:
+            response = _append_response_warning(response, "ungrounded_tool_anchors_filtered:" + ",".join(resolved.unresolved))
+        return response
 
 
 def _suppression_reasons(
@@ -185,6 +193,59 @@ def _suppression_reasons(
     if elapsed_ms > options.max_latency_ms:
         reasons.append("latency_exceeded")
     return tuple(dict.fromkeys(reasons))
+
+
+def _resolved_files(resolved: object) -> tuple[str, ...]:
+    return tuple(
+        anchor.requested
+        for anchor in getattr(resolved, "resolved", ())
+        if getattr(anchor, "kind", "") == "File"
+    )
+
+
+def _resolved_symbols(resolved: object) -> tuple[str, ...]:
+    return tuple(
+        anchor.requested
+        for anchor in getattr(resolved, "resolved", ())
+        if getattr(anchor, "kind", "") == "Symbol"
+    )
+
+
+def _grounded_request(
+    request: HarnessQueryRequest,
+    *,
+    resolved_files: tuple[str, ...],
+    resolved_symbols: tuple[str, ...],
+) -> HarnessQueryRequest:
+    return HarnessQueryRequest(
+        intent=request.intent,
+        user_goal=request.user_goal,
+        files=resolved_files,
+        symbols=resolved_symbols,
+        commits=request.commits,
+        errors=request.errors,
+        recent_tool_result=request.recent_tool_result,
+        max_cards=request.max_cards,
+        max_tokens=request.max_tokens,
+        detail=request.detail,
+        session_id=request.session_id,
+        already_seen_node_ids=request.already_seen_node_ids,
+        already_seen_relation_ids=request.already_seen_relation_ids,
+        already_seen_card_ids=request.already_seen_card_ids,
+    )
+
+
+def _append_response_warning(response: HarnessQueryResponse, warning: str) -> HarnessQueryResponse:
+    return HarnessQueryResponse(
+        status=response.status,
+        intent_requested=response.intent_requested,
+        intent_used=response.intent_used,
+        intent_correction=response.intent_correction,
+        cards=response.cards,
+        next_actions=response.next_actions,
+        trace=response.trace,
+        warnings=tuple(dict.fromkeys((*response.warnings, warning))),
+    )
 
 
 def _has_graph_grounding(cards: tuple[HarnessCard, ...]) -> bool:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
@@ -196,6 +196,8 @@ def _suppression_reasons(
         reasons.append("missing_graph_grounding")
     if any(str(warning).startswith("duplicate_tool_card:") for warning in response.warnings):
         reasons.append("duplicate_card")
+    if "redundant_file_read_card" in response.warnings:
+        reasons.append("redundant_file_read_card")
     if _has_only_vector_evidence(response.cards):
         reasons.append("vector_only_evidence")
     if token_overhead > options.max_tokens:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
@@ -11,6 +11,7 @@ from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryReques
 from agent_memory_orchestrator.domain.semantic_harness import HarnessQueryResponse
 from agent_memory_orchestrator.domain.semantic_harness import resolve_anchors
 
+from .cards import enrich_tool_overlay_response
 from .extract import classify_tool_kind
 from .extract import extract_tool_result_anchors
 from .models import CapturedToolResult
@@ -73,7 +74,7 @@ class ToolContextPlanner:
         parse_ms = _elapsed_ms(parse_start)
 
         query_start = time.perf_counter()
-        response = self._response_for_overlay(repo_id=repo_id, request=request, anchors=anchors)
+        response = self._response_for_overlay(repo_id=repo_id, request=request, anchors=anchors, tool_kind=tool_kind)
         query_ms = _elapsed_ms(query_start)
 
         decision_start = time.perf_counter()
@@ -146,6 +147,7 @@ class ToolContextPlanner:
         repo_id: str,
         request: HarnessQueryRequest,
         anchors: ToolResultAnchors,
+        tool_kind: str,
     ) -> HarnessQueryResponse:
         if not anchors.has_any:
             return _no_anchor_response(request)
@@ -161,6 +163,12 @@ class ToolContextPlanner:
             resolved_symbols=_resolved_symbols(resolved),
         )
         response = self._runtime.query(repo_id, grounded_request)
+        response = enrich_tool_overlay_response(
+            graph=graph,
+            request=grounded_request,
+            response=response,
+            tool_kind=tool_kind,
+        )
         if resolved.unresolved:
             response = _append_response_warning(response, "ungrounded_tool_anchors_filtered:" + ",".join(resolved.unresolved))
         return response
@@ -186,6 +194,8 @@ def _suppression_reasons(
         reasons.append("low_card_confidence")
     if not _has_graph_grounding(response.cards):
         reasons.append("missing_graph_grounding")
+    if any(str(warning).startswith("duplicate_tool_card:") for warning in response.warnings):
+        reasons.append("duplicate_card")
     if _has_only_vector_evidence(response.cards):
         reasons.append("vector_only_evidence")
     if token_overhead > options.max_tokens:

--- a/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
+++ b/src/agent_memory_orchestrator/application/services/semantic_harness/tool_context/planner.py
@@ -198,6 +198,8 @@ def _suppression_reasons(
         reasons.append("duplicate_card")
     if "redundant_file_read_card" in response.warnings:
         reasons.append("redundant_file_read_card")
+    if "broad_search_anchor_only_card" in response.warnings:
+        reasons.append("broad_search_anchor_only_card")
     if _has_only_vector_evidence(response.cards):
         reasons.append("vector_only_evidence")
     if token_overhead > options.max_tokens:

--- a/tests/application/semantic_harness/test_commit_update_service.py
+++ b/tests/application/semantic_harness/test_commit_update_service.py
@@ -43,6 +43,44 @@ def test_commit_update_service_builds_delta_from_real_git_commit(tmp_path) -> No
     assert first_sha != second_sha
 
 
+def test_commit_update_service_uses_changed_line_hunks_for_symbol_mapping(tmp_path) -> None:
+    if subprocess.run(["git", "--version"], capture_output=True, check=False).returncode != 0:
+        pytest.skip("git unavailable")
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+    _git(tmp_path, "config", "user.name", "Test User")
+    (tmp_path / "src").mkdir()
+    target = tmp_path / "src" / "auth.py"
+    target.write_text(
+        "def login():\n"
+        "    return False\n"
+        "\n"
+        "def logout():\n"
+        "    return True\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "add", "src/auth.py")
+    _git(tmp_path, "commit", "-m", "add auth flows")
+    target.write_text(
+        "def login():\n"
+        "    return True\n"
+        "\n"
+        "def logout():\n"
+        "    return True\n",
+        encoding="utf-8",
+    )
+    _git(tmp_path, "add", "src/auth.py")
+    _git(tmp_path, "commit", "-m", "fix login")
+    sha = _git(tmp_path, "rev-parse", "HEAD").strip()
+
+    result = CommitUpdateService().build_delta_for_commit(tmp_path, sha, repo_id="repo:test")
+
+    assert result.diff_hunk_count == 1
+    assert {mapping.status for mapping in result.delta.hunk_mappings} == {"mapped"}
+    assert [mapping.target_kind for mapping in result.delta.hunk_mappings] == ["Symbol"]
+    assert result.delta.hunk_mappings[0].target_node_id.endswith(":login:function")
+
+
 def _git(cwd, *args: str) -> str:
     result = subprocess.run(
         ["git", "-C", str(cwd), *args],

--- a/tests/application/semantic_harness/test_tool_context_extract.py
+++ b/tests/application/semantic_harness/test_tool_context_extract.py
@@ -135,3 +135,31 @@ def test_codex_manual_links_are_not_repo_anchors() -> None:
     anchors = extract_tool_result_anchors(captured)
 
     assert anchors.files == ()
+
+
+def test_malformed_repo_like_paths_are_not_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "Get-ChildItem"},
+        tool_response=(
+            "src//agent_memory_orchestrator//domain//semantic_harness//anchor_resolution.py\n"
+            "src/agent_memory_orchestrator/domain/semantic_harness/doc_semantics/*.py\n"
+        ),
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ()
+
+
+def test_generated_tmp_reports_do_not_feed_overlay_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "Get-Content .tmp/semantic-harness-profile/shadow_replay.json"},
+        tool_response='{"files": ["src/auth.py", "docs/SKILL.md"]}',
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert anchors.files == ()
+    assert anchors.errors == ()

--- a/tests/application/semantic_harness/test_tool_context_extract.py
+++ b/tests/application/semantic_harness/test_tool_context_extract.py
@@ -202,3 +202,30 @@ def test_git_ls_files_inventory_does_not_feed_overlay_anchors() -> None:
 
     assert classify_tool_kind(captured) == "unknown"
     assert anchors.files == ()
+
+
+def test_git_add_status_inventory_does_not_feed_overlay_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "git add src/auth.py; git status --short"},
+        tool_response="M  src/auth.py\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "unknown"
+    assert anchors.files == ()
+
+
+def test_get_childitem_listing_does_not_feed_overlay_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "Get-ChildItem -Recurse src | Select-Object FullName"},
+        tool_response=r"C:\repo\src\auth.py",
+        cwd=r"C:\repo",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "unknown"
+    assert anchors.files == ()

--- a/tests/application/semantic_harness/test_tool_context_extract.py
+++ b/tests/application/semantic_harness/test_tool_context_extract.py
@@ -46,6 +46,19 @@ def test_extract_git_diff_changed_files() -> None:
     assert anchors.files == ("src/auth.py",)
 
 
+def test_extract_root_config_patch_file() -> None:
+    captured = CapturedToolResult(
+        tool_name="apply_patch",
+        tool_input={"command": "*** Begin Patch\n*** Update File: pyproject.toml\n@@\n"},
+        tool_response="Success. Updated the following files:\nM pyproject.toml\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "apply_patch"
+    assert anchors.files == ("pyproject.toml",)
+
+
 def test_extract_pytest_failure_files_and_errors() -> None:
     captured = CapturedToolResult(
         tool_name="shell_command",

--- a/tests/application/semantic_harness/test_tool_context_extract.py
+++ b/tests/application/semantic_harness/test_tool_context_extract.py
@@ -176,3 +176,29 @@ def test_generated_tmp_reports_do_not_feed_overlay_anchors() -> None:
 
     assert anchors.files == ()
     assert anchors.errors == ()
+
+
+def test_git_status_inventory_does_not_feed_overlay_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "git status --short; git branch --show-current"},
+        tool_response=" M src/auth.py\n?? tests/test_auth.py\nmain\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "unknown"
+    assert anchors.files == ()
+
+
+def test_git_ls_files_inventory_does_not_feed_overlay_anchors() -> None:
+    captured = CapturedToolResult(
+        tool_name="shell_command",
+        tool_input={"command": "git ls-files | Select-Object -First 10"},
+        tool_response="src/auth.py\ntests/test_auth.py\n",
+    )
+
+    anchors = extract_tool_result_anchors(captured)
+
+    assert classify_tool_kind(captured) == "unknown"
+    assert anchors.files == ()

--- a/tests/application/semantic_harness/test_tool_context_metrics.py
+++ b/tests/application/semantic_harness/test_tool_context_metrics.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import CapturedToolResult
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import ShadowReplayReport
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import ToolOverlayDecision
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import ToolOverlayEvalRecord
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import ToolOverlayLatency
+from agent_memory_orchestrator.application.services.semantic_harness.tool_context import ToolResultAnchors
+
+
+def test_shadow_metrics_gate_token_overhead_on_attached_cards() -> None:
+    attached = _record(would_attach=True, token_overhead=300)
+    suppressed = _record(would_attach=False, token_overhead=1200)
+
+    metrics = ShadowReplayReport(
+        repo_id="repo:test",
+        source_path="evidence.jsonl",
+        records=(attached, suppressed),
+    ).as_dict()["metrics"]
+
+    assert metrics["token_overhead_p95"] == 300
+    assert metrics["all_token_overhead_p95"] == 1200
+
+
+def _record(*, would_attach: bool, token_overhead: int) -> ToolOverlayEvalRecord:
+    return ToolOverlayEvalRecord(
+        decision=ToolOverlayDecision(
+            mode="shadow",
+            tool_kind="file_read",
+            captured=CapturedToolResult(
+                tool_name="shell_command",
+                tool_input={"command": "Get-Content src/auth.py"},
+                tool_response="def login():\n    return True\n",
+            ),
+            anchors=ToolResultAnchors(files=("src/auth.py",)),
+            harness_request={},
+            harness_response={"status": "partial_structural", "cards": []},
+            latency=ToolOverlayLatency(),
+            would_attach=would_attach,
+            token_overhead_estimate=token_overhead,
+        )
+    )

--- a/tests/application/semantic_harness/test_tool_context_planner.py
+++ b/tests/application/semantic_harness/test_tool_context_planner.py
@@ -92,6 +92,33 @@ def test_unresolved_tool_anchors_do_not_trigger_fallback_cards(tmp_path) -> None
     assert decision.would_attach is False
 
 
+def test_mixed_tool_anchors_query_only_grounded_subset(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "auth.py").write_text("def login():\n    return True\n", encoding="utf-8")
+    runtime = SemanticHarnessRuntimeService()
+    runtime.bootstrap_repo(repo, repo_id="repo:test")
+
+    decision = ToolContextPlanner(runtime=runtime).plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "Get-Content src/auth.py src/missing.py"},
+            tool_response="def login():\n    return True\nNo such file: src/missing.py",
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.harness_response["status"] == "partial_structural"
+    assert decision.harness_response["cards"]
+    assert decision.harness_response["warnings"] == [
+        "structural_only:no_work_history_or_semantic_reasoning_attached",
+        "ungrounded_tool_anchors_filtered:file:src/missing.py",
+    ]
+    assert decision.would_attach is True
+
+
 def test_file_read_prefers_file_anchor_over_unresolved_content_symbols(tmp_path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/application/semantic_harness/test_tool_context_planner.py
+++ b/tests/application/semantic_harness/test_tool_context_planner.py
@@ -5,6 +5,19 @@ from agent_memory_orchestrator.application.services.semantic_harness.tool_contex
 from agent_memory_orchestrator.application.services.semantic_harness.tool_context import ToolContextPlanner
 
 
+def _runtime_for_tool_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "tests").mkdir()
+    (repo / "src" / "auth.py").write_text("def login():\n    return True\n", encoding="utf-8")
+    (repo / "tests" / "test_auth.py").write_text("def test_login():\n    assert True\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+    runtime = SemanticHarnessRuntimeService()
+    runtime.bootstrap_repo(repo, repo_id="repo:test")
+    return repo, runtime
+
+
 def test_file_read_replay_generates_grounded_shadow_attach(tmp_path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -31,6 +44,83 @@ def test_file_read_replay_generates_grounded_shadow_attach(tmp_path) -> None:
     assert decision.confidence >= 0.75
     assert decision.anchors.files == ("src/auth.py",)
     assert decision.harness_response["status"] == "partial_structural"
+
+
+def test_test_output_failure_generates_test_target_card(tmp_path) -> None:
+    repo, runtime = _runtime_for_tool_repo(tmp_path)
+
+    decision = ToolContextPlanner(runtime=runtime).plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "python -m pytest tests/test_auth.py -q"},
+            tool_response="FAILED tests/test_auth.py::test_login - AssertionError: bad redirect\n",
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.tool_kind == "test_output"
+    assert decision.would_attach is True
+    assert decision.harness_response["cards"][0]["type"] == "test_target"
+    assert decision.harness_response["cards"][0]["confidence"] >= 0.75
+
+
+def test_git_diff_generates_diff_impact_card(tmp_path) -> None:
+    repo, runtime = _runtime_for_tool_repo(tmp_path)
+
+    decision = ToolContextPlanner(runtime=runtime).plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "git diff -- src/auth.py"},
+            tool_response="diff --git a/src/auth.py b/src/auth.py\n--- a/src/auth.py\n+++ b/src/auth.py\n",
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.tool_kind == "git_diff"
+    assert decision.would_attach is True
+    assert decision.harness_response["cards"][0]["type"] == "risk"
+    assert decision.harness_response["cards"][0]["title"] == "Review diff impact for src/auth.py"
+
+
+def test_apply_patch_generates_patch_impact_card_for_root_config(tmp_path) -> None:
+    repo, runtime = _runtime_for_tool_repo(tmp_path)
+
+    decision = ToolContextPlanner(runtime=runtime).plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="apply_patch",
+            tool_input={"command": "*** Begin Patch\n*** Update File: pyproject.toml\n@@\n"},
+            tool_response="Success. Updated the following files:\nM pyproject.toml\n",
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.tool_kind == "apply_patch"
+    assert decision.would_attach is True
+    assert decision.harness_response["cards"][0]["type"] == "risk"
+    assert decision.harness_response["cards"][0]["title"] == "Verify patch impact for pyproject.toml"
+
+
+def test_apply_patch_honors_seen_tool_cards(tmp_path) -> None:
+    repo, runtime = _runtime_for_tool_repo(tmp_path)
+    planner = ToolContextPlanner(runtime=runtime)
+    captured = CapturedToolResult(
+        tool_name="apply_patch",
+        tool_input={"command": "*** Begin Patch\n*** Update File: src/auth.py\n@@\n"},
+        tool_response="Success. Updated the following files:\nM src/auth.py\n",
+        cwd=str(repo),
+    )
+
+    first = planner.plan(repo_id="repo:test", captured=captured)
+    seen = tuple(card["card_id"] for card in first.harness_response["cards"])
+    second = planner.plan(repo_id="repo:test", captured=captured, already_seen_card_ids=seen)
+
+    assert first.would_attach is True
+    assert second.would_attach is False
+    assert "duplicate_card" in second.suppression_reasons
+    assert "no_cards" in second.suppression_reasons
 
 
 def test_unknown_tool_without_anchors_suppresses() -> None:

--- a/tests/application/semantic_harness/test_tool_context_planner.py
+++ b/tests/application/semantic_harness/test_tool_context_planner.py
@@ -18,7 +18,7 @@ def _runtime_for_tool_repo(tmp_path):
     return repo, runtime
 
 
-def test_file_read_replay_generates_grounded_shadow_attach(tmp_path) -> None:
+def test_file_read_same_file_only_card_suppresses_as_redundant(tmp_path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "src").mkdir()
@@ -39,11 +39,12 @@ def test_file_read_replay_generates_grounded_shadow_attach(tmp_path) -> None:
 
     assert decision.mode == "shadow"
     assert decision.tool_kind == "file_read"
-    assert decision.would_attach is True
+    assert decision.would_attach is False
     assert decision.would_replace is False
-    assert decision.confidence >= 0.75
     assert decision.anchors.files == ("src/auth.py",)
     assert decision.harness_response["status"] == "partial_structural"
+    assert "redundant_file_read_card" in decision.suppression_reasons
+    assert "low_card_confidence" in decision.suppression_reasons
 
 
 def test_test_output_failure_generates_test_target_card(tmp_path) -> None:
@@ -204,9 +205,11 @@ def test_mixed_tool_anchors_query_only_grounded_subset(tmp_path) -> None:
     assert decision.harness_response["cards"]
     assert decision.harness_response["warnings"] == [
         "structural_only:no_work_history_or_semantic_reasoning_attached",
+        "redundant_file_read_card",
         "ungrounded_tool_anchors_filtered:file:src/missing.py",
     ]
-    assert decision.would_attach is True
+    assert decision.would_attach is False
+    assert "low_card_confidence" in decision.suppression_reasons
 
 
 def test_file_read_prefers_file_anchor_over_unresolved_content_symbols(tmp_path) -> None:
@@ -228,5 +231,6 @@ def test_file_read_prefers_file_anchor_over_unresolved_content_symbols(tmp_path)
     )
 
     assert decision.harness_response["status"] == "partial_structural"
-    assert decision.would_attach is True
+    assert decision.would_attach is False
+    assert "redundant_file_read_card" in decision.suppression_reasons
     assert decision.token_overhead_estimate <= 900

--- a/tests/application/semantic_harness/test_tool_context_planner.py
+++ b/tests/application/semantic_harness/test_tool_context_planner.py
@@ -85,6 +85,33 @@ def test_git_diff_generates_diff_impact_card(tmp_path) -> None:
     assert decision.harness_response["cards"][0]["title"] == "Review diff impact for src/auth.py"
 
 
+def test_broad_search_anchor_only_cards_suppress(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    lines: list[str] = []
+    for index in range(9):
+        path = repo / "src" / f"mod_{index}.py"
+        path.write_text(f"def target_{index}():\n    return True\n", encoding="utf-8")
+        lines.append(f"src/mod_{index}.py:1:def target_{index}():")
+    runtime = SemanticHarnessRuntimeService()
+    runtime.bootstrap_repo(repo, repo_id="repo:test")
+
+    decision = ToolContextPlanner(runtime=runtime).plan(
+        repo_id="repo:test",
+        captured=CapturedToolResult(
+            tool_name="shell_command",
+            tool_input={"command": "rg -n target src -S"},
+            tool_response="\n".join(lines),
+            cwd=str(repo),
+        ),
+    )
+
+    assert decision.tool_kind == "search"
+    assert decision.would_attach is False
+    assert "broad_search_anchor_only_card" in decision.suppression_reasons
+
+
 def test_apply_patch_generates_patch_impact_card_for_root_config(tmp_path) -> None:
     repo, runtime = _runtime_for_tool_repo(tmp_path)
 

--- a/tests/runtime/cli/test_semantic_harness_cli.py
+++ b/tests/runtime/cli/test_semantic_harness_cli.py
@@ -120,10 +120,12 @@ def test_amo_harness_shadow_replay_reads_post_tool_use_rows(tmp_path, monkeypatc
     assert payload["ok"] is True
     assert payload["shadow_only"] is True
     assert payload["record_count"] == 1
-    assert payload["metrics"]["token_overhead_p95"] > 0
+    assert payload["metrics"]["token_overhead_p95"] == 0
+    assert payload["metrics"]["all_token_overhead_p95"] > 0
     assert payload["metrics"]["acceptance_thresholds"]["p95_shadow_latency_ms"] == 500
-    assert payload["metrics"]["by_tool_kind"]["file_read"]["suppress_rate"] == 0.0
-    assert payload["records"][0]["decision"]["would_attach"] is True
+    assert payload["metrics"]["by_tool_kind"]["file_read"]["suppress_rate"] == 1.0
+    assert payload["records"][0]["decision"]["would_attach"] is False
+    assert "redundant_file_read_card" in payload["records"][0]["decision"]["suppression_reasons"]
     assert payload["records"][0]["decision"]["would_replace"] is False
     assert payload["records"][0]["captured"]["raw_output_hash"]
     assert (tmp_path / "shadow.json").exists()


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Validation

- [ ] `python -m pytest -q`
- [ ] `ruff check src tests`
- [ ] `npm run check` in `npm/agent-memory-orchestrator-cli` when installer files change
- [ ] `npm pack --dry-run` in `npm/agent-memory-orchestrator-cli` when packaging files change

## Safety

- [ ] No secrets, local evidence, transcripts, Kuzu stores, SQLite databases, or `.tmp` artifacts are committed.
- [ ] Hook behavior remains capture-only and fail-open.
- [ ] Retrieval remains explicit through CLI/MCP/UI, not automatic prompt injection.
- [ ] Public docs were updated if commands, architecture, or user-visible behavior changed.

## Notes

Add migration notes, follow-up work, or screenshots when useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced tool overlay context management with graph-grounded contextual cards that provide relevant information without redundancy.

* **Bug Fixes**
  * Improved filtering of low-signal tool outputs (redundant file reads, broad searches, inventory commands) to reduce noise.
  * Better token efficiency by separating overhead metrics for attached vs. all cards.

* **Tests**
  * Comprehensive test coverage added for commit hunk mapping, tool overlay decisions, anchor extraction, and metrics validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->